### PR TITLE
Add integrated Agents Hub dashboard

### DIFF
--- a/native/macos/zmuxHost/build-zmux-host.sh
+++ b/native/macos/zmuxHost/build-zmux-host.sh
@@ -47,7 +47,8 @@ if [[ -z "$GHOSTTY_ROOT" ]]; then
 	for candidate in \
 		"$REPO_ROOT/../ghostty" \
 		"$REPO_ROOT/../ghostty-zmux-survival" \
-		"$REPO_ROOT/../../_forks/ghostty"; do
+		"$REPO_ROOT/../../_forks/ghostty" \
+		"$HOME/dev/_active/ghostty"; do
 		if [[ -d "$candidate/macos/GhosttyKit.xcframework" ]]; then
 			GHOSTTY_ROOT="$(cd "$candidate" && pwd)"
 			break

--- a/native/sidebar/modal-host.tsx
+++ b/native/sidebar/modal-host.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { useEffect, useLayoutEffect, useState } from "react";
 import { AgentConfigModal, type AgentConfigDraft } from "../../sidebar/agent-config-modal";
+import { AgentsHubModal } from "../../sidebar/agents-hub-modal";
 import { CommandConfigModal, type CommandConfigDraft } from "../../sidebar/command-config-modal";
 import { DaemonSessionsModal } from "../../sidebar/daemon-sessions-modal";
 import { DelayedSendModal } from "../../sidebar/delayed-send-modal";
@@ -33,6 +34,7 @@ import "../../sidebar/styles.css";
 
 type AppModalKind =
   | "agentConfig"
+  | "agentsHub"
   | "commandConfig"
   | "configureActions"
   | "configureAgents"
@@ -277,6 +279,11 @@ function AppModalHost() {
       />
       <DaemonSessionsModal
         isOpen={activeModal === "daemonSessions"}
+        onClose={closeModal}
+        vscode={vscode}
+      />
+      <AgentsHubModal
+        isOpen={activeModal === "agentsHub"}
         onClose={closeModal}
         vscode={vscode}
       />
@@ -738,6 +745,8 @@ function isModalRenderable({
       return false;
     case "agentConfig":
       return config.agentDraft !== undefined;
+    case "agentsHub":
+      return true;
     case "commandConfig":
       return config.commandDraft !== undefined;
     case "delayedSend":

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -193,6 +193,7 @@ import {
 } from "../../shared/workspace-dock-icons";
 import {
   DEFAULT_zmux_SETTINGS,
+  getDefaultEditorCommandForSettings,
   getZedOverlayTargetAppLabel,
   normalizezmuxSettings,
   type SidebarSide,
@@ -10271,6 +10272,38 @@ async function createNativePluginsBrowserChat(): Promise<void> {
   createNativeBrowserSession(PLUGINS_BROWSER_CHAT_URL);
 }
 
+async function openAgentsHubFileInDefaultEditor(filePath: string): Promise<void> {
+  /**
+   * CDXC:AgentsHub 2026-05-12-09:24
+   * Agents Hub renders inside the modal host, but external edit still belongs
+   * to native so it can honor the user's configured editor command.
+   */
+  const normalizedFilePath = filePath.trim();
+  if (!normalizedFilePath) {
+    showNativeMessage("warning", "Choose an Agents Hub file first.");
+    return;
+  }
+
+  const editorCommand = getDefaultEditorCommandForSettings(settings).trim();
+  if (!editorCommand) {
+    showNativeMessage("warning", "Set a default editor command in Settings first.");
+    return;
+  }
+
+  const result = await runNativeProcess("/bin/zsh", [
+    "-lc",
+    `${editorCommand} ${quoteNativeShellArg(normalizedFilePath)}`,
+  ]);
+  if (result.exitCode !== 0) {
+    showNativeMessage(
+      "error",
+      result.stderr.trim() ||
+        result.stdout.trim() ||
+        `Unable to open ${normalizedFilePath} with ${editorCommand}.`,
+    );
+  }
+}
+
 async function createNativeBrowserChat(): Promise<void> {
   /**
    * CDXC:Chats 2026-05-08-11:07
@@ -11204,6 +11237,12 @@ function handleSidebarMessage(message: SidebarToExtensionMessage): void {
       return;
     case "openPluginsBrowserChat":
       void createNativePluginsBrowserChat();
+      return;
+    case "openAgentsHubPathInFinder":
+      openNativeWorkspaceInFinder(message.path);
+      return;
+    case "openAgentsHubFileInDefaultEditor":
+      void openAgentsHubFileInDefaultEditor(message.filePath);
       return;
     case "openBrowserChat":
       void createNativeBrowserChat();

--- a/shared/session-grid-contract-sidebar.ts
+++ b/shared/session-grid-contract-sidebar.ts
@@ -577,6 +577,19 @@ export type SidebarToExtensionMessage =
     }
   | {
       /**
+       * CDXC:AgentsHub 2026-05-12-09:21
+       * Agents Hub runs in the full-window modal host, but profile/file actions
+       * still need native filesystem affordances from the sidebar bridge.
+       */
+      path: string;
+      type: "openAgentsHubPathInFinder";
+    }
+  | {
+      filePath: string;
+      type: "openAgentsHubFileInDefaultEditor";
+    }
+  | {
+      /**
        * CDXC:Chats 2026-05-08-11:53
        * The reference-style Chats section header has a hover-only browser
        * action beside New Chat. It creates a new projectless chat and opens a

--- a/shared/zmux-settings.test.ts
+++ b/shared/zmux-settings.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "vitest";
 import {
   BROWSER_OPEN_MODE_OPTIONS,
   DEFAULT_zmux_SETTINGS,
+  DEFAULT_EDITOR_COMMAND_OPTIONS,
+  getDefaultEditorCommandForSettings,
   GHOSTTY_THEME_SETTING_OPTIONS,
   normalizezmuxSettings,
   PROMPT_EDITOR_BACKEND_OPTIONS,
@@ -82,6 +84,50 @@ describe("normalizezmuxSettings", () => {
     });
     expect(normalizezmuxSettings({ showProjectEditorDiffFileCount: true })).toMatchObject({
       showProjectEditorDiffFileCount: true,
+    });
+  });
+
+  test("supports built-in and custom default editor commands", () => {
+    /**
+     * CDXC:AgentsHub 2026-05-12-09:22
+     * Agents Hub edit actions should have one normalized editor command
+     * setting, with common editor CLIs available without custom text.
+     */
+    expect(DEFAULT_zmux_SETTINGS.defaultEditorCommand).toBe("code");
+    expect(normalizezmuxSettings({})).toMatchObject({
+      customDefaultEditorCommand: "",
+      defaultEditorCommand: "code",
+    });
+    expect(normalizezmuxSettings({ defaultEditorCommand: "code-insiders" })).toMatchObject({
+      defaultEditorCommand: "code-insiders",
+    });
+    expect(normalizezmuxSettings({ defaultEditorCommand: "zed" })).toMatchObject({
+      defaultEditorCommand: "zed",
+    });
+    expect(normalizezmuxSettings({ defaultEditorCommand: "invalid" })).toMatchObject({
+      defaultEditorCommand: "code",
+    });
+    const customSettings = normalizezmuxSettings({
+      customDefaultEditorCommand: "  my-editor --reuse-window  ",
+      defaultEditorCommand: "other",
+    });
+    expect(customSettings).toMatchObject({
+      customDefaultEditorCommand: "my-editor --reuse-window",
+      defaultEditorCommand: "other",
+    });
+    expect(getDefaultEditorCommandForSettings(customSettings)).toBe("my-editor --reuse-window");
+    expect(
+      getDefaultEditorCommandForSettings(
+        normalizezmuxSettings({ customDefaultEditorCommand: "", defaultEditorCommand: "other" }),
+      ),
+    ).toBe("code");
+    expect(DEFAULT_EDITOR_COMMAND_OPTIONS).toContainEqual({
+      label: "VS Code Insiders (code-insiders)",
+      value: "code-insiders",
+    });
+    expect(DEFAULT_EDITOR_COMMAND_OPTIONS).toContainEqual({
+      label: "Other",
+      value: "other",
     });
   });
 

--- a/shared/zmux-settings.ts
+++ b/shared/zmux-settings.ts
@@ -38,6 +38,16 @@ export type GhosttyCopyOnSelect = "false" | "true" | "clipboard";
 export type GhosttyScrollbar = "system" | "never";
 export type TerminalCursorStyle = "bar" | "block" | "underline";
 export type BrowserOpenMode = "chrome-canary" | "browser-pane";
+export type DefaultEditorCommand =
+  | "code"
+  | "code-insiders"
+  | "zed"
+  | "zeditor"
+  | "cursor"
+  | "windsurf"
+  | "codium"
+  | "subl"
+  | "other";
 export type SessionPersistenceProvider = "off" | "tmux" | "zmx" | "zellij";
 export type SessionStatusIndicatorSize = "small" | "medium" | "large" | "x-large";
 export type SidebarMode = "combined" | "separated";
@@ -61,6 +71,8 @@ export type zmuxSettings = {
   browserOpenMode: BrowserOpenMode;
   codeServerLinkVscodeUserConfig: boolean;
   codeServerUseVscodeInsidersUserConfig: boolean;
+  customDefaultEditorCommand: string;
+  defaultEditorCommand: DefaultEditorCommand;
   showProjectEditorDiffFileCount: boolean;
   completionBellEnabled: boolean;
   completionSound: CompletionSoundSetting;
@@ -150,6 +162,15 @@ export const DEFAULT_zmux_SETTINGS: zmuxSettings = {
    */
   codeServerLinkVscodeUserConfig: true,
   codeServerUseVscodeInsidersUserConfig: false,
+  /**
+   * CDXC:AgentsHub 2026-05-12-09:22
+   * Agents Hub file-edit actions should use one Settings-owned editor command.
+   * Start with VS Code because its `code <file>` command is the most common
+   * cross-project default, while Settings exposes Zed, Cursor, and custom
+   * commands for users who prefer a different editor.
+   */
+  customDefaultEditorCommand: "",
+  defaultEditorCommand: "code",
   /**
    * CDXC:EditorPanes 2026-05-10-16:12
    * Project editor rows should hide the changed-file count by default and show
@@ -326,6 +347,21 @@ export const BROWSER_OPEN_MODE_OPTIONS: ReadonlyArray<{
   { label: "Browser Panes", value: "browser-pane" },
 ];
 
+export const DEFAULT_EDITOR_COMMAND_OPTIONS: ReadonlyArray<{
+  label: string;
+  value: DefaultEditorCommand;
+}> = [
+  { label: "VS Code (code)", value: "code" },
+  { label: "VS Code Insiders (code-insiders)", value: "code-insiders" },
+  { label: "Zed (zed)", value: "zed" },
+  { label: "Zed alternate (zeditor)", value: "zeditor" },
+  { label: "Cursor (cursor)", value: "cursor" },
+  { label: "Windsurf (windsurf)", value: "windsurf" },
+  { label: "VSCodium (codium)", value: "codium" },
+  { label: "Sublime Text (subl)", value: "subl" },
+  { label: "Other", value: "other" },
+];
+
 export const SESSION_PERSISTENCE_PROVIDER_OPTIONS: ReadonlyArray<{
   label: string;
   value: SessionPersistenceProvider;
@@ -479,6 +515,16 @@ export function normalizezmuxSettings(candidate: unknown): zmuxSettings {
       source,
       "codeServerUseVscodeInsidersUserConfig",
       DEFAULT_zmux_SETTINGS.codeServerUseVscodeInsidersUserConfig,
+    ),
+    defaultEditorCommand: normalizeDefaultEditorCommand(
+      readString(source, "defaultEditorCommand", DEFAULT_zmux_SETTINGS.defaultEditorCommand),
+    ),
+    customDefaultEditorCommand: normalizeCustomDefaultEditorCommand(
+      readString(
+        source,
+        "customDefaultEditorCommand",
+        DEFAULT_zmux_SETTINGS.customDefaultEditorCommand,
+      ),
     ),
     /**
      * CDXC:EditorPanes 2026-05-10-16:12
@@ -833,6 +879,30 @@ function normalizeTerminalCursorStyle(value: string | undefined): TerminalCursor
 
 function normalizeBrowserOpenMode(value: string | undefined): BrowserOpenMode {
   return value === "browser-pane" ? "browser-pane" : DEFAULT_zmux_SETTINGS.browserOpenMode;
+}
+
+function normalizeDefaultEditorCommand(value: string | undefined): DefaultEditorCommand {
+  return value === "code-insiders" ||
+    value === "zed" ||
+    value === "zeditor" ||
+    value === "cursor" ||
+    value === "windsurf" ||
+    value === "codium" ||
+    value === "subl" ||
+    value === "other"
+    ? value
+    : DEFAULT_zmux_SETTINGS.defaultEditorCommand;
+}
+
+function normalizeCustomDefaultEditorCommand(value: string | undefined): string {
+  return (value ?? "").trim().slice(0, 240);
+}
+
+export function getDefaultEditorCommandForSettings(settings: zmuxSettings): string {
+  const customCommand = settings.customDefaultEditorCommand.trim();
+  return settings.defaultEditorCommand === "other"
+    ? customCommand || DEFAULT_zmux_SETTINGS.defaultEditorCommand
+    : settings.defaultEditorCommand;
 }
 
 function normalizeSidebarMode(value: string | undefined): SidebarMode {

--- a/sidebar/agents-hub-modal.tsx
+++ b/sidebar/agents-hub-modal.tsx
@@ -1,0 +1,740 @@
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconEdit,
+  IconFile,
+  IconSearch,
+  IconX,
+} from "@tabler/icons-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getDefaultEditorCommandForSettings } from "../shared/zmux-settings";
+import { cn } from "@/lib/utils";
+import { useSidebarStore } from "./sidebar-store";
+import type { WebviewApi } from "./webview-api";
+
+type AgentsHubTab = "mds" | "skills" | "hooks" | "configs";
+
+type AgentProfile = {
+  agent: "CC" | "CX" | "OC" | "PI";
+  badge: "M" | "1" | "W";
+  filePath: string;
+  label: string;
+  profilePath: string;
+  targetPath?: string;
+};
+
+type AgentsHubFile = {
+  content: string;
+  id: string;
+  language: string;
+  name: string;
+  path: string;
+};
+
+type AgentsHubGroup = {
+  description: string;
+  files: AgentsHubFile[];
+  id: string;
+  name: string;
+  path: string;
+  profiles: AgentProfile[];
+};
+
+type MonacoAmdRequire = {
+  (deps: string[], callback: () => void): void;
+  config?: (config: Record<string, unknown>) => void;
+};
+
+declare global {
+  interface Window {
+    MonacoEnvironment?: unknown;
+    monaco?: {
+      editor: {
+        create: (
+          element: HTMLElement,
+          options: Record<string, unknown>,
+        ) => {
+          dispose: () => void;
+          getModel: () => unknown;
+          getValue: () => string;
+          layout: () => void;
+          onDidChangeModelContent: (listener: () => void) => { dispose: () => void };
+          setValue: (value: string) => void;
+        };
+        setModelLanguage: (model: unknown, language: string) => void;
+      };
+    };
+  }
+}
+
+const mainClaude: AgentProfile = {
+  agent: "CC",
+  badge: "M",
+  filePath: "/Users/madda/.claude/CLAUDE.md",
+  label: "Claude Code main",
+  profilePath: "/Users/madda/.claude",
+  targetPath: "/Users/madda/.agents/main.md",
+};
+
+const personalClaude: AgentProfile = {
+  agent: "CC",
+  badge: "1",
+  filePath: "/Users/madda/.claude-profiles/personal/CLAUDE.md",
+  label: "Claude Code personal",
+  profilePath: "/Users/madda/.claude-profiles/personal",
+  targetPath: "/Users/madda/.agents/main.md",
+};
+
+const mainCodex: AgentProfile = {
+  agent: "CX",
+  badge: "M",
+  filePath: "/Users/madda/.codex/AGENTS.md",
+  label: "Codex main",
+  profilePath: "/Users/madda/.codex",
+  targetPath: "/Users/madda/.agents/main.md",
+};
+
+const personalCodex: AgentProfile = {
+  agent: "CX",
+  badge: "1",
+  filePath: "/Users/madda/.codex-profiles/personal/AGENTS.md",
+  label: "Codex personal",
+  profilePath: "/Users/madda/.codex-profiles/personal",
+  targetPath: "/Users/madda/.agents/main.md",
+};
+
+const workCodex: AgentProfile = {
+  agent: "CX",
+  badge: "W",
+  filePath: "/Users/madda/.codex-profiles/work/AGENTS.md",
+  label: "Codex work",
+  profilePath: "/Users/madda/.codex-profiles/work",
+  targetPath: "/Users/madda/.agents/main.md",
+};
+
+const openCode: AgentProfile = {
+  agent: "OC",
+  badge: "M",
+  filePath: "/Users/madda/.config/opencode/opencode.json",
+  label: "OpenCode main",
+  profilePath: "/Users/madda/.config/opencode",
+};
+
+const piAgent: AgentProfile = {
+  agent: "PI",
+  badge: "M",
+  filePath: "/Users/madda/.pi/agent/settings.json",
+  label: "Pi agent",
+  profilePath: "/Users/madda/.pi/agent",
+};
+
+const linkedProfiles = [mainClaude, personalClaude, mainCodex, personalCodex, workCodex];
+
+const tabLabels: Record<AgentsHubTab, string> = {
+  configs: "Configs & MCPs",
+  hooks: "Hooks",
+  mds: "MDs",
+  skills: "Skills",
+};
+
+const groupsByTab: Record<AgentsHubTab, AgentsHubGroup[]> = {
+  mds: [
+    {
+      description: "Shared instructions used by linked Claude and Codex profiles.",
+      files: [
+        {
+          content:
+            "# Main Agent Instructions\n\nThis shared markdown file is linked into Claude and Codex profiles.\n\nThe filesystem bridge will load the real contents here next.",
+          id: "md-main-file",
+          language: "markdown",
+          name: "main.md",
+          path: "/Users/madda/.agents/main.md",
+        },
+      ],
+      id: "md-main",
+      name: "main.md",
+      path: "/Users/madda/.agents/main.md",
+      profiles: linkedProfiles,
+    },
+  ],
+  skills: [
+    {
+      description: "Shared skill folder linked into agent profile skill directories.",
+      files: [
+        {
+          content:
+            "# madda-sync-skills\n\nSelected skill files will be loaded here and edited in Monaco.",
+          id: "skill-sync-md",
+          language: "markdown",
+          name: "SKILL.md",
+          path: "/Users/madda/agents/skills/madda-sync-skills/SKILL.md",
+        },
+        {
+          content: "#!/usr/bin/env bash\nset -euo pipefail\n\n# Sync script loads here.",
+          id: "skill-sync-script",
+          language: "shell",
+          name: "scripts/sync_skills.sh",
+          path: "/Users/madda/agents/skills/madda-sync-skills/scripts/sync_skills.sh",
+        },
+        {
+          content: "name: madda-sync-skills\ninstall: linked\n",
+          id: "skill-sync-agent",
+          language: "yaml",
+          name: "agents/openai.yaml",
+          path: "/Users/madda/agents/skills/madda-sync-skills/agents/openai.yaml",
+        },
+      ],
+      id: "skill-sync",
+      name: "madda-sync-skills",
+      path: "/Users/madda/agents/skills/madda-sync-skills",
+      profiles: linkedProfiles,
+    },
+  ],
+  hooks: [
+    {
+      description: "Shell, TypeScript, and config files linked into agent hook folders.",
+      files: [
+        {
+          content: "# Shared hooks\n\nHook documentation opens here.",
+          id: "hook-readme",
+          language: "markdown",
+          name: "README.md",
+          path: "/Users/madda/agents/hooks/README.md",
+        },
+        {
+          content: "export function notify(message: string) {\n  return message;\n}\n",
+          id: "hook-notification",
+          language: "typescript",
+          name: "notification.ts",
+          path: "/Users/madda/agents/hooks/notification.ts",
+        },
+      ],
+      id: "hooks-shared",
+      name: "shared hooks",
+      path: "/Users/madda/agents/hooks",
+      profiles: [...linkedProfiles, piAgent],
+    },
+  ],
+  configs: [
+    {
+      description: "Claude uses global and profile JSON settings.",
+      files: [
+        {
+          content: "{\n  \"mcpServers\": {}\n}\n",
+          id: "config-claude-json",
+          language: "json",
+          name: "~/.claude.json",
+          path: "/Users/madda/.claude.json",
+        },
+        {
+          content: "{\n  \"permissions\": {},\n  \"hooks\": {}\n}\n",
+          id: "config-claude-settings",
+          language: "json",
+          name: "~/.claude/settings.json",
+          path: "/Users/madda/.claude/settings.json",
+        },
+      ],
+      id: "config-claude",
+      name: "Claude configs",
+      path: "/Users/madda/.claude",
+      profiles: [mainClaude, personalClaude],
+    },
+    {
+      description: "Codex profile configuration is TOML per profile.",
+      files: [
+        {
+          content: "model = \"gpt-5.1-codex-max\"\n\n[mcp_servers]\n",
+          id: "config-codex-main",
+          language: "toml",
+          name: "~/.codex/config.toml",
+          path: "/Users/madda/.codex/config.toml",
+        },
+        {
+          content: "profile = \"personal\"\n\n[mcp_servers]\n",
+          id: "config-codex-personal",
+          language: "toml",
+          name: "~/.codex-profiles/personal/config.toml",
+          path: "/Users/madda/.codex-profiles/personal/config.toml",
+        },
+      ],
+      id: "config-codex",
+      name: "Codex configs",
+      path: "/Users/madda/.codex",
+      profiles: [mainCodex, personalCodex, workCodex],
+    },
+    {
+      description: "OpenCode config files live under ~/.config/opencode.",
+      files: [
+        {
+          content: "{\n  \"$schema\": \"https://opencode.ai/config.json\",\n  \"mcp\": {}\n}\n",
+          id: "config-opencode-json",
+          language: "json",
+          name: "opencode.json",
+          path: "/Users/madda/.config/opencode/opencode.json",
+        },
+      ],
+      id: "config-opencode",
+      name: "OpenCode configs",
+      path: "/Users/madda/.config/opencode",
+      profiles: [openCode],
+    },
+    {
+      description: "Pi agent settings and extension hooks live under ~/.pi/agent.",
+      files: [
+        {
+          content: "{\n  \"extensions\": []\n}\n",
+          id: "config-pi-settings",
+          language: "json",
+          name: "settings.json",
+          path: "/Users/madda/.pi/agent/settings.json",
+        },
+      ],
+      id: "config-pi",
+      name: "Pi configs",
+      path: "/Users/madda/.pi/agent",
+      profiles: [piAgent],
+    },
+  ],
+};
+
+export function AgentsHubModal({
+  isOpen,
+  onClose,
+  vscode,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  vscode: WebviewApi;
+}) {
+  const settings = useSidebarStore((state) => state.hud.settings);
+  const editorCommand = settings ? getDefaultEditorCommandForSettings(settings) : "code";
+
+  return (
+    <TooltipProvider>
+      <Dialog open={isOpen} onOpenChange={(open) => (!open ? onClose() : undefined)}>
+        <DialogContent className="agents-hub-dialog zmux-settings-shadcn" showCloseButton={false}>
+          <button
+            aria-label="Close Agents Hub"
+            className="agents-hub-close"
+            onClick={onClose}
+            type="button"
+          >
+            <IconX aria-hidden="true" />
+          </button>
+          <DialogHeader className="agents-hub-header">
+            <DialogTitle>Agents Hub</DialogTitle>
+          </DialogHeader>
+          <AgentsHubSurface editorCommand={editorCommand} vscode={vscode} />
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
+  );
+}
+
+function AgentsHubSurface({
+  editorCommand,
+  vscode,
+}: {
+  editorCommand: string;
+  vscode: WebviewApi;
+}) {
+  const [activeTab, setActiveTab] = useState<AgentsHubTab>("mds");
+  const [query, setQuery] = useState("");
+  const [selectedFileIds, setSelectedFileIds] = useState<Record<AgentsHubTab, string>>({
+    configs: firstFileId("configs"),
+    hooks: firstFileId("hooks"),
+    mds: firstFileId("mds"),
+    skills: firstFileId("skills"),
+  });
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(
+    () => new Set(["skill-sync", "hooks-shared", "config-claude", "config-codex"]),
+  );
+
+  const activeFile = findFile(activeTab, selectedFileIds[activeTab]);
+
+  return (
+    <Tabs
+      className="agents-hub-tabs"
+      onValueChange={(value) => setActiveTab(value as AgentsHubTab)}
+      value={activeTab}
+    >
+      <TabsList className="agents-hub-tabs-list">
+        {(Object.keys(tabLabels) as AgentsHubTab[]).map((tab) => (
+          <TabsTrigger key={tab} value={tab}>
+            {tabLabels[tab]}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {(Object.keys(tabLabels) as AgentsHubTab[]).map((tab) => (
+        <TabsContent className="agents-hub-tab-content" key={tab} value={tab}>
+          <section className="agents-hub-layout">
+            <aside className="agents-hub-list-pane">
+              <div className="agents-hub-search">
+                <IconSearch data-icon="inline-start" />
+                <Input
+                  aria-label={`Search ${tabLabels[tab]}`}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder={`Search ${tabLabels[tab]}`}
+                  value={query}
+                />
+              </div>
+              <ScrollArea className="agents-hub-scroll">
+                <GroupList
+                  activeFileId={selectedFileIds[tab]}
+                  activeTab={tab}
+                  expandedIds={expandedIds}
+                  onSelectFile={(fileId) => {
+                    setActiveTab(tab);
+                    setSelectedFileIds((current) => ({ ...current, [tab]: fileId }));
+                  }}
+                  onToggleExpanded={(groupId) => {
+                    setExpandedIds((current) => {
+                      const next = new Set(current);
+                      if (next.has(groupId)) {
+                        next.delete(groupId);
+                      } else {
+                        next.add(groupId);
+                      }
+                      return next;
+                    });
+                  }}
+                  query={query}
+                  vscode={vscode}
+                />
+              </ScrollArea>
+            </aside>
+            <EditorPane editorCommand={editorCommand} file={activeFile} vscode={vscode} />
+          </section>
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}
+
+function GroupList({
+  activeFileId,
+  activeTab,
+  expandedIds,
+  onSelectFile,
+  onToggleExpanded,
+  query,
+  vscode,
+}: {
+  activeFileId: string;
+  activeTab: AgentsHubTab;
+  expandedIds: Set<string>;
+  onSelectFile: (fileId: string) => void;
+  onToggleExpanded: (groupId: string) => void;
+  query: string;
+  vscode: WebviewApi;
+}) {
+  const groups = useFilteredGroups(activeTab, query);
+  const expandable = activeTab !== "mds";
+
+  if (groups.length === 0) {
+    return (
+      <div className="agents-hub-empty">
+        <IconSearch data-icon="inline-start" />
+        <span>No matching files.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="agents-hub-group-list">
+      {groups.map((group) => {
+        const isExpanded = expandedIds.has(group.id);
+        const isActiveGroup = group.files.some((file) => file.id === activeFileId);
+        const primaryFile = group.files[0]!;
+
+        return (
+          <section className={cn("agents-hub-group", isActiveGroup && "is-active")} key={group.id}>
+            <button
+              className="agents-hub-group-main"
+              onClick={() => {
+                if (expandable) {
+                  onToggleExpanded(group.id);
+                }
+                onSelectFile(primaryFile.id);
+              }}
+              type="button"
+            >
+              <span className="agents-hub-group-title-row">
+                {expandable ? (
+                  isExpanded ? (
+                    <IconChevronDown data-icon="inline-start" />
+                  ) : (
+                    <IconChevronRight data-icon="inline-start" />
+                  )
+                ) : (
+                  <IconFile data-icon="inline-start" />
+                )}
+                <span className="agents-hub-group-title">{group.name}</span>
+                <span className="agents-hub-count">
+                  {group.files.length} {group.files.length === 1 ? "file" : "files"}
+                </span>
+              </span>
+              <span className="agents-hub-path">{group.path}</span>
+              <span className="agents-hub-description">{group.description}</span>
+            </button>
+            <ProfileRow profiles={group.profiles} vscode={vscode} />
+            {expandable && isExpanded ? (
+              <div className="agents-hub-file-list">
+                {group.files.map((file) => (
+                  <button
+                    className={cn("agents-hub-file-row", file.id === activeFileId && "is-active")}
+                    key={file.id}
+                    onClick={() => onSelectFile(file.id)}
+                    type="button"
+                  >
+                    <IconFile data-icon="inline-start" />
+                    <span>{file.name}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProfileRow({ profiles, vscode }: { profiles: AgentProfile[]; vscode: WebviewApi }) {
+  return (
+    <div className="agents-hub-profile-row" aria-label="Profiles using this item">
+      {profiles.map((profile) => (
+        <Tooltip key={`${profile.agent}-${profile.badge}-${profile.profilePath}`}>
+          <TooltipTrigger asChild>
+            <button
+              aria-label={`Open ${profile.label} profile in Finder`}
+              className="agents-hub-agent-icon"
+              onClick={(event) => {
+                event.stopPropagation();
+                vscode.postMessage({
+                  path: profile.profilePath,
+                  type: "openAgentsHubPathInFinder",
+                });
+              }}
+              type="button"
+            >
+              <span className="agents-hub-agent-code">{profile.agent}</span>
+              <span className="agents-hub-agent-badge">{profile.badge}</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent align="start">
+            {`${profile.label}\n${profile.filePath}${
+              profile.targetPath ? ` -> ${profile.targetPath}` : ""
+            }\nClick to open ${profile.profilePath} in Finder`}
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}
+
+function EditorPane({
+  editorCommand,
+  file,
+  vscode,
+}: {
+  editorCommand: string;
+  file: AgentsHubFile;
+  vscode: WebviewApi;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<ReturnType<NonNullable<typeof window.monaco>["editor"]["create"]> | null>(
+    null,
+  );
+  const latestFileRef = useRef(file);
+  const [fallbackValue, setFallbackValue] = useState(file.content);
+  const [monacoAvailable, setMonacoAvailable] = useState(true);
+
+  useEffect(() => {
+    latestFileRef.current = file;
+    setFallbackValue(file.content);
+  }, [file]);
+
+  useEffect(() => {
+    let disposed = false;
+    let contentDisposable: { dispose: () => void } | null = null;
+
+    loadMonaco()
+      .then(() => {
+        if (disposed || !containerRef.current || !window.monaco || editorRef.current) {
+          return;
+        }
+
+        const initialFile = latestFileRef.current;
+        const editor = window.monaco.editor.create(containerRef.current, {
+          automaticLayout: true,
+          fontFamily: "var(--font-mono)",
+          fontSize: 13,
+          language: initialFile.language,
+          minimap: { enabled: false },
+          padding: { bottom: 16, top: 16 },
+          scrollBeyondLastLine: false,
+          theme: "vs-dark",
+          value: initialFile.content,
+        });
+        contentDisposable = editor.onDidChangeModelContent(() => {
+          setFallbackValue(editor.getValue());
+        });
+        editorRef.current = editor;
+      })
+      .catch(() => {
+        if (!disposed) {
+          setMonacoAvailable(false);
+        }
+      });
+
+    return () => {
+      disposed = true;
+      contentDisposable?.dispose();
+      editorRef.current?.dispose();
+      editorRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    const monaco = window.monaco;
+    if (!editor || !monaco) {
+      return;
+    }
+    if (editor.getValue() !== file.content) {
+      editor.setValue(file.content);
+    }
+    const model = editor.getModel();
+    if (model) {
+      // Keep Monaco's language mode aligned with the selected file extension.
+      monaco.editor.setModelLanguage(model, file.language);
+    }
+    editor.layout();
+  }, [file.content, file.id, file.language]);
+
+  return (
+    <div className="agents-hub-editor-frame">
+      <div className="agents-hub-editor-toolbar">
+        <div className="agents-hub-editor-file">
+          <span className="agents-hub-editor-name">{file.name}</span>
+          <span className="agents-hub-path">{file.path}</span>
+        </div>
+        <div className="agents-hub-editor-actions">
+          <span className="agents-hub-language">{file.language}</span>
+          <Button
+            onClick={() =>
+              vscode.postMessage({
+                filePath: file.path,
+                type: "openAgentsHubFileInDefaultEditor",
+              })
+            }
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <IconEdit data-icon="inline-start" />
+            {editorCommand}
+          </Button>
+        </div>
+      </div>
+      <Separator />
+      <div className="agents-hub-editor-body">
+        {monacoAvailable ? (
+          <div className="agents-hub-monaco" ref={containerRef} />
+        ) : (
+          <Textarea
+            aria-label={`${file.name} contents`}
+            className="agents-hub-editor-fallback"
+            onChange={(event) => setFallbackValue(event.target.value)}
+            spellCheck={false}
+            value={fallbackValue}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function useFilteredGroups(tab: AgentsHubTab, query: string): AgentsHubGroup[] {
+  return useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return groupsByTab[tab];
+    }
+    return groupsByTab[tab].filter((group) => {
+      const groupText = `${group.name} ${group.path} ${group.description}`.toLowerCase();
+      const fileText = group.files
+        .map((file) => `${file.name} ${file.path}`)
+        .join(" ")
+        .toLowerCase();
+      return groupText.includes(normalizedQuery) || fileText.includes(normalizedQuery);
+    });
+  }, [query, tab]);
+}
+
+function findFile(tab: AgentsHubTab, fileId: string): AgentsHubFile {
+  for (const group of groupsByTab[tab]) {
+    const file = group.files.find((candidate) => candidate.id === fileId);
+    if (file) {
+      return file;
+    }
+  }
+  return groupsByTab[tab][0]!.files[0]!;
+}
+
+function firstFileId(tab: AgentsHubTab): string {
+  return groupsByTab[tab][0]!.files[0]!.id;
+}
+
+function getMonacoRequire(): MonacoAmdRequire | undefined {
+  return (window as unknown as { require?: MonacoAmdRequire }).require;
+}
+
+function loadMonaco(): Promise<void> {
+  if (window.monaco) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const configureLoader = (amdRequire: MonacoAmdRequire) => {
+      window.MonacoEnvironment = {
+        getWorkerUrl: () => "./monaco/vs/base/worker/workerMain.js",
+      };
+      amdRequire.config?.({ paths: { vs: "./monaco/vs" } });
+      amdRequire(["vs/editor/editor.main"], resolve);
+    };
+
+    const existingRequire = getMonacoRequire();
+    if (existingRequire) {
+      configureLoader(existingRequire);
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "./monaco/vs/loader.js";
+    script.onload = () => {
+      const loadedRequire = getMonacoRequire();
+      if (loadedRequire) {
+        configureLoader(loadedRequire);
+      } else {
+        reject(new Error("Monaco loader did not expose require"));
+      }
+    };
+    script.onerror = () => reject(new Error("Unable to load Monaco"));
+    document.body.appendChild(script);
+  });
+}

--- a/sidebar/app-modal-host-bridge.ts
+++ b/sidebar/app-modal-host-bridge.ts
@@ -8,6 +8,7 @@ type T3BrowserAccessMessage = Extract<ExtensionToSidebarMessage, { type: "showT3
 
 export type AppModalKind =
   | "agentConfig"
+  | "agentsHub"
   | "commandConfig"
   | "configureActions"
   | "configureAgents"

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -64,6 +64,7 @@ import {
 import {
   BROWSER_OPEN_MODE_OPTIONS,
   DEFAULT_zmux_SETTINGS,
+  DEFAULT_EDITOR_COMMAND_OPTIONS,
   GHOSTTY_CONFIRM_CLOSE_SURFACE_OPTIONS,
   GHOSTTY_COPY_ON_SELECT_OPTIONS,
   GHOSTTY_SCROLLBAR_OPTIONS,
@@ -78,6 +79,7 @@ import {
   ZED_OVERLAY_TARGET_APP_OPTIONS,
   normalizezmuxSettings,
   type BrowserOpenMode,
+  type DefaultEditorCommand,
   type GhosttyConfirmCloseSurface,
   type GhosttyCopyOnSelect,
   type GhosttyScrollbar,
@@ -262,6 +264,21 @@ export function SettingsModal({
       },
     ]),
     editor: getSettingsSectionSearch(settingsSearchQuery, "Editor", [
+      {
+        key: "defaultEditorCommand",
+        options: DEFAULT_EDITOR_COMMAND_OPTIONS,
+        subtitle: "Choose the command used when opening files in an external editor.",
+        title: "Default editor command",
+      },
+      ...(draft.defaultEditorCommand === "other"
+        ? [
+            {
+              key: "customDefaultEditorCommand",
+              subtitle: "Write a custom editor command for the Other editor option.",
+              title: "Custom editor command",
+            },
+          ]
+        : []),
       {
         key: "codeServerLinkVscodeUserConfig",
         subtitle: "Use the VS Code settings from the local VS Code install.",
@@ -1395,6 +1412,29 @@ export function SettingsModal({
 
             {shouldShowSettingsSection(settingsSearch.editor) ? (
             <SettingsSection title="Editor">
+              {shouldShowSetting(settingsSearch.editor, "defaultEditorCommand") ? (
+              <SelectField
+                description="Choose the command used when opening files in an external editor."
+                label="Default editor command"
+                {...getSettingModificationProps("defaultEditorCommand")}
+                onChange={(value) =>
+                  updateDraft("defaultEditorCommand", value as DefaultEditorCommand)
+                }
+                options={DEFAULT_EDITOR_COMMAND_OPTIONS}
+                value={draft.defaultEditorCommand}
+              />
+              ) : null}
+              {draft.defaultEditorCommand === "other" &&
+              shouldShowSetting(settingsSearch.editor, "customDefaultEditorCommand") ? (
+              <TextField
+                description="Write the command exactly as it should be launched. The file path will be passed to it later."
+                label="Custom editor command"
+                {...getSettingModificationProps("customDefaultEditorCommand")}
+                onChange={(value) => updateDraft("customDefaultEditorCommand", value)}
+                placeholder="my-editor --reuse-window"
+                value={draft.customDefaultEditorCommand}
+              />
+              ) : null}
               {/* CDXC:EditorPanes 2026-05-06-15:00: Embedded code-server
                   panes pass --link-vscode-user-config by default so editor
                   sessions inherit local VS Code user settings. The Insiders

--- a/sidebar/sidebar-app.tsx
+++ b/sidebar/sidebar-app.tsx
@@ -29,6 +29,7 @@ import {
   IconSearch,
   IconSettings,
   IconTerminal2,
+  IconUsersGroup,
   IconWorld,
   type TablerIcon,
 } from "@tabler/icons-react";
@@ -2106,6 +2107,10 @@ export function SidebarApp({ messageSource = window, vscode }: SidebarAppProps) 
     vscode.postMessage({ type: "openPluginsBrowserChat" });
   };
 
+  const openReferenceAgentsHub = () => {
+    openAppModal({ modal: "agentsHub", type: "open" });
+  };
+
   const browserAccessSessionId = useMemo(() => {
     const orderedSessionIds = groupOrder.flatMap(
       (groupId) => authoritativeSessionIdsByGroup[groupId] ?? [],
@@ -2174,6 +2179,7 @@ export function SidebarApp({ messageSource = window, vscode }: SidebarAppProps) 
             isOverflowMenuOpen={isOverflowMenuOpen}
             isSessionSearchOpen={isSessionSearchOpen}
             onCloseSearch={closeSessionSearch}
+            onOpenAgentsHub={openReferenceAgentsHub}
             onCreateSession={createReferenceSession}
             onOpenPlugins={openReferencePlugins}
             onOpenPreviousSessions={openPreviousSessions}
@@ -2660,6 +2666,7 @@ function SidebarReferenceTopChrome({
   isSessionSearchOpen,
   onCloseSearch,
   onCreateSession,
+  onOpenAgentsHub,
   onOpenPlugins,
   onOpenPreviousSessions,
   onSearch,
@@ -2673,6 +2680,7 @@ function SidebarReferenceTopChrome({
   isSessionSearchOpen: boolean;
   onCloseSearch: () => void;
   onCreateSession: () => void;
+  onOpenAgentsHub: () => void;
   onOpenPlugins: () => void;
   onOpenPreviousSessions: () => void;
   onSearch: () => void;
@@ -2715,6 +2723,11 @@ function SidebarReferenceTopChrome({
           onToggleMenu={onToggleMenu}
         />
         <SidebarReferenceNavButton icon={IconGridDots} label="Plugins" onClick={onOpenPlugins} />
+        <SidebarReferenceNavButton
+          icon={IconUsersGroup}
+          label="Agents Hub"
+          onClick={onOpenAgentsHub}
+        />
         <SidebarReferenceSearchNavItem
           inputRef={searchInputRef}
           isOpen={isSessionSearchOpen}

--- a/sidebar/styles.css
+++ b/sidebar/styles.css
@@ -5,6 +5,7 @@
 @import "./styles/group-panels.css";
 @import "./styles/groups.css";
 @import "./styles/modals.css";
+@import "./styles/agents-hub.css";
 @import "./styles/session-cards.css";
 @import "./styles/session-chrome.css";
 @import "./styles/session-overlays.css";

--- a/sidebar/styles/agents-hub.css
+++ b/sidebar/styles/agents-hub.css
@@ -1,0 +1,407 @@
+.agents-hub-dialog {
+  background: #0e0e0e !important;
+  border-color: var(--border) !important;
+  display: flex !important;
+  flex-direction: column !important;
+  height: min(820px, calc(100vh - 2rem)) !important;
+  max-height: min(820px, calc(100vh - 2rem)) !important;
+  max-width: min(1180px, calc(100vw - 2rem)) !important;
+  overflow: hidden !important;
+  padding: 1rem !important;
+  width: min(1180px, calc(100vw - 2rem)) !important;
+}
+
+.agents-hub-header {
+  flex: 0 0 auto;
+  padding-right: 2.5rem;
+}
+
+.agents-hub-close {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: var(--settings-control-radius);
+  color: var(--foreground);
+  display: flex;
+  height: 2rem;
+  justify-content: center;
+  position: absolute;
+  right: 0.75rem;
+  top: 0.75rem;
+  width: 2rem;
+}
+
+.agents-hub-close:hover,
+.agents-hub-close:focus-visible {
+  background: var(--muted);
+  outline: none;
+}
+
+.agents-hub-tabs {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.agents-hub-tabs-list {
+  flex: 0 0 auto;
+  display: grid !important;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  height: 2.75rem !important;
+  width: 100% !important;
+}
+
+.agents-hub-tab-content {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.agents-hub-layout {
+  background: #0e0e0e;
+  border: 1px solid var(--border);
+  border-radius: var(--settings-control-radius);
+  display: grid;
+  flex: 1 1 auto;
+  grid-template-columns: minmax(18rem, 23rem) minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.agents-hub-list-pane {
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.agents-hub-search {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.75rem;
+}
+
+.agents-hub-search input {
+  min-width: 0;
+}
+
+.agents-hub-search svg,
+.agents-hub-group-title-row svg,
+.agents-hub-file-row svg {
+  color: var(--muted-foreground);
+  flex: 0 0 auto;
+}
+
+.agents-hub-scroll {
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.agents-hub-scroll [data-slot="scroll-area-viewport"] {
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.agents-hub-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-width: 0;
+  padding: 0 0.75rem 0.75rem;
+}
+
+.agents-hub-group {
+  border: 1px solid transparent;
+  border-radius: var(--settings-control-radius);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0.625rem;
+  width: 100%;
+}
+
+.agents-hub-group:hover,
+.agents-hub-group.is-active {
+  background: color-mix(in srgb, var(--muted) 42%, transparent);
+  border-color: var(--border);
+}
+
+.agents-hub-group-main,
+.agents-hub-file-row {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: default;
+  display: flex;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.agents-hub-group-main {
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  width: 100%;
+}
+
+.agents-hub-group-title-row {
+  align-items: center;
+  display: flex;
+  gap: 0.375rem;
+  min-width: 0;
+  width: 100%;
+}
+
+.agents-hub-group-title {
+  color: var(--foreground);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.25;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-hub-count {
+  color: var(--muted-foreground);
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  margin-left: auto;
+}
+
+.agents-hub-path,
+.agents-hub-description {
+  color: var(--muted-foreground);
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-hub-description {
+  color: color-mix(in srgb, var(--muted-foreground) 80%, transparent);
+}
+
+.agents-hub-profile-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.agents-hub-agent-icon {
+  align-items: center;
+  background: #0e0e0e;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  color: var(--foreground);
+  cursor: default;
+  display: inline-flex;
+  height: 1.75rem;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  width: 1.75rem;
+}
+
+.agents-hub-agent-icon:hover,
+.agents-hub-agent-icon:focus-visible {
+  background: var(--muted);
+  outline: none;
+}
+
+.agents-hub-agent-code {
+  font-size: 0.6875rem;
+  font-weight: 750;
+  line-height: 1;
+}
+
+.agents-hub-agent-badge {
+  align-items: center;
+  background: var(--foreground);
+  border: 1px solid #0e0e0e;
+  border-radius: 999px;
+  bottom: -0.25rem;
+  color: #0e0e0e;
+  display: flex;
+  font-size: 0.5625rem;
+  font-weight: 750;
+  height: 0.875rem;
+  justify-content: center;
+  line-height: 1;
+  position: absolute;
+  right: -0.25rem;
+  width: 0.875rem;
+}
+
+.agents-hub-dialog [data-slot="tooltip-content"] {
+  white-space: pre-line;
+}
+
+.agents-hub-file-list {
+  border-left: 1px solid var(--border);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  margin-left: 0.875rem;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  padding-left: 0.5rem;
+}
+
+.agents-hub-file-row {
+  align-items: center;
+  border-radius: var(--settings-control-radius);
+  box-sizing: border-box;
+  color: var(--muted-foreground);
+  gap: 0.375rem;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  width: 100%;
+}
+
+.agents-hub-file-row span {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-hub-file-row:hover,
+.agents-hub-file-row.is-active {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.agents-hub-empty {
+  align-items: center;
+  color: var(--muted-foreground);
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+.agents-hub-editor-frame {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.agents-hub-editor-toolbar {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 1rem;
+  justify-content: space-between;
+  min-width: 0;
+  padding: 0.75rem;
+}
+
+.agents-hub-editor-file {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.agents-hub-editor-name {
+  color: var(--foreground);
+  font-size: 0.9375rem;
+  font-weight: 650;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agents-hub-editor-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.5rem;
+}
+
+.agents-hub-language {
+  border: 1px solid var(--border);
+  border-radius: var(--settings-control-radius);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1;
+  padding: 0.375rem 0.5rem;
+}
+
+.agents-hub-editor-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  position: relative;
+}
+
+.agents-hub-monaco {
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+}
+
+.agents-hub-editor-fallback {
+  border: 0 !important;
+  border-radius: 0 !important;
+  font-family: var(--font-mono);
+  height: 100%;
+  min-height: 100%;
+  resize: none;
+}
+
+@media (max-width: 760px) {
+  .agents-hub-dialog {
+    height: calc(100vh - 1rem) !important;
+    max-height: calc(100vh - 1rem) !important;
+    max-width: calc(100vw - 1rem) !important;
+    width: calc(100vw - 1rem) !important;
+  }
+
+  .agents-hub-tabs-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    height: auto !important;
+  }
+
+  .agents-hub-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(14rem, 42vh) minmax(0, 1fr);
+  }
+
+  .agents-hub-list-pane {
+    border-bottom: 1px solid var(--border);
+    border-right: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new integrated Agents Hub modal in the sidebar app-modal WebView path instead of a standalone HTML page
- Route the sidebar button to the app modal and wire native actions for opening profile folders in Finder and files in the configured editor
- Keep the dashboard focused on MDs, Skills, Hooks, and Configs with shared shadcn UI patterns

## Testing
- Not run (not requested)
- Verified the new modal and sidebar bridge compile cleanly in local typecheck/build validation during implementation