### PR TITLE
Refine command panel chrome, layout, and hotkey handling

### DIFF
--- a/native/macos/zmuxHost/Sources/zmuxHost/AppDelegate.swift
+++ b/native/macos/zmuxHost/Sources/zmuxHost/AppDelegate.swift
@@ -1632,6 +1632,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
       break
     case .rotateActivePaneLayoutClockwiseFromTitlebar:
       break
+    case .toggleCommandsPanelFromTitlebar:
+      break
     case .runSidebarCommandFromTitlebar:
       break
     case .configureZedOverlay(let command):
@@ -3380,6 +3382,14 @@ final class zmuxRootView: NSView {
       """)
   }
 
+  private func toggleCommandsPanelFromTitlebar() {
+    sidebarView.evaluateJavaScript(
+      """
+      window.__zmux_NATIVE_SIDEBAR__?.toggleCommandsPanelFromTitlebar?.();
+      undefined;
+      """)
+  }
+
   private func refreshWorkspaceOpenTargetAvailabilityFromTitlebar() {
     /**
      CDXC:TitlebarOpenIn 2026-05-11-03:13
@@ -3548,6 +3558,8 @@ final class zmuxRootView: NSView {
       refreshWorkspaceOpenTargetAvailabilityFromTitlebar()
     case .rotateActivePaneLayoutClockwiseFromTitlebar:
       rotateActivePaneLayoutClockwiseFromTitlebar()
+    case .toggleCommandsPanelFromTitlebar:
+      toggleCommandsPanelFromTitlebar()
     case .runSidebarCommandFromTitlebar(let command):
       runSidebarCommandFromTitlebar(command)
     case .configureZedOverlay(let command):
@@ -3971,7 +3983,7 @@ final class zmuxRootView: NSView {
 
   private static func isHotkeyCandidate(_ event: NSEvent) -> Bool {
     let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-    return !flags.isDisjoint(with: [.command, .control, .option, .shift])
+    return !flags.isDisjoint(with: [.command, .control, .option, .shift]) || event.keyCode == 111
   }
 
   private static func normalizedHotkeyKey(_ event: NSEvent) -> String? {
@@ -3984,6 +3996,8 @@ final class zmuxRootView: NSView {
       return "down"
     case 123:
       return "left"
+    case 111:
+      return "f12"
     default:
       break
     }
@@ -5207,6 +5221,9 @@ final class zmuxFocusReportingWindow: NSWindow {
      */
     if event.type == .keyDown {
       onKeyDownDispatch?(event)
+      if onKeyEquivalent?(event) == true {
+        return
+      }
     }
     super.sendEvent(event)
   }

--- a/native/macos/zmuxHost/Sources/zmuxHost/HostProtocol.swift
+++ b/native/macos/zmuxHost/Sources/zmuxHost/HostProtocol.swift
@@ -58,6 +58,7 @@ enum HostCommand: Decodable {
   case openActiveProjectEditorFromTitlebar
   case refreshWorkspaceOpenTargetAvailabilityFromTitlebar
   case rotateActivePaneLayoutClockwiseFromTitlebar
+  case toggleCommandsPanelFromTitlebar
   case runSidebarCommandFromTitlebar(RunSidebarCommandFromTitlebar)
   case configureZedOverlay(ConfigureZedOverlay)
   case openZedWorkspace(OpenZedWorkspace)
@@ -125,6 +126,7 @@ enum HostCommand: Decodable {
     case openActiveProjectEditorFromTitlebar
     case refreshWorkspaceOpenTargetAvailabilityFromTitlebar
     case rotateActivePaneLayoutClockwiseFromTitlebar
+    case toggleCommandsPanelFromTitlebar
     case runSidebarCommandFromTitlebar
     case configureZedOverlay
     case openZedWorkspace
@@ -249,6 +251,8 @@ enum HostCommand: Decodable {
       self = .refreshWorkspaceOpenTargetAvailabilityFromTitlebar
     case .rotateActivePaneLayoutClockwiseFromTitlebar:
       self = .rotateActivePaneLayoutClockwiseFromTitlebar
+    case .toggleCommandsPanelFromTitlebar:
+      self = .toggleCommandsPanelFromTitlebar
     case .runSidebarCommandFromTitlebar:
       self = .runSidebarCommandFromTitlebar(try RunSidebarCommandFromTitlebar(from: decoder))
     case .configureZedOverlay:
@@ -366,6 +370,12 @@ struct SetActiveTerminalSet: Decodable {
   let appTitle: String?
   let attentionSessionIds: [String]?
   let backgroundColor: String?
+  let commandsPanelActiveSessionIds: [String]?
+  let commandsPanelFocusedSessionId: String?
+  let commandsPanelHeightRatio: Double?
+  let commandsPanelIsVisible: Bool?
+  let commandsPanelLayout: NativeTerminalLayout?
+  let commandsPanelMode: String?
   let focusRequestId: Int?
   let focusedSessionId: String?
   let sleepingSessionIds: [String]?
@@ -734,6 +744,7 @@ enum HostEvent: Encodable {
   case terminalExited(sessionId: String, exitCode: Int?)
   case terminalFocused(sessionId: String)
   case terminalBell(sessionId: String)
+  case commandsPanelHeightRatioChanged(heightRatio: Double)
   case terminalError(sessionId: String, message: String)
   case projectEditorLoadState(projectId: String, status: String, message: String?)
   case sessionStatusIndicatorClicked(status: NativeSessionStatusIndicatorStatus)
@@ -748,6 +759,7 @@ enum HostEvent: Encodable {
     case exitCode
     case cwd
     case foregroundPid
+    case heightRatio
     case message
     case protocolVersion
     case action
@@ -857,6 +869,9 @@ enum HostEvent: Encodable {
     case .terminalBell(let sessionId):
       try container.encode("terminalBell", forKey: .type)
       try container.encode(sessionId, forKey: .sessionId)
+    case .commandsPanelHeightRatioChanged(let heightRatio):
+      try container.encode("commandsPanelHeightRatioChanged", forKey: .type)
+      try container.encode(heightRatio, forKey: .heightRatio)
     case .terminalError(let sessionId, let message):
       try container.encode("terminalError", forKey: .type)
       try container.encode(sessionId, forKey: .sessionId)
@@ -918,10 +933,13 @@ enum HostEvent: Encodable {
 
 enum TerminalTitleBarAction: String, Codable, Hashable {
   case close
+  case closeCommandsPanel
   case delayedSend
+  case expandCommandsPanel
   case fork
   case newTerminal
   case openBrowser
+  case pinCommandsPanel
   case popOut
   case reload
   case rename
@@ -929,6 +947,7 @@ enum TerminalTitleBarAction: String, Codable, Hashable {
   case sleep
   case splitHorizontal
   case splitVertical
+  case unpinCommandsPanel
 }
 
 enum PaneDropPlacement: String, Codable {

--- a/native/macos/zmuxHost/Sources/zmuxHost/TerminalWorkspaceView.swift
+++ b/native/macos/zmuxHost/Sources/zmuxHost/TerminalWorkspaceView.swift
@@ -827,6 +827,11 @@ final class TerminalWorkspaceView: NSView {
     var lastWindowX: CGFloat
   }
 
+  private struct CommandsPanelResizeDrag {
+    let startHeight: CGFloat
+    let startY: CGFloat
+  }
+
   private struct PaneHeaderDrag {
     var isDragging: Bool
     var lastLoggedMoveAt: TimeInterval
@@ -861,6 +866,9 @@ final class TerminalWorkspaceView: NSView {
   }
 
   private static let terminalTitleBarHeight: CGFloat = 33
+  private static let commandPanelTitleBarHeight: CGFloat = 26
+  private static let collapsedCommandsPanelLeftMargin: CGFloat = 4
+  private static let collapsedCommandsPanelRightMargin: CGFloat = 8
   /**
    CDXC:NativePaneResize 2026-05-11-18:42
    The native fallback pane gap must match the shared default used by sidebar
@@ -873,6 +881,7 @@ final class TerminalWorkspaceView: NSView {
   private static let paneResizeMinimumWidth: CGFloat = 220
   private static let paneResizeOuterEdgeExclusion: CGFloat = 8
   private static let paneResizeRailWidth: CGFloat = 5
+  private static let floatingCommandsPanelMargin: CGFloat = 25
   /**
    CDXC:NativePaneResize 2026-05-11-10:40
    Pane split resizing must match native model: only the actual split rail owns
@@ -894,7 +903,10 @@ final class TerminalWorkspaceView: NSView {
   private static let floatingEditorMinimumWidth: CGFloat = 420
   private static let floatingEditorFrameDefaultsKey = "zmux.floatingEditor.frame.v1"
   private static let defaultWorkspaceBackgroundColor = NSColor(
-    calibratedRed: 0.071, green: 0.071, blue: 0.071, alpha: 1)
+    calibratedRed: 14.0 / 255.0,
+    green: 14.0 / 255.0,
+    blue: 14.0 / 255.0,
+    alpha: 1)
   private let ghostty: ZmuxGhosttyApp
   private let sendEvent: (HostEvent) -> Void
   var onSidebarResizeDrag: ((CGFloat) -> Void)?
@@ -908,6 +920,12 @@ final class TerminalWorkspaceView: NSView {
   private var pendingAuthenticatedWebPaneLoadSessionIds = Set<String>()
   private var t3ThreadRouteRetryAttemptsBySessionId = [String: Int]()
   private var activeSessionIds = Set<String>()
+  private var commandsPanelActiveSessionIds = Set<String>()
+  private var commandsPanelFocusedSessionId: String?
+  private var commandsPanelHeightRatio: CGFloat = 0.32
+  private var commandsPanelIsVisible = false
+  private var commandsPanelLayout: NativeTerminalLayout?
+  private var commandsPanelMode: String = "pinned"
   private var attentionSessionIds = Set<String>()
   private var poppedOutSessionIds = Set<String>()
   private var poppedOutPaneControllers: [String: PoppedOutPaneWindowController] = [:]
@@ -932,6 +950,10 @@ final class TerminalWorkspaceView: NSView {
   private var paneResizeRatiosByPath: [String: [CGFloat]] = [:]
   private var paneResizeDrag: PaneResizeDrag?
   private var sidebarResizeDrag: SidebarResizeDrag?
+  private var commandsPanelResizeDrag: CommandsPanelResizeDrag?
+  private let commandsPanelChromeView = CommandsPanelChromeView()
+  private let commandsPanelCollapsedRightMarginView = NSView(frame: .zero)
+  private let commandsPanelResizeHandleView = TerminalWorkspacePaneResizeHandleView()
   private var paneResizeHandleViews: [TerminalWorkspacePaneResizeHandleView] = []
   private var paneHeaderDrag: PaneHeaderDrag?
   private var paneHeaderDragGhostView: TerminalPaneHeaderDragGhostView?
@@ -995,6 +1017,20 @@ final class TerminalWorkspaceView: NSView {
     super.init(frame: .zero)
     wantsLayer = true
     layer?.backgroundColor = Self.defaultWorkspaceBackgroundColor.cgColor
+    commandsPanelChromeView.isHidden = true
+    commandsPanelCollapsedRightMarginView.wantsLayer = true
+    commandsPanelCollapsedRightMarginView.layer?.backgroundColor = NSColor.black.cgColor
+    commandsPanelCollapsedRightMarginView.isHidden = true
+    commandsPanelResizeHandleView.configure(direction: .vertical, cursor: .resizeUpDown)
+    commandsPanelResizeHandleView.onMouseDown = { [weak self] event in
+      _ = self?.beginCommandsPanelResize(with: event)
+    }
+    commandsPanelResizeHandleView.onMouseDragged = { [weak self] event in
+      _ = self?.continueCommandsPanelResize(with: event)
+    }
+    commandsPanelResizeHandleView.onMouseUp = { [weak self] event in
+      _ = self?.endCommandsPanelResize(with: event)
+    }
   }
 
   required init?(coder: NSCoder) {
@@ -2576,7 +2612,12 @@ final class TerminalWorkspaceView: NSView {
       needsLayout = true
       layoutSubtreeIfNeeded()
     }
-    focusedSessionId = sessionId
+    let isCommandPanelSession = commandsPanelActiveSessionIds.contains(sessionId)
+    if isCommandPanelSession {
+      commandsPanelFocusedSessionId = sessionId
+    } else {
+      focusedSessionId = sessionId
+    }
     orderTerminalPaneViewsToFront(sessions[sessionId])
     updateAllTerminalBorders()
     let targetWindow = poppedOutPaneControllers[sessionId]?.window ?? window
@@ -2610,6 +2651,9 @@ final class TerminalWorkspaceView: NSView {
         "visibleSessionIds": orderedVisibleSessionIds(),
         "windowIsKey": window?.isKeyWindow ?? false,
       ])
+    if isCommandPanelSession {
+      emitFocusedSessionSelectionIfNeeded(sessionId: sessionId, reason: reason)
+    }
   }
 
   private func focusTerminalFromContentMouseDown(
@@ -2622,7 +2666,13 @@ final class TerminalWorkspaceView: NSView {
     let responderSessionId =
       event.window?.firstResponder.flatMap { sessionId(containing: $0) } ?? currentResponderSessionId()
     let isSurfaceFirstResponder = event.window?.firstResponder === surfaceView
-    guard focusedSessionId != clickedSessionId || responderSessionId != clickedSessionId || !isSurfaceFirstResponder else {
+    let localFocusedSessionId = commandsPanelActiveSessionIds.contains(clickedSessionId)
+      ? commandsPanelFocusedSessionId
+      : focusedSessionId
+    guard localFocusedSessionId != clickedSessionId
+      || responderSessionId != clickedSessionId
+      || !isSurfaceFirstResponder
+    else {
       return
     }
     /**
@@ -2636,6 +2686,7 @@ final class TerminalWorkspaceView: NSView {
       event: "nativeWorkspace.terminalContent.focusMouseDown",
       details: [
         "focusedSessionIdBefore": nullableString(focusedSessionId),
+        "commandsPanelFocusedSessionIdBefore": nullableString(commandsPanelFocusedSessionId),
         "isSurfaceFirstResponder": isSurfaceFirstResponder,
         "responderSessionIdBefore": nullableString(responderSessionId),
         "sessionId": clickedSessionId,
@@ -2895,6 +2946,7 @@ final class TerminalWorkspaceView: NSView {
   func setActiveTerminalSet(_ command: SetActiveTerminalSet) {
     let responderBefore = responderSnapshot()
     let nextActiveSessionIds = Set(command.activeSessionIds)
+    let nextCommandsPanelActiveSessionIds = Set(command.commandsPanelActiveSessionIds ?? [])
     let nextActiveProjectEditorId = command.activeProjectEditorId
     let nextPoppedOutSessionIds = Set(command.poppedOutSessionIds ?? []).intersection(nextActiveSessionIds)
     let nextPaneGap = Self.clampedPaneGap(command.paneGap)
@@ -2938,6 +2990,12 @@ final class TerminalWorkspaceView: NSView {
         ])
     }
     activeSessionIds = nextActiveSessionIds
+    commandsPanelActiveSessionIds = nextCommandsPanelActiveSessionIds
+    commandsPanelFocusedSessionId = command.commandsPanelFocusedSessionId
+    commandsPanelHeightRatio = Self.clampedCommandsPanelHeightRatio(command.commandsPanelHeightRatio)
+    commandsPanelIsVisible = command.commandsPanelIsVisible == true
+    commandsPanelLayout = command.commandsPanelLayout
+    commandsPanelMode = command.commandsPanelMode ?? "pinned"
     attentionSessionIds = Set(command.attentionSessionIds ?? [])
     poppedOutSessionIds = nextPoppedOutSessionIds
     sleepingSessionIds = Set(command.sleepingSessionIds ?? [])
@@ -2960,6 +3018,11 @@ final class TerminalWorkspaceView: NSView {
     applyWorkspaceBackgroundColor(command.backgroundColor)
     let isProjectEditorActive = activeProjectEditorId != nil
     for session in sessions.values {
+      let isCommandActive = commandsPanelActiveSessionIds.contains(session.sessionId)
+      let chromeRole: TerminalPaneChromeRole = isCommandActive ? .commands : .workspace
+      session.titleBarView.setChromeRole(chromeRole)
+      session.borderView.setChromeRole(chromeRole)
+      session.borderView.setHidesInactiveCommandBorder(isCommandActive && commandsPanelMode == "pinned")
       if let title = sessionTitles[session.sessionId] {
         session.titleBarView.setTitle(
           normalizedTerminalSessionTitle(title, sessionId: session.sessionId)
@@ -2973,7 +3036,7 @@ final class TerminalWorkspaceView: NSView {
         colorHex: sessionAgentIconColors[session.sessionId])
       if shouldRelayout {
         let isPoppedOut = poppedOutSessionIds.contains(session.sessionId)
-        let isActive = !isProjectEditorActive && activeSessionIds.contains(session.sessionId)
+        let isActive = (!isProjectEditorActive && activeSessionIds.contains(session.sessionId)) || isCommandActive
         session.containerView.isHidden = !isActive || isPoppedOut
         session.scrollView.isHidden = false
         session.searchBarView.isHidden = !isActive || session.view.searchState == nil
@@ -3105,8 +3168,12 @@ final class TerminalWorkspaceView: NSView {
       return
     }
     lastAppliedLayoutFocusRequestId = focusRequestId
-    if let focusedSessionId = command.focusedSessionId,
-      activeSessionIds.contains(focusedSessionId)
+    let requestedFocusSessionId =
+      command.focusedSessionId.flatMap { activeSessionIds.contains($0) ? $0 : nil }
+      ?? command.commandsPanelFocusedSessionId.flatMap {
+        commandsPanelActiveSessionIds.contains($0) ? $0 : nil
+      }
+    if let focusedSessionId = requestedFocusSessionId
     {
       if shouldPreserveNonTerminalFirstResponder() {
         /**
@@ -3133,8 +3200,10 @@ final class TerminalWorkspaceView: NSView {
         event: "nativeWorkspace.setActiveTerminalSet.focusSkipped",
         details: [
           "activeSessionIds": Array(activeSessionIds).sorted(),
+          "commandsPanelActiveSessionIds": Array(commandsPanelActiveSessionIds).sorted(),
           "focusRequestId": focusRequestId,
           "focusedSessionId": nullableString(command.focusedSessionId),
+          "commandsPanelFocusedSessionId": nullableString(command.commandsPanelFocusedSessionId),
           "reason": "focusedSessionNotActive",
         ])
     }
@@ -3160,6 +3229,43 @@ final class TerminalWorkspaceView: NSView {
       layoutFloatingEditorOverlay()
     }
     paneResizeHits.removeAll()
+    let commandSessionIds = orderedVisibleCommandSessionIds()
+    let hasCommandsPanelSessions = !commandSessionIds.isEmpty
+    let shouldShowExpandedCommandsPanel = commandsPanelIsVisible && hasCommandsPanelSessions
+    let shouldShowCollapsedCommandsPanel = !commandsPanelIsVisible && hasCommandsPanelSessions
+    let shouldShowCommandsPanel = shouldShowExpandedCommandsPanel || shouldShowCollapsedCommandsPanel
+    let shouldReserveCommandsPanelSpace =
+      shouldShowCollapsedCommandsPanel || (shouldShowExpandedCommandsPanel && commandsPanelMode == "pinned")
+    let commandPanelHeight = shouldShowExpandedCommandsPanel
+      ? clampedCommandsPanelHeight(bounds.height * commandsPanelHeightRatio)
+      : shouldShowCollapsedCommandsPanel ? collapsedCommandsPanelHeight() : 0
+    let shouldFloatCommandsPanel = shouldShowExpandedCommandsPanel && commandsPanelMode == "floating"
+    let floatingCommandsPanelMargin = shouldFloatCommandsPanel ? Self.floatingCommandsPanelMargin : 0
+    let commandPanelResolvedHeight = min(
+      max(0, bounds.height - floatingCommandsPanelMargin * 2),
+      commandPanelHeight)
+    let collapsedCommandsPanelLeftMargin =
+      shouldShowCollapsedCommandsPanel ? Self.collapsedCommandsPanelLeftMargin : 0
+    let collapsedCommandsPanelRightMargin =
+      shouldShowCollapsedCommandsPanel ? Self.collapsedCommandsPanelRightMargin : 0
+    let resolvedCommandPanelBounds: CGRect = shouldShowCommandsPanel
+      ? CGRect(
+          x: bounds.minX + floatingCommandsPanelMargin + collapsedCommandsPanelLeftMargin,
+          y: bounds.minY + floatingCommandsPanelMargin,
+          width: max(
+            0,
+            bounds.width - floatingCommandsPanelMargin * 2 - collapsedCommandsPanelLeftMargin
+              - collapsedCommandsPanelRightMargin),
+          height: commandPanelResolvedHeight)
+      : .zero
+    let workspaceBounds =
+      shouldReserveCommandsPanelSpace
+      ? CGRect(
+          x: bounds.minX,
+          y: resolvedCommandPanelBounds.maxY,
+          width: bounds.width,
+          height: max(0, bounds.height - resolvedCommandPanelBounds.height))
+      : bounds
     if let activeProjectEditorId,
       let editorSession = projectEditorPaneSessions[activeProjectEditorId]
     {
@@ -3177,20 +3283,54 @@ final class TerminalWorkspaceView: NSView {
       ])
       hideSplitSessionSurfacesForActiveEditor()
       editorSession.hostView.isHidden = false
-      layoutProjectEditorPane(editorSession)
+      layoutProjectEditorPane(editorSession, in: workspaceBounds)
       orderProjectEditorPaneToFront(editorSession)
+      if shouldShowCommandsPanel {
+        syncCommandsPanelChrome(
+          in: resolvedCommandPanelBounds,
+          isExpanded: shouldShowExpandedCommandsPanel,
+          isFloating: shouldShowExpandedCommandsPanel && commandsPanelMode == "floating")
+        layoutCommandsPanel(commandSessionIds, in: resolvedCommandPanelBounds)
+        syncCommandsPanelResizeHandle(
+          in: resolvedCommandPanelBounds,
+          isExpanded: shouldShowExpandedCommandsPanel)
+        syncPaneResizeHandleViews()
+      } else {
+        hideCommandsPanelChrome()
+        hideCommandsPanelResizeHandle()
+        hidePaneResizeHandleViews()
+      }
       return
     }
     let visibleSessionIds = orderedVisibleSessionIds()
-    guard !visibleSessionIds.isEmpty else {
+    guard !visibleSessionIds.isEmpty || shouldShowCommandsPanel else {
+      hideCommandsPanelResizeHandle()
       hidePaneResizeHandleViews()
       discardCursorRects()
       return
     }
-    if let terminalLayout {
-      layoutTree(terminalLayout, in: layoutBounds(forVisibleCount: visibleSessionIds.count), path: "root")
+    if !visibleSessionIds.isEmpty {
+      if let terminalLayout {
+        layoutTree(
+          terminalLayout,
+          in: layoutBounds(forVisibleCount: visibleSessionIds.count, in: workspaceBounds),
+          path: "root")
+      } else {
+        layoutGrid(visibleSessionIds, in: layoutBounds(forVisibleCount: visibleSessionIds.count, in: workspaceBounds))
+      }
+    }
+    if shouldShowCommandsPanel {
+      syncCommandsPanelChrome(
+        in: resolvedCommandPanelBounds,
+        isExpanded: shouldShowExpandedCommandsPanel,
+        isFloating: shouldShowExpandedCommandsPanel && commandsPanelMode == "floating")
+      layoutCommandsPanel(commandSessionIds, in: resolvedCommandPanelBounds)
+      syncCommandsPanelResizeHandle(
+        in: resolvedCommandPanelBounds,
+        isExpanded: shouldShowExpandedCommandsPanel)
     } else {
-      layoutGrid(visibleSessionIds, in: layoutBounds(forVisibleCount: visibleSessionIds.count))
+      hideCommandsPanelChrome()
+      hideCommandsPanelResizeHandle()
     }
     updateOuterBottomPaneBorderCorner()
     syncPaneResizeHandleViews()
@@ -3203,6 +3343,75 @@ final class TerminalWorkspaceView: NSView {
       handleView.isHidden = true
       handleView.frame = .zero
     }
+  }
+
+  private func hideCommandsPanelResizeHandle() {
+    commandsPanelResizeDrag = nil
+    commandsPanelResizeHandleView.isHidden = true
+    commandsPanelResizeHandleView.frame = .zero
+  }
+
+  private func hideCommandsPanelChrome() {
+    commandsPanelChromeView.isHidden = true
+    commandsPanelChromeView.frame = .zero
+    commandsPanelCollapsedRightMarginView.isHidden = true
+    commandsPanelCollapsedRightMarginView.frame = .zero
+  }
+
+  private func syncCommandsPanelChrome(in commandPanelBounds: CGRect, isExpanded: Bool, isFloating: Bool) {
+    commandsPanelChromeView.frame = commandPanelBounds
+    commandsPanelChromeView.isHidden = false
+    commandsPanelChromeView.layer?.zPosition = isFloating ? 250 : 0
+    if commandsPanelChromeView.superview !== self {
+      addSubview(commandsPanelChromeView, positioned: .below, relativeTo: nil)
+    }
+    if let firstCommandSessionId = orderedVisibleCommandSessionIds().first,
+      let firstCommandSession = sessions[firstCommandSessionId],
+      firstCommandSession.containerView.superview === self
+    {
+      addSubview(commandsPanelChromeView, positioned: .below, relativeTo: firstCommandSession.containerView)
+    } else {
+      addSubview(commandsPanelChromeView, positioned: .below, relativeTo: nil)
+    }
+    syncCommandsPanelCollapsedRightMargin(from: commandPanelBounds, isExpanded: isExpanded)
+  }
+
+  private func syncCommandsPanelCollapsedRightMargin(from commandPanelBounds: CGRect, isExpanded: Bool) {
+    guard !isExpanded, commandPanelBounds.maxX < bounds.maxX else {
+      commandsPanelCollapsedRightMarginView.isHidden = true
+      commandsPanelCollapsedRightMarginView.frame = .zero
+      return
+    }
+    commandsPanelCollapsedRightMarginView.frame = CGRect(
+      x: commandPanelBounds.maxX,
+      y: commandPanelBounds.minY,
+      width: max(0, bounds.maxX - commandPanelBounds.maxX),
+      height: commandPanelBounds.height)
+    commandsPanelCollapsedRightMarginView.isHidden = false
+    commandsPanelCollapsedRightMarginView.layer?.zPosition = commandsPanelChromeView.layer?.zPosition ?? 0
+    if commandsPanelCollapsedRightMarginView.superview !== self {
+      addSubview(commandsPanelCollapsedRightMarginView, positioned: .below, relativeTo: nil)
+    }
+    addSubview(commandsPanelCollapsedRightMarginView, positioned: .below, relativeTo: commandsPanelChromeView)
+  }
+
+  private func syncCommandsPanelResizeHandle(in commandPanelBounds: CGRect, isExpanded: Bool) {
+    guard isExpanded else {
+      hideCommandsPanelResizeHandle()
+      return
+    }
+    let railHeight = max(Self.paneResizeRailWidth, 12)
+    commandsPanelResizeHandleView.frame = CGRect(
+      x: commandPanelBounds.minX,
+      y: max(bounds.minY, commandPanelBounds.maxY - railHeight / 2),
+      width: commandPanelBounds.width,
+      height: min(railHeight, bounds.height)
+    )
+    commandsPanelResizeHandleView.configure(direction: .vertical, cursor: .resizeUpDown)
+    commandsPanelResizeHandleView.isHidden = false
+    commandsPanelResizeHandleView.layer?.zPosition = 10_500
+    addSubview(commandsPanelResizeHandleView, positioned: .above, relativeTo: nil)
+    window?.invalidateCursorRects(for: commandsPanelResizeHandleView)
   }
 
   private func syncPaneResizeHandleViews() {
@@ -3336,11 +3545,65 @@ final class TerminalWorkspaceView: NSView {
   }
 
   private func layoutBounds(forVisibleCount visibleCount: Int) -> CGRect {
-    let inset = visibleCount <= 1 ? Self.singlePaneInset : paneGap
-    return bounds.insetBy(dx: inset, dy: inset)
+    layoutBounds(forVisibleCount: visibleCount, in: bounds)
   }
 
-  private func layoutProjectEditorPane(_ session: ProjectEditorPaneSession) {
+  private func layoutBounds(forVisibleCount visibleCount: Int, in rect: CGRect) -> CGRect {
+    let inset = visibleCount <= 1 ? Self.singlePaneInset : paneGap
+    return rect.insetBy(dx: inset, dy: inset)
+  }
+
+  private func layoutCommandsPanel(_ sessionIds: [String], in rect: CGRect) {
+    guard !sessionIds.isEmpty else {
+      return
+    }
+    let panelBounds = rect.insetBy(dx: commandPanelOuterInset(), dy: commandPanelOuterInset())
+    if let commandsPanelLayout {
+      layoutTree(commandsPanelLayout, in: panelBounds, path: "commands")
+    } else {
+      layoutGrid(sessionIds, in: panelBounds)
+    }
+    orderCommandsPanelToFront(sessionIds)
+  }
+
+  private func clampedCommandsPanelHeight(_ value: CGFloat) -> CGFloat {
+    guard bounds.height > 0 else {
+      return 0
+    }
+    let minimumHeight = min(Self.paneResizeMinimumHeight, bounds.height)
+    let maximumHeight = max(minimumHeight, bounds.height * 0.55)
+    return min(max(value, minimumHeight), maximumHeight)
+  }
+
+  private func collapsedCommandsPanelHeight() -> CGFloat {
+    Self.commandPanelTitleBarHeight + commandPanelOuterInset() * 2
+  }
+
+  private func commandPanelOuterInset() -> CGFloat {
+    2 / max(window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2, 1)
+  }
+
+  private func orderCommandsPanelToFront(_ sessionIds: [String]) {
+    for sessionId in sessionIds {
+      guard let session = sessions[sessionId], session.containerView.superview === self else {
+        continue
+      }
+      addSubview(session.containerView, positioned: .above, relativeTo: nil)
+      session.containerView.layer?.zPosition = commandsPanelIsVisible ? 300 : 100
+    }
+    if commandsPanelChromeView.superview === self, commandsPanelIsVisible {
+      commandsPanelChromeView.layer?.zPosition = commandsPanelMode == "floating" ? 250 : 0
+    }
+  }
+
+  private func keepCommandsPanelAboveWorkspacePanes() {
+    guard commandsPanelIsVisible, !commandsPanelActiveSessionIds.isEmpty else {
+      return
+    }
+    orderCommandsPanelToFront(orderedVisibleCommandSessionIds())
+  }
+
+  private func layoutProjectEditorPane(_ session: ProjectEditorPaneSession, in rect: CGRect? = nil) {
     NativeT3CodePaneReproLog.append("nativeWorkspace.projectEditor.layout.start", [
       "hostFrameBefore": describeFrame(session.hostView.frame),
       "projectId": session.projectId,
@@ -3348,7 +3611,7 @@ final class TerminalWorkspaceView: NSView {
       "workspaceBounds": describeFrame(bounds),
       "windowNumber": window?.windowNumber ?? NSNull(),
     ])
-    let nextFrame = bounds
+    let nextFrame = rect ?? bounds
     /**
      CDXC:EditorPanes 2026-05-08-13:37
      Sidebar resize must not synchronously refresh or display the hosted VS
@@ -3400,6 +3663,9 @@ final class TerminalWorkspaceView: NSView {
     paneResizeDrag = nil
     resetPaneHeaderInteractionState()
     for session in sessions.values {
+      if commandsPanelActiveSessionIds.contains(session.sessionId) {
+        continue
+      }
       moveOffscreen(session.containerView)
     }
     for session in webPaneSessions.values {
@@ -3505,6 +3771,18 @@ final class TerminalWorkspaceView: NSView {
     return fromLayout.filter { activeSessionIds.contains($0) }
   }
 
+  private func orderedVisibleCommandSessionIds() -> [String] {
+    let fromLayout = commandsPanelLayout.map(leafSessionIds) ?? Array(sessions.keys)
+    return fromLayout.filter { commandsPanelActiveSessionIds.contains($0) }
+  }
+
+  private func orderedVisibleCommandPaneOwnerSessionIds() -> [String] {
+    guard let commandsPanelLayout else {
+      return orderedVisibleCommandSessionIds()
+    }
+    return visibleCommandPaneOwnerSessionIds(in: commandsPanelLayout)
+  }
+
   /**
    CDXC:PaneTabs 2026-05-12-10:37
    Hit testing needs the visible pane owner for each tab group, not every
@@ -3538,14 +3816,39 @@ final class TerminalWorkspaceView: NSView {
     }
   }
 
+  private func visibleCommandPaneOwnerSessionIds(in node: NativeTerminalLayout) -> [String] {
+    switch node {
+    case .leaf(let sessionId):
+      return commandsPanelActiveSessionIds.contains(sessionId) ? [sessionId] : []
+    case .tabs(let activeSessionId, let sessionIds):
+      let tabSessionIds = sessionIds.filter {
+        commandsPanelActiveSessionIds.contains($0) || sleepingSessionIds.contains($0)
+      }
+      let activeTabSessionIds = tabSessionIds.filter { commandsPanelActiveSessionIds.contains($0) }
+      guard !activeTabSessionIds.isEmpty else {
+        return []
+      }
+      return [
+        activeSessionId.flatMap { activeTabSessionIds.contains($0) ? $0 : nil }
+          ?? activeTabSessionIds[0]
+      ]
+    case .split(_, _, let children):
+      return children.flatMap { visibleCommandPaneOwnerSessionIds(in: $0) }
+    }
+  }
+
+  private func isPaneSessionVisible(_ sessionId: String) -> Bool {
+    activeSessionIds.contains(sessionId) || commandsPanelActiveSessionIds.contains(sessionId)
+  }
+
   private func layoutTree(_ node: NativeTerminalLayout, in rect: CGRect, path: String) {
     switch node {
     case .leaf(let sessionId):
       setPaneTabs([sessionId], activeSessionId: sessionId, on: sessionId)
       setFrame(rect, for: sessionId)
     case .tabs(let activeSessionId, let sessionIds):
-      let tabSessionIds = sessionIds.filter { activeSessionIds.contains($0) || sleepingSessionIds.contains($0) }
-      let activeTabSessionIds = tabSessionIds.filter { activeSessionIds.contains($0) }
+      let tabSessionIds = sessionIds.filter { isPaneSessionVisible($0) || sleepingSessionIds.contains($0) }
+      let activeTabSessionIds = tabSessionIds.filter { isPaneSessionVisible($0) }
       guard !activeTabSessionIds.isEmpty else { return }
       let selectedSessionId =
         activeSessionId.flatMap { activeTabSessionIds.contains($0) ? $0 : nil } ?? activeTabSessionIds[0]
@@ -3556,7 +3859,7 @@ final class TerminalWorkspaceView: NSView {
       setFrame(rect, for: selectedSessionId)
     case .split(let direction, let ratio, let children):
       let visibleChildren = children.filter {
-        !leafSessionIds($0).allSatisfy { !activeSessionIds.contains($0) }
+        !leafSessionIds($0).allSatisfy { !isPaneSessionVisible($0) }
       }
       guard !visibleChildren.isEmpty else { return }
       if visibleChildren.count == 1 {
@@ -4024,6 +4327,16 @@ final class TerminalWorkspaceView: NSView {
   }
 
   private func paneResizeHandleHitView(at point: NSPoint) -> NSView? {
+    if
+      !commandsPanelResizeHandleView.isHidden,
+      commandsPanelResizeHandleView.alphaValue > 0,
+      commandsPanelResizeHandleView.frame.contains(point)
+    {
+      let handlePoint = commandsPanelResizeHandleView.convert(point, from: self)
+      if let hitView = commandsPanelResizeHandleView.hitTest(handlePoint) {
+        return hitView
+      }
+    }
     for handleView in paneResizeHandleViews.reversed() {
       guard
         !handleView.isHidden,
@@ -4055,6 +4368,13 @@ final class TerminalWorkspaceView: NSView {
   private func paneTitleBarHitView(at point: CGPoint) -> NSView? {
     guard paneResizeHit(at: point) == nil else {
       return nil
+    }
+    for sessionId in orderedVisibleCommandPaneOwnerSessionIds().reversed() {
+      if let session = sessions[sessionId],
+        let hitView = paneTitleBarHitView(session.titleBarView, at: point)
+      {
+        return hitView
+      }
     }
     for sessionId in orderedVisiblePaneOwnerSessionIds().reversed() {
       if let session = sessions[sessionId],
@@ -4094,22 +4414,18 @@ final class TerminalWorkspaceView: NSView {
   }
 
   private func paneContentHitView(at point: CGPoint) -> NSView? {
+    for sessionId in orderedVisibleCommandPaneOwnerSessionIds().reversed() {
+      if let session = sessions[sessionId],
+        let hitView = terminalPaneContentHitView(session, at: point)
+      {
+        return hitView
+      }
+    }
     for sessionId in orderedVisiblePaneOwnerSessionIds().reversed() {
       if let session = sessions[sessionId],
-        !session.containerView.isHidden,
-        session.containerView.window != nil,
-        session.containerView.frame.contains(point)
+        let hitView = terminalPaneContentHitView(session, at: point)
       {
-        if !session.searchBarView.isHidden {
-          let searchPoint = convert(point, to: session.searchBarView)
-          if session.searchBarView.bounds.contains(searchPoint) {
-            return session.searchBarView.hitTest(searchPoint) ?? session.searchBarView
-          }
-        }
-        let contentPoint = convert(point, to: session.scrollView)
-        if session.scrollView.bounds.contains(contentPoint) {
-          return session.scrollView.hitTest(contentPoint) ?? session.scrollView
-        }
+        return hitView
       }
       if let session = webPaneSessions[sessionId],
         !session.containerView.isHidden,
@@ -4121,6 +4437,26 @@ final class TerminalWorkspaceView: NSView {
           return session.hostView.hitTest(contentPoint) ?? session.hostView
         }
       }
+    }
+    return nil
+  }
+
+  private func terminalPaneContentHitView(_ session: TerminalSession, at point: CGPoint) -> NSView? {
+    guard !session.containerView.isHidden,
+      session.containerView.window != nil,
+      session.containerView.frame.contains(point)
+    else {
+      return nil
+    }
+    if !session.searchBarView.isHidden {
+      let searchPoint = convert(point, to: session.searchBarView)
+      if session.searchBarView.bounds.contains(searchPoint) {
+        return session.searchBarView.hitTest(searchPoint) ?? session.searchBarView
+      }
+    }
+    let contentPoint = convert(point, to: session.scrollView)
+    if session.scrollView.bounds.contains(contentPoint) {
+      return session.scrollView.hitTest(contentPoint) ?? session.scrollView
     }
     return nil
   }
@@ -4291,6 +4627,41 @@ final class TerminalWorkspaceView: NSView {
     if sidebarResizeEdgeRect?.contains(point) == true {
       NSCursor.resizeLeftRight.set()
     }
+    return true
+  }
+
+  @discardableResult
+  private func beginCommandsPanelResize(with event: NSEvent) -> Bool {
+    let point = convert(event.locationInWindow, from: nil)
+    let startHeight = clampedCommandsPanelHeight(bounds.height * commandsPanelHeightRatio)
+    commandsPanelResizeDrag = CommandsPanelResizeDrag(startHeight: startHeight, startY: point.y)
+    NSCursor.resizeUpDown.set()
+    return true
+  }
+
+  @discardableResult
+  private func continueCommandsPanelResize(with event: NSEvent) -> Bool {
+    guard let drag = commandsPanelResizeDrag else {
+      return false
+    }
+    let point = convert(event.locationInWindow, from: nil)
+    let nextHeight = clampedCommandsPanelHeight(drag.startHeight + point.y - drag.startY)
+    commandsPanelHeightRatio = Self.clampedCommandsPanelHeightRatio(Double(nextHeight / max(bounds.height, 1)))
+    NSCursor.resizeUpDown.set()
+    needsLayout = true
+    layoutSubtreeIfNeeded()
+    return true
+  }
+
+  @discardableResult
+  private func endCommandsPanelResize(with event: NSEvent) -> Bool {
+    guard commandsPanelResizeDrag != nil else {
+      return false
+    }
+    _ = continueCommandsPanelResize(with: event)
+    commandsPanelResizeDrag = nil
+    sendEvent(.commandsPanelHeightRatioChanged(heightRatio: Double(commandsPanelHeightRatio)))
+    NSCursor.resizeUpDown.set()
     return true
   }
 
@@ -4774,6 +5145,14 @@ final class TerminalWorkspaceView: NSView {
         "sessionId": sessionId,
         "titleBarFrame": describeFrame(paneTitleBarFrame(for: sessionId) ?? .zero),
       ])
+    if commandsPanelActiveSessionIds.contains(sessionId), !commandsPanelIsVisible {
+      NativePaneTabDragReproLog.append(event: "nativeCommandsPanel.collapsedTitleBar.expandRequested", details: [
+        "hitPoint": nativePaneTabsDebugFrame(CGRect(x: startPoint.x, y: startPoint.y, width: 0, height: 0)),
+        "sessionId": sessionId,
+      ])
+      sendEvent(.paneTabSelected(sessionId: sessionId))
+      return
+    }
     focusSession(sessionId: sessionId, reason: focusReason)
   }
 
@@ -5759,7 +6138,7 @@ final class TerminalWorkspaceView: NSView {
 
   private func setPoppedOutPlaceholderFrame(_ rect: CGRect, for sessionId: String) {
     let title = normalizedTerminalSessionTitle(sessionTitles[sessionId], sessionId: sessionId)
-    let titleBarHeight = min(Self.terminalTitleBarHeight, max(rect.height, 0))
+    let titleBarHeight = min(titleBarHeight(for: sessionId), max(rect.height, 0))
     let titleBarRect = CGRect(
       x: rect.minX,
       y: rect.maxY - titleBarHeight,
@@ -5840,7 +6219,7 @@ final class TerminalWorkspaceView: NSView {
      bar that the reference workspace renders in React. The AppKit surface is
      therefore laid out below native chrome instead of covering the full pane.
      */
-    let titleBarHeight = min(Self.terminalTitleBarHeight, max(rect.height, 0))
+    let titleBarHeight = min(titleBarHeight(for: sessionId), max(rect.height, 0))
     mountTerminalPaneContainer(for: session)
     session.containerView.frame = rect
     session.containerView.isHidden = false
@@ -5866,6 +6245,15 @@ final class TerminalWorkspaceView: NSView {
     session.titleBarView.frame = titleBarRect
     session.titleBarView.needsLayout = true
     session.titleBarView.layoutSubtreeIfNeeded()
+    if commandsPanelActiveSessionIds.contains(sessionId) && !commandsPanelIsVisible {
+      session.scrollView.frame = .zero
+      session.scrollView.isHidden = true
+      session.searchBarView.frame = .zero
+      session.searchBarView.isHidden = true
+      session.borderView.frame = session.containerView.bounds
+      updateTerminalBorder(for: sessionId)
+      return
+    }
     session.scrollView.frame = availableTerminalRect
     session.scrollView.needsLayout = true
     session.scrollView.layoutSubtreeIfNeeded()
@@ -5878,6 +6266,12 @@ final class TerminalWorkspaceView: NSView {
       availableTerminalRect: availableTerminalRect,
       terminalRect: terminalRect)
     updateTerminalBorder(for: sessionId)
+  }
+
+  private func titleBarHeight(for sessionId: String) -> CGFloat {
+    commandsPanelActiveSessionIds.contains(sessionId)
+      ? Self.commandPanelTitleBarHeight
+      : Self.terminalTitleBarHeight
   }
 
   private func movePaneSessionOffscreen(_ sessionId: String) {
@@ -6069,6 +6463,7 @@ final class TerminalWorkspaceView: NSView {
     }
     containerView.alphaValue = 1
     containerView.layer?.zPosition = 100
+    keepCommandsPanelAboveWorkspacePanes()
   }
 
   private func scheduleWebPaneReload(sessionId: String, url: URL, remainingAttempts: Int) {
@@ -7419,7 +7814,8 @@ final class TerminalWorkspaceView: NSView {
     guard let session = sessions[sessionId] else {
       return
     }
-    let isActive = activeSessionIds.contains(sessionId)
+    let isCommandActive = commandsPanelActiveSessionIds.contains(sessionId)
+    let isActive = activeSessionIds.contains(sessionId) || isCommandActive
     setHidden(!isActive, for: session.titleBarView)
     setHidden(!isActive || session.view.searchState == nil, for: session.searchBarView)
     setHidden(!isActive, for: session.borderView)
@@ -7431,7 +7827,8 @@ final class TerminalWorkspaceView: NSView {
       faviconDataUrls: sessionFaviconDataUrls,
       agentIconDataUrls: sessionAgentIconDataUrls,
       agentIconColors: sessionAgentIconColors)
-    session.titleBarView.setFocusedPane(focusedSessionId == sessionId)
+    let isCommandFocused = isCommandActive && commandPanelFocusedResponderSessionId() == sessionId
+    session.titleBarView.setFocusedPane(focusedSessionId == sessionId || isCommandFocused)
     session.borderView.setState(
       isFocused: shouldShowFocusedPaneBorder(for: sessionId),
       isAttention: attentionSessionIds.contains(sessionId)
@@ -7446,7 +7843,27 @@ final class TerminalWorkspaceView: NSView {
      failure, so keep the selected-pane border enabled and fix resize event
      ownership instead of hiding focus chrome.
      */
-    focusedSessionId == sessionId && orderedVisibleSessionIds().count > 1
+    let isCommandPanelSession = commandsPanelActiveSessionIds.contains(sessionId)
+    if isCommandPanelSession {
+      return commandsPanelFocusedSessionId == sessionId
+        && commandPanelFocusedResponderSessionId() == sessionId
+    }
+    return !commandPanelOwnsResponder()
+      && focusedSessionId == sessionId
+      && orderedVisibleSessionIds().count > 1
+  }
+
+  private func commandPanelOwnsResponder() -> Bool {
+    commandPanelFocusedResponderSessionId() != nil
+  }
+
+  private func commandPanelFocusedResponderSessionId() -> String? {
+    guard let responderSessionId = currentResponderSessionId(),
+      commandsPanelActiveSessionIds.contains(responderSessionId)
+    else {
+      return nil
+    }
+    return responderSessionId
   }
 
   private func keyboardRouteDebugPayload(
@@ -7668,17 +8085,27 @@ final class TerminalWorkspaceView: NSView {
         ])
       return
     }
-    guard activeSessionIds.contains(focusedSessionId) else {
+    guard activeSessionIds.contains(focusedSessionId)
+      || commandsPanelActiveSessionIds.contains(focusedSessionId)
+    else {
       TerminalFocusDebugLog.append(
         event: "nativeWorkspace.focusedInactiveSessionIgnored",
         details: [
           "activeSessionIds": Array(activeSessionIds).sorted(),
+          "commandsPanelActiveSessionIds": Array(commandsPanelActiveSessionIds).sorted(),
           "reason": reason,
           "sessionId": focusedSessionId,
         ])
       return
     }
-    if lastEmittedFocusedSessionId == focusedSessionId, self.focusedSessionId == focusedSessionId {
+    emitFocusedSessionSelectionIfNeeded(sessionId: focusedSessionId, reason: reason)
+  }
+
+  private func emitFocusedSessionSelectionIfNeeded(sessionId focusedSessionId: String, reason: String) {
+    let localFocusedSessionId = commandsPanelActiveSessionIds.contains(focusedSessionId)
+      ? commandsPanelFocusedSessionId
+      : self.focusedSessionId
+    if lastEmittedFocusedSessionId == focusedSessionId, localFocusedSessionId == focusedSessionId {
       TerminalFocusDebugLog.append(
         event: "nativeWorkspace.terminalFocused.duplicateSkipped",
         details: [
@@ -7687,7 +8114,7 @@ final class TerminalWorkspaceView: NSView {
         ])
       return
     }
-    if lastEmittedFocusedSessionId == focusedSessionId, self.focusedSessionId != focusedSessionId {
+    if lastEmittedFocusedSessionId == focusedSessionId, localFocusedSessionId != focusedSessionId {
       /**
        CDXC:NativeTerminalFocus 2026-05-13-07:41
        A previous native focus emission can be followed by sidebar/layout sync
@@ -7700,13 +8127,17 @@ final class TerminalWorkspaceView: NSView {
         details: [
           "emittedFocusedSessionId": focusedSessionId,
           "lastEmittedFocusedSessionId": nullableString(lastEmittedFocusedSessionId),
-          "localFocusedSessionId": nullableString(self.focusedSessionId),
+          "localFocusedSessionId": nullableString(localFocusedSessionId),
           "reason": reason,
           "responder": responderSnapshot(),
         ])
     }
     lastEmittedFocusedSessionId = focusedSessionId
-    self.focusedSessionId = focusedSessionId
+    if commandsPanelActiveSessionIds.contains(focusedSessionId) {
+      commandsPanelFocusedSessionId = focusedSessionId
+    } else {
+      self.focusedSessionId = focusedSessionId
+    }
     updateAllTerminalBorders()
     TerminalFocusDebugLog.append(
       event: "nativeWorkspace.terminalFocused.emitted",
@@ -7718,6 +8149,8 @@ final class TerminalWorkspaceView: NSView {
       event: "nativeFocusTrace.terminalFocusedEmitted",
       details: [
         "activeSessionIds": Array(activeSessionIds).sorted(),
+        "commandsPanelActiveSessionIds": Array(commandsPanelActiveSessionIds).sorted(),
+        "commandsPanelFocusedSessionId": nullableString(commandsPanelFocusedSessionId),
         "focusedSessionId": focusedSessionId,
         "reason": reason,
         "responder": responderSnapshot(),
@@ -7768,6 +8201,13 @@ final class TerminalWorkspaceView: NSView {
       return defaultPaneGap
     }
     return CGFloat(min(48, max(0, value)))
+  }
+
+  private static func clampedCommandsPanelHeightRatio(_ value: Double?) -> CGFloat {
+    guard let value, value.isFinite else {
+      return 0.32
+    }
+    return CGFloat(min(0.55, max(0.18, value)))
   }
 
   private static func workspaceBackgroundColor(_ value: String?) -> NSColor {
@@ -9815,7 +10255,6 @@ private final class TerminalTitleBarActionButton: NSButton {
   private var isPointerInside = false {
     didSet { updateActionChrome() }
   }
-
   override var isHighlighted: Bool {
     didSet { updateActionChrome() }
   }
@@ -9866,7 +10305,7 @@ private final class TerminalTitleBarActionButton: NSButton {
 
   override func layout() {
     super.layout()
-    layer?.cornerRadius = min(5, min(bounds.width, bounds.height) / 3)
+    layer?.cornerRadius = 0
   }
 
   override func updateTrackingAreas() {
@@ -9926,6 +10365,11 @@ private func nativePaneTabsDebugFrame(_ frame: CGRect) -> [String: Double] {
   ]
 }
 
+fileprivate enum TerminalPaneChromeRole {
+  case commands
+  case workspace
+}
+
 private final class TerminalTitleBarTabButton: NSButton {
   enum InlineAction {
     case close
@@ -9955,6 +10399,10 @@ private final class TerminalTitleBarTabButton: NSButton {
     alpha: 1
   ).cgColor
   private static let sleepingIconColor = NSColor(calibratedWhite: 0.86, alpha: 0.42)
+  private static let commandTabSeparatorColor = NSColor(calibratedWhite: 1, alpha: 0.10).cgColor
+  private static let workspaceTabBaseRed: CGFloat = 0x05 / 255
+  private static let workspaceTabBaseGreen: CGFloat = 0x06 / 255
+  private static let workspaceTabBaseBlue: CGFloat = 0x08 / 255
   private static let sleepingIconSize: CGFloat = 9
   private static let activityIndicatorSize: CGFloat = 8
   private static let activityIndicatorTrailingPadding: CGFloat = 9
@@ -9962,9 +10410,10 @@ private final class TerminalTitleBarTabButton: NSButton {
   private static let identityIconSize: CGFloat = 12
   private static let identityIconGap: CGFloat = 5
   private static let titleInlineActionGap: CGFloat = 4
+  private static let titleFont = NSFont.systemFont(ofSize: 11, weight: .semibold)
   private static let titleTextHeight: CGFloat = 18
-  private static let titleVerticalOffset: CGFloat = 0
-
+  private static let titleVerticalOffset: CGFloat = 2
+  private static let commandTitleVerticalOffset: CGFloat = 2
   /**
    CDXC:PaneTabs 2026-05-10-18:30
    Pane tabs are native title-bar controls because Ghostty and WKWebView panes
@@ -9993,7 +10442,9 @@ private final class TerminalTitleBarTabButton: NSButton {
   private var identityFaviconDataUrl: String?
   private var identityFaviconImage: NSImage?
   private var isFocusedPane = true
+  private var chromeRole: TerminalPaneChromeRole = .workspace
   private var isSleepingTab = false
+  private var showsCommandTrailingSeparator = false
   private var pendingMouseDownInlineAction: InlineAction?
   private var hoverTrackingArea: NSTrackingArea?
   private var isTabHovered = false {
@@ -10019,11 +10470,11 @@ private final class TerminalTitleBarTabButton: NSButton {
 
   private func configure() {
     wantsLayer = true
-    layer?.cornerRadius = 5
+    layer?.cornerRadius = 0
     layer?.masksToBounds = true
     bezelStyle = .texturedRounded
     isBordered = false
-    font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+    font = Self.titleFont
     lineBreakMode = .byTruncatingTail
     imagePosition = .noImage
   }
@@ -10049,14 +10500,47 @@ private final class TerminalTitleBarTabButton: NSButton {
     updateChrome()
   }
 
+  fileprivate func setChromeRole(_ role: TerminalPaneChromeRole) {
+    guard chromeRole != role else {
+      return
+    }
+    chromeRole = role
+    layer?.cornerRadius = 0
+    font = Self.titleFont
+    updateChrome()
+  }
+
+  fileprivate func setShowsCommandTrailingSeparator(_ showsSeparator: Bool) {
+    guard showsCommandTrailingSeparator != showsSeparator else {
+      return
+    }
+    showsCommandTrailingSeparator = showsSeparator
+    needsDisplay = true
+  }
+
   private func updateChrome() {
     contentTintColor = titleColor
-    layer?.backgroundColor = (
-      isActiveTab
-        ? NSColor(calibratedWhite: 1, alpha: isFocusedPane ? (isSleepingTab ? 0.075 : 0.13) : 0.05)
-        : NSColor(calibratedWhite: 1, alpha: isFocusedPane ? (isSleepingTab ? 0.032 : 0.06) : 0.024)
-    ).cgColor
+    layer?.backgroundColor = tabBackgroundColor().cgColor
     needsDisplay = true
+  }
+
+  private func tabBackgroundColor() -> NSColor {
+    let overlayAlpha =
+      isActiveTab
+      ? (isFocusedPane ? (isSleepingTab ? CGFloat(0.075) : CGFloat(0.13)) : CGFloat(0.05))
+      : (isFocusedPane ? (isSleepingTab ? CGFloat(0.032) : CGFloat(0.06)) : CGFloat(0.024))
+    guard chromeRole == .commands else {
+      return NSColor(calibratedWhite: 1, alpha: overlayAlpha)
+    }
+    return Self.compositedWorkspaceTabColor(overlayAlpha: overlayAlpha)
+  }
+
+  private static func compositedWorkspaceTabColor(overlayAlpha: CGFloat) -> NSColor {
+    NSColor(
+      calibratedRed: workspaceTabBaseRed + (1 - workspaceTabBaseRed) * overlayAlpha,
+      green: workspaceTabBaseGreen + (1 - workspaceTabBaseGreen) * overlayAlpha,
+      blue: workspaceTabBaseBlue + (1 - workspaceTabBaseBlue) * overlayAlpha,
+      alpha: 1)
   }
 
   func setTabHovered(_ hovered: Bool) {
@@ -10186,6 +10670,7 @@ private final class TerminalTitleBarTabButton: NSButton {
     drawTitle()
     if !isTabHovered {
       drawActivityIndicatorIfNeeded()
+      drawCommandSeparatorIfNeeded()
       return
     }
     /**
@@ -10199,6 +10684,7 @@ private final class TerminalTitleBarTabButton: NSButton {
      narrow right-side tab controls respond without workspace monitor routing.
      */
     drawInlineActionControl()
+    drawCommandSeparatorIfNeeded()
   }
 
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
@@ -10455,9 +10941,10 @@ private final class TerminalTitleBarTabButton: NSButton {
   private func drawTitle() {
     let titleLeadingInset = titleLeadingInsetForIdentity()
     let reservedTrailingWidth = titleTrailingReservedWidth()
+    let titleFont = Self.titleFont
     let titleRect = CGRect(
       x: titleLeadingInset,
-      y: floor((bounds.height - Self.titleTextHeight) / 2) + Self.titleVerticalOffset,
+      y: floor((bounds.height - Self.titleTextHeight) / 2) + titleVerticalOffset,
       width: max(bounds.width - titleLeadingInset - reservedTrailingWidth, 0),
       height: Self.titleTextHeight)
     guard titleRect.width > 0 else {
@@ -10468,11 +10955,27 @@ private final class TerminalTitleBarTabButton: NSButton {
     paragraphStyle.alignment = .left
     paragraphStyle.lineBreakMode = .byTruncatingTail
     let attributes: [NSAttributedString.Key: Any] = [
-      .font: font ?? NSFont.systemFont(ofSize: 11, weight: .semibold),
+      .font: titleFont,
       .foregroundColor: titleColor,
       .paragraphStyle: paragraphStyle,
     ]
     (title as NSString).draw(in: titleRect, withAttributes: attributes)
+  }
+
+  private var titleVerticalOffset: CGFloat {
+    chromeRole == .commands ? Self.commandTitleVerticalOffset : Self.titleVerticalOffset
+  }
+
+  private func drawCommandSeparatorIfNeeded() {
+    guard chromeRole == .commands, showsCommandTrailingSeparator,
+      let context = NSGraphicsContext.current?.cgContext
+    else {
+      return
+    }
+    context.saveGState()
+    context.setFillColor(Self.commandTabSeparatorColor)
+    context.fill(CGRect(x: bounds.maxX - 1, y: 0, width: 1, height: max(bounds.height, 1)))
+    context.restoreGState()
   }
 
   private func titleLeadingInsetForIdentity() -> CGFloat {
@@ -10528,12 +11031,11 @@ private final class TerminalTitleBarTabButton: NSButton {
   }
 
   private var activityIndicatorFrame: CGRect {
-    let size = Self.activityIndicatorSize
     return CGRect(
-      x: bounds.maxX - Self.activityIndicatorTrailingPadding - size,
-      y: floor((bounds.height - size) / 2),
-      width: size,
-      height: size)
+      x: bounds.maxX - Self.activityIndicatorTrailingPadding - Self.activityIndicatorSize,
+      y: floor((bounds.height - Self.activityIndicatorSize) / 2),
+      width: Self.activityIndicatorSize,
+      height: Self.activityIndicatorSize)
   }
 
   private func drawActivityIndicatorIfNeeded() {
@@ -10584,8 +11086,8 @@ private final class TerminalTitleBarTabButton: NSButton {
     let controlFrame = inlineActionControlFrame
     let controlPath = CGPath(
       roundedRect: controlFrame,
-      cornerWidth: 5,
-      cornerHeight: 5,
+      cornerWidth: 0,
+      cornerHeight: 0,
       transform: nil)
 
     context.saveGState()
@@ -10747,6 +11249,18 @@ private final class TerminalSessionTitleBarView: NSView {
     blue: 0x08 / 255,
     alpha: 0.96
   ).cgColor
+  private static let commandBackgroundColor = NSColor(
+    calibratedWhite: 0.0,
+    alpha: 1.0
+  ).cgColor
+  private static let commandCollapsedTrailingBackgroundColor = NSColor(
+    calibratedWhite: 0.0,
+    alpha: 1.0
+  )
+  private static let commandBorderColor = NSColor(
+    calibratedWhite: 0.54,
+    alpha: 0.24
+  ).cgColor
   private static let titleColor = NSColor(
     calibratedRed: 0xE1 / 255,
     green: 0xE1 / 255,
@@ -10770,6 +11284,7 @@ private final class TerminalSessionTitleBarView: NSView {
   private static let minimumVisibleTabViewportWidthWithDoubleClickTarget: CGFloat = 56
   private static let preferredDoubleClickNewTerminalTargetWidth: CGFloat = 34
   private static let minimumDoubleClickNewTerminalTargetWidth: CGFloat = 24
+  private static let commandActionTrailingInset: CGFloat = 8
   private static let tabViewportTrailingGap: CGFloat = 4
 
   private let faviconImageView = NSImageView(frame: .zero)
@@ -10777,6 +11292,7 @@ private final class TerminalSessionTitleBarView: NSView {
   private let activityIndicatorView = NSView(frame: .zero)
   private let tabClipView = NSView(frame: .zero)
   private let tabContentView = NSView(frame: .zero)
+  private let commandCollapsedTrailingBackgroundView = NSView(frame: .zero)
   private let bottomBorderView = NSView(frame: .zero)
   private let actionMenuButton = TerminalTitleBarActionButton(title: "", target: nil, action: nil)
   private var actionButtons: [(action: TerminalTitleBarAction, button: NSButton)]
@@ -10787,6 +11303,7 @@ private final class TerminalSessionTitleBarView: NSView {
   private var agentIconDataUrl: String?
   private var agentIconImage: NSImage?
   private var activity: NativeTerminalActivity?
+  private var chromeRole: TerminalPaneChromeRole = .workspace
   private var faviconImage: NSImage?
   private var isFocusedPane = false
   private var layoutHiddenActions = Set<TerminalTitleBarAction>()
@@ -10903,12 +11420,27 @@ private final class TerminalSessionTitleBarView: NSView {
       button.sessionId = tab.sessionId
       button.title = tab.title
       button.toolTip = tab.title
+      button.setChromeRole(chromeRole)
       button.setActive(tab.sessionId == activeSessionId)
       button.setSleeping(tab.isSleeping)
     }
     updateTabGroupFocusAppearance()
     needsLayout = true
     window?.invalidateCursorRects(for: self)
+  }
+
+  fileprivate func setChromeRole(_ role: TerminalPaneChromeRole) {
+    guard chromeRole != role else {
+      return
+    }
+    chromeRole = role
+    layer?.backgroundColor = backgroundColor(for: role)
+    bottomBorderView.layer?.backgroundColor = borderColor(for: role)
+    titleLabel.textColor = titleColor(for: role)
+    for button in tabButtons {
+      button.setChromeRole(role)
+    }
+    needsDisplay = true
   }
 
   func setTabActivities(_ activities: [String: NativeTerminalActivity]) {
@@ -11000,6 +11532,11 @@ private final class TerminalSessionTitleBarView: NSView {
     tabContentView.wantsLayer = true
     tabClipView.addSubview(tabContentView)
 
+    commandCollapsedTrailingBackgroundView.wantsLayer = true
+    commandCollapsedTrailingBackgroundView.layer?.backgroundColor =
+      Self.commandCollapsedTrailingBackgroundColor.cgColor
+    commandCollapsedTrailingBackgroundView.isHidden = true
+
     bottomBorderView.wantsLayer = true
     bottomBorderView.layer?.backgroundColor = Self.borderColor
 
@@ -11007,6 +11544,7 @@ private final class TerminalSessionTitleBarView: NSView {
     addSubview(titleLabel)
     addSubview(activityIndicatorView)
     addSubview(tabClipView)
+    addSubview(commandCollapsedTrailingBackgroundView, positioned: .below, relativeTo: tabClipView)
     /**
      CDXC:PaneTabs 2026-05-12-12:44
      Pane title bars must not paint colored debug hit-region overlays in normal
@@ -11055,6 +11593,18 @@ private final class TerminalSessionTitleBarView: NSView {
       return
     }
     onMouseDown?(event)
+  }
+
+  private func backgroundColor(for role: TerminalPaneChromeRole) -> CGColor {
+    role == .commands ? Self.commandBackgroundColor : Self.backgroundColor
+  }
+
+  private func borderColor(for role: TerminalPaneChromeRole) -> CGColor {
+    role == .commands ? Self.commandBorderColor : Self.borderColor
+  }
+
+  private func titleColor(for role: TerminalPaneChromeRole) -> NSColor {
+    Self.titleColor
   }
 
   override func scrollWheel(with event: NSEvent) {
@@ -11469,17 +12019,23 @@ private final class TerminalSessionTitleBarView: NSView {
 
   override func layout() {
     super.layout()
-    let insetX: CGFloat = 8
-    let buttonSize: CGFloat = 28
+    let isCommandChrome = chromeRole == .commands
+    let insetX: CGFloat = isCommandChrome ? 0 : 8
+    let buttonSize: CGFloat = isCommandChrome ? bounds.height : 28
     let buttonGap: CGFloat = 0
     let separatorGap: CGFloat = 6
     let separatorWidth: CGFloat = 1
-    let separatorHeight: CGFloat = 14
+    let separatorHeight: CGFloat = isCommandChrome ? 10 : 14
     let indicatorSize: CGFloat = 8
     let indicatorGap: CGFloat = 6
-    let centerY = floor((bounds.height - buttonSize) / 2)
+    let tabViewportTrailingGap = isCommandChrome ? CGFloat(0) : Self.tabViewportTrailingGap
+    let centerY = isCommandChrome ? 0 : floor((bounds.height - buttonSize) / 2)
     let separatorY = floor((bounds.height - separatorHeight) / 2)
-    var trailingX = bounds.width - insetX
+    let isCollapsedCommandPanelBar =
+      isCommandChrome && actionButtons.map(\.action) == [.expandCommandsPanel]
+    let actionTrailingInset =
+      isCommandChrome && !isCollapsedCommandPanelBar ? Self.commandActionTrailingInset : insetX
+    var trailingX = bounds.width - actionTrailingInset
 
     /**
      CDXC:NativeTerminals 2026-04-28-05:18
@@ -11521,17 +12077,18 @@ private final class TerminalSessionTitleBarView: NSView {
      route current layouts through the compact menu so panes do not switch back
      to the expanded icon cluster on wider widths.
      */
-    let shouldCollapseActionMenu = !nonCloseActions.isEmpty
+    let shouldCollapseActionMenu =
+      !Self.isCommandsPanelChromeActionSet(actionButtons.map(\.action)) && !nonCloseActions.isEmpty
     let minimumContentWidthForCollapsedControls =
       tabItems.isEmpty ? 0 : Self.minimumVisibleTabViewportWidth
     let hasCloseAction = actionButtons.contains { $0.action == .close }
     let canReserveCloseActionInCollapsedLayout =
       hasCloseAction
-      && bounds.width - insetX * 2 - buttonSize - Self.tabViewportTrailingGap
+      && bounds.width - insetX * 2 - buttonSize - tabViewportTrailingGap
         >= minimumContentWidthForCollapsedControls
     let reservedCloseActionWidth = canReserveCloseActionInCollapsedLayout ? buttonSize : 0
     let canReserveCollapsedActionMenu =
-      bounds.width - insetX * 2 - reservedCloseActionWidth - buttonSize - Self.tabViewportTrailingGap
+      bounds.width - insetX * 2 - reservedCloseActionWidth - buttonSize - tabViewportTrailingGap
         >= minimumContentWidthForCollapsedControls
     var separatorIndex = 0
     if shouldCollapseActionMenu {
@@ -11628,17 +12185,30 @@ private final class TerminalSessionTitleBarView: NSView {
       tabClipView.isHidden = false
       let tabViewportMaxX = reserveDoubleClickNewTerminalTarget(
         from: insetX,
-        to: max(insetX, trailingX - Self.tabViewportTrailingGap))
+        to: max(insetX, trailingX - tabViewportTrailingGap))
       layoutTabButtons(
         from: insetX,
         to: tabViewportMaxX,
         centerY: centerY,
         height: buttonSize)
+      if isCollapsedCommandPanelBar {
+        commandCollapsedTrailingBackgroundView.isHidden = false
+        commandCollapsedTrailingBackgroundView.frame = CGRect(
+          x: tabViewportFrame.maxX,
+          y: 0,
+          width: max(0, bounds.width - tabViewportFrame.maxX),
+          height: bounds.height)
+      } else {
+        commandCollapsedTrailingBackgroundView.isHidden = true
+        commandCollapsedTrailingBackgroundView.frame = .zero
+      }
       bottomBorderView.frame = CGRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1)
       window?.invalidateCursorRects(for: self)
       return
     }
 
+    commandCollapsedTrailingBackgroundView.isHidden = true
+    commandCollapsedTrailingBackgroundView.frame = .zero
     doubleClickNewTerminalFrame = .zero
     tabClipView.isHidden = true
     tabClipView.frame = .zero
@@ -11709,9 +12279,10 @@ private final class TerminalSessionTitleBarView: NSView {
         .font: titleLabel.font ?? NSFont.systemFont(ofSize: 12, weight: .bold)
       ]).width
     )
+    let titleLabelVerticalOffset: CGFloat = chromeRole == .commands ? 0 : 2
     titleLabel.frame = CGRect(
       x: titleX,
-      y: floor((bounds.height - 16) / 2),
+      y: floor((bounds.height - 16) / 2) + titleLabelVerticalOffset,
       width: maxTitleWidth,
       height: 16
     )
@@ -11783,9 +12354,10 @@ private final class TerminalSessionTitleBarView: NSView {
      Sleep/Close hit areas to stay inside the pane so activation and lifecycle
      controls remain usable without horizontal scrolling.
      */
-    let gap: CGFloat = 2
-    let maxTabWidth: CGFloat = 175
-    let minTabWidth: CGFloat = 80
+    let isCommandChrome = chromeRole == .commands
+    let gap: CGFloat = isCommandChrome ? 0 : 2
+    let maxTabWidth: CGFloat = isCommandChrome ? 160 : 175
+    let minTabWidth: CGFloat = isCommandChrome ? 72 : 80
     let tabCount = max(tabButtons.count, 1)
     let totalGap = gap * CGFloat(max(tabCount - 1, 0))
     let fittedWidth = (availableWidth - totalGap) / CGFloat(tabCount)
@@ -11803,8 +12375,9 @@ private final class TerminalSessionTitleBarView: NSView {
       width: tabContentWidth,
       height: height)
     var nextX: CGFloat = 0
-    for button in tabButtons {
+    for (index, button) in tabButtons.enumerated() {
       button.frame = CGRect(x: nextX, y: 0, width: tabWidth, height: height)
+      button.setShowsCommandTrailingSeparator(isCommandChrome && index < tabButtons.count - 1)
       nextX += tabWidth + gap
     }
   }
@@ -12086,6 +12659,16 @@ private final class TerminalSessionTitleBarView: NSView {
     return count
   }
 
+  private static func isCommandsPanelChromeActionSet(_ actions: [TerminalTitleBarAction]) -> Bool {
+    if actions == [.expandCommandsPanel] {
+      return true
+    }
+    guard actions.count == 2, actions.contains(.closeCommandsPanel) else {
+      return false
+    }
+    return actions.contains(.pinCommandsPanel) || actions.contains(.unpinCommandsPanel)
+  }
+
   private static func actionClusterWidth(
     for actions: [TerminalTitleBarAction],
     buttonSize: CGFloat,
@@ -12109,6 +12692,8 @@ private final class TerminalSessionTitleBarView: NSView {
       return 2
     case .popOut, .restorePopOut:
       return 3
+    case .pinCommandsPanel, .unpinCommandsPanel, .closeCommandsPanel, .expandCommandsPanel:
+      return 3
     case .close, .sleep:
       return 4
     }
@@ -12120,6 +12705,10 @@ private final class TerminalSessionTitleBarView: NSView {
       return makeActionButton(systemSymbolName: "terminal", fallbackTitle: "T", tooltip: "New Terminal")
     case .openBrowser:
       return makeActionButton(systemSymbolName: "globe", fallbackTitle: "B", tooltip: "Open Browser Pane")
+    case .pinCommandsPanel:
+      return makeActionButton(systemSymbolName: "pin", fallbackTitle: "P", tooltip: "Pin Commands Panel")
+    case .unpinCommandsPanel:
+      return makeActionButton(systemSymbolName: "pin.slash", fallbackTitle: "U", tooltip: "Unpin Commands Panel")
     case .popOut:
       return makeActionButton(systemSymbolName: "arrow.up.right.square", fallbackTitle: "P", tooltip: "Pop Out Pane")
     case .restorePopOut:
@@ -12140,6 +12729,10 @@ private final class TerminalSessionTitleBarView: NSView {
       return makeActionButton(systemSymbolName: "moon", fallbackTitle: "S", tooltip: "Sleep Session")
     case .close:
       return makeActionButton(systemSymbolName: "xmark", fallbackTitle: "X", tooltip: "Close Session")
+    case .closeCommandsPanel:
+      return makeActionButton(systemSymbolName: "chevron.down", fallbackTitle: "v", tooltip: "Minimize Commands Panel")
+    case .expandCommandsPanel:
+      return makeActionButton(systemSymbolName: "chevron.up", fallbackTitle: "^", tooltip: "Expand Commands Panel")
     }
   }
 
@@ -12149,6 +12742,10 @@ private final class TerminalSessionTitleBarView: NSView {
       return "New Terminal"
     case .openBrowser:
       return "Open Browser Pane"
+    case .pinCommandsPanel:
+      return "Pin Commands Panel"
+    case .unpinCommandsPanel:
+      return "Unpin Commands Panel"
     case .popOut:
       return "Pop Out Pane"
     case .restorePopOut:
@@ -12169,6 +12766,10 @@ private final class TerminalSessionTitleBarView: NSView {
       return "Sleep Session"
     case .close:
       return "Close Session"
+    case .closeCommandsPanel:
+      return "Minimize Commands Panel"
+    case .expandCommandsPanel:
+      return "Expand Commands Panel"
     }
   }
 
@@ -12179,6 +12780,10 @@ private final class TerminalSessionTitleBarView: NSView {
       symbolName = "terminal"
     case .openBrowser:
       symbolName = "globe"
+    case .pinCommandsPanel:
+      symbolName = "pin"
+    case .unpinCommandsPanel:
+      symbolName = "pin.slash"
     case .popOut:
       symbolName = "arrow.up.right.square"
     case .restorePopOut:
@@ -12199,6 +12804,10 @@ private final class TerminalSessionTitleBarView: NSView {
       symbolName = "moon"
     case .close:
       symbolName = "xmark"
+    case .closeCommandsPanel:
+      symbolName = "chevron.down"
+    case .expandCommandsPanel:
+      symbolName = "chevron.up"
     }
     return NSImage(systemSymbolName: symbolName, accessibilityDescription: actionMenuTitle(for: action))
   }
@@ -13228,6 +13837,31 @@ private final class TerminalPaneLeafContainerView: NSView {
   }
 }
 
+private final class CommandsPanelChromeView: NSView {
+  private static let backgroundColor = NSColor(
+    calibratedWhite: 0.0,
+    alpha: 1.0
+  )
+
+  override var isOpaque: Bool {
+    false
+  }
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    wantsLayer = true
+    layer?.backgroundColor = Self.backgroundColor.cgColor
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) is not supported")
+  }
+
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    nil
+  }
+}
+
 private final class TerminalWorkspacePaneResizeHandleView: NSView {
   var onMouseDown: ((NSEvent) -> Void)?
   var onMouseDragged: ((NSEvent) -> Void)?
@@ -13347,6 +13981,12 @@ final class TerminalPaneBorderView: NSView {
     blue: 0x73 / 255,
     alpha: 0.95
   ).cgColor
+  private static let commandBorderColor = NSColor(
+    calibratedRed: 0x11 / 255,
+    green: 0x11 / 255,
+    blue: 0x11 / 255,
+    alpha: 1
+  ).cgColor
   private static let attentionBorderColor = NSColor(
     calibratedRed: 0x65 / 255,
     green: 0xE5 / 255,
@@ -13354,8 +13994,11 @@ final class TerminalPaneBorderView: NSView {
     alpha: 1
   ).cgColor
   private static let roundedBottomCornerRadius: CGFloat = 12
-  private static let borderWidth: CGFloat = 2
+  private static let activeBorderWidth: CGFloat = 2
+  private static let inactiveCommandBorderWidth: CGFloat = 2
 
+  private var chromeRole: TerminalPaneChromeRole = .workspace
+  private var hidesInactiveCommandBorder = false
   private var roundedBottomCorner: TerminalPaneRoundedBottomCorner = .none
   private var state: BorderState = .none
 
@@ -13392,7 +14035,7 @@ final class TerminalPaneBorderView: NSView {
 
     let path = borderPath(in: bounds)
     borderColor.setStroke()
-    path.lineWidth = Self.borderWidth
+    path.lineWidth = currentBorderWidth()
     path.stroke()
   }
 
@@ -13409,6 +14052,30 @@ final class TerminalPaneBorderView: NSView {
       return
     }
     roundedBottomCorner = corner
+    needsDisplay = true
+  }
+
+  fileprivate func setChromeRole(_ role: TerminalPaneChromeRole) {
+    guard chromeRole != role else {
+      return
+    }
+    chromeRole = role
+    switch state {
+    case .attention:
+      layer?.shadowColor = Self.attentionBorderColor
+    case .focused:
+      layer?.shadowColor = Self.focusedBorderColor
+    case .none:
+      layer?.shadowColor = nil
+    }
+    needsDisplay = true
+  }
+
+  fileprivate func setHidesInactiveCommandBorder(_ hides: Bool) {
+    guard hidesInactiveCommandBorder != hides else {
+      return
+    }
+    hidesInactiveCommandBorder = hides
     needsDisplay = true
   }
 
@@ -13432,6 +14099,7 @@ final class TerminalPaneBorderView: NSView {
       layer?.shadowColor = Self.focusedBorderColor
       layer?.shadowOpacity = 0.18
     case .none:
+      layer?.shadowColor = nil
       layer?.shadowOpacity = 0
     }
     needsDisplay = true
@@ -13444,12 +14112,27 @@ final class TerminalPaneBorderView: NSView {
     case .focused:
       return NSColor(cgColor: Self.focusedBorderColor)
     case .none:
+      if hidesInactiveCommandBorder {
+        return nil
+      }
+      if chromeRole == .commands {
+        return NSColor(cgColor: Self.commandBorderColor)
+      }
       return nil
     }
   }
 
+  private func currentBorderWidth() -> CGFloat {
+    if state == .none && hidesInactiveCommandBorder {
+      return 0
+    }
+    state == .none && chromeRole == .commands
+      ? Self.inactiveCommandBorderWidth
+      : Self.activeBorderWidth
+  }
+
   private func borderPath(in bounds: CGRect) -> NSBezierPath {
-    let inset = Self.borderWidth / 2
+    let inset = currentBorderWidth() / 2
     let rect = bounds.insetBy(dx: inset, dy: inset)
     let radius = roundedBottomCorner == .none
       ? 0

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -44,12 +44,16 @@ import {
 import {
   clampVisibleSessionCount,
   createAgentSessionDefaultTitle,
+  createDefaultCommandsPanelState,
   createDefaultGroupedSessionWorkspaceSnapshot,
+  createSessionRecord,
+  createTimestampedSessionId,
   createSidebarHudState,
   DEFAULT_TERMINAL_SESSION_TITLE,
   createSidebarSessionItems,
   getCodexSessionIdFromTitle,
   getSessionCardPrimaryTitle,
+  getSlotPosition,
   isGhostPlaceholderSessionTitle,
   normalizeTerminalTitle,
   getVisiblePrimaryTitle,
@@ -82,9 +86,12 @@ import {
   type SessionGroupRecord,
   type SessionPaneLayoutNode,
   type BrowserSessionRecord,
+  type CommandsPanelMode,
+  type CommandsPanelState,
 } from "../../shared/session-grid-contract";
 import { createDisplaySessionLayout } from "../../shared/active-sessions-sort";
 import { focusDirectionInSnapshot } from "../../shared/session-grid-state-create-focus";
+import { normalizeSessionRecord } from "../../shared/session-grid-state-helpers";
 import {
   createDefaultSidebarGitState,
   type SidebarGitAction,
@@ -230,17 +237,21 @@ type NativePetOverlayActivity = {
 };
 type NativeTerminalTitleBarAction =
   | "close"
+  | "closeCommandsPanel"
   | "delayedSend"
+  | "expandCommandsPanel"
   | "fork"
   | "newTerminal"
   | "openBrowser"
+  | "pinCommandsPanel"
   | "popOut"
   | "reload"
   | "rename"
   | "restorePopOut"
   | "sleep"
   | "splitHorizontal"
-  | "splitVertical";
+  | "splitVertical"
+  | "unpinCommandsPanel";
 type ProjectEditorLoadStatus = "idle" | "opening" | "running" | "error";
 
 type NativeHostCommand =
@@ -301,6 +312,12 @@ type NativeHostCommand =
   | { sessionId: string; type: "sendTerminalEnter" }
   | {
 	      activeSessionIds: string[];
+      commandsPanelActiveSessionIds?: string[];
+      commandsPanelFocusedSessionId?: string;
+      commandsPanelHeightRatio?: number;
+      commandsPanelIsVisible?: boolean;
+      commandsPanelLayout?: NativeTerminalLayout;
+      commandsPanelMode?: "floating" | "pinned";
 	      activeProjectDiffStats?: SidebarProjectDiffStats;
 	      activeProjectEditorIsOpen?: boolean;
 	      activeProjectEditorIsSleeping?: boolean;
@@ -572,6 +589,7 @@ type NativeHostEvent =
   | { exitCode?: number; sessionId: string; type: "terminalExited" }
   | { sessionId: string; type: "terminalFocused" }
   | { sessionId: string; type: "terminalBell" }
+  | { heightRatio: number; type: "commandsPanelHeightRatioChanged" }
   | { message: string; sessionId: string; type: "terminalError" }
   | {
       message?: string;
@@ -649,6 +667,7 @@ declare global {
 	      openActiveProjectEditorFromTitlebar: () => void;
 	      refreshWorkspaceOpenTargetAvailabilityFromTitlebar: () => void;
 	      rotateActivePaneLayoutClockwiseFromTitlebar: () => void;
+	      toggleCommandsPanelFromTitlebar: () => void;
 	      runSidebarCommandFromTitlebar: (commandId: string) => void;
 	    };
     __zmux_NATIVE_CLI__?: {
@@ -836,6 +855,7 @@ const pendingGitCommitRequests = new Map<
 >();
 
 type NativeProject = {
+  commandsPanel: CommandsPanelState;
   icon?: WorkspaceDockIcon;
   iconDataUrl?: string;
   isChat?: boolean;
@@ -2906,6 +2926,7 @@ function normalizeStoredNativeProject(candidate: unknown): NativeProject[] {
     {
       icon: normalizeWorkspaceDockIcon(project.icon) ?? normalizeLegacyWorkspaceDockIcon(project),
       iconDataUrl: normalizeWorkspaceDockIconDataUrl(project.iconDataUrl),
+      commandsPanel: normalizeStoredCommandsPanelState(project.commandsPanel),
       isChat: project.isChat === true,
       isRecentProject: project.isRecentProject === true,
       name: project.name?.trim() || projectNameFromPath(path),
@@ -2923,8 +2944,62 @@ function normalizeStoredNativeProject(candidate: unknown): NativeProject[] {
   ];
 }
 
+function normalizeStoredCommandsPanelState(candidate: unknown): CommandsPanelState {
+  const defaults = createDefaultCommandsPanelState();
+  if (!candidate || typeof candidate !== "object") {
+    return defaults;
+  }
+  const source = candidate as Partial<CommandsPanelState>;
+  const sessions = Array.isArray(source.sessions)
+    ? source.sessions
+        .map((session, index) =>
+          normalizeSessionRecord({
+            ...session,
+            kind: "terminal",
+            surface: "commands",
+            slotIndex: index,
+          } as TerminalSessionRecord),
+        )
+        .filter((session): session is TerminalSessionRecord => session.kind === "terminal")
+        .map((session, index) => {
+          const position = getSlotPosition(index);
+          return {
+            ...session,
+            column: position.column,
+            row: position.row,
+            slotIndex: index,
+            surface: "commands" as const,
+          };
+        })
+    : [];
+  const sessionIds = new Set(sessions.map((session) => session.sessionId));
+  const activeSessionId =
+    source.activeSessionId && sessionIds.has(source.activeSessionId)
+      ? source.activeSessionId
+      : sessions[0]?.sessionId;
+  const paneLayout = normalizeCommandPaneLayout(source.paneLayout, sessionIds, activeSessionId);
+  return {
+    activeSessionId,
+    heightRatio: normalizeCommandsPanelHeightRatio(source.heightRatio),
+    isVisible: source.isVisible === true,
+    mode: normalizeCommandsPanelMode(source.mode),
+    ...(paneLayout ? { paneLayout } : {}),
+    sessions,
+  };
+}
+
+function normalizeCommandsPanelMode(mode: unknown): CommandsPanelMode {
+  return mode === "floating" ? "floating" : "pinned";
+}
+
+function normalizeCommandsPanelHeightRatio(heightRatio: unknown): number {
+  const numericHeightRatio = typeof heightRatio === "number" ? heightRatio : 0.32;
+  return Math.max(0.18, Math.min(0.55, Number.isFinite(numericHeightRatio) ? numericHeightRatio : 0.32));
+}
+
 function createInitialProject(): NativeProject {
   return {
+    commandsPanel: createDefaultCommandsPanelState(),
     isChat: false,
     name: initialWorkspaceName,
     path: initialWorkspacePath,
@@ -2965,6 +3040,12 @@ function summarizeNativeProject(project: NativeProject) {
       title: group.title,
       visibleSessionIds: group.snapshot.visibleSessionIds,
     })),
+    commandsPanel: {
+      activeSessionId: project.commandsPanel.activeSessionId,
+      isVisible: project.commandsPanel.isVisible,
+      mode: project.commandsPanel.mode,
+      sessionCount: project.commandsPanel.sessions.length,
+    },
     isChat: project.isChat === true,
     isRecentProject: project.isRecentProject === true,
     name: project.name,
@@ -3780,6 +3861,7 @@ function activatePreviousSessionProject(previousSession: SidebarPreviousSessionI
   projects = [
     ...projects,
     {
+      commandsPanel: createDefaultCommandsPanelState(),
       isChat: false,
       name: previousSession.projectName?.trim() || projectNameFromPath(projectPath),
       path: projectPath,
@@ -4069,6 +4151,27 @@ function updateProjectWorkspace(
   writeStoredProjects("updateProjectWorkspace");
 }
 
+function updateProjectCommandsPanel(
+  projectId: string,
+  updater: (commandsPanel: CommandsPanelState) => CommandsPanelState,
+): void {
+  projects = projects.map((project) =>
+    project.projectId === projectId
+      ? {
+          ...project,
+          commandsPanel: normalizeStoredCommandsPanelState(updater(project.commandsPanel)),
+        }
+      : project,
+  );
+  writeStoredProjects("updateProjectCommandsPanel");
+}
+
+function updateActiveProjectCommandsPanel(
+  updater: (commandsPanel: CommandsPanelState) => CommandsPanelState,
+): void {
+  updateProjectCommandsPanel(activeProject().projectId, updater);
+}
+
 function updateActiveProjectWorkspace(
   updater: (workspace: GroupedSessionWorkspaceSnapshot) => GroupedSessionWorkspaceSnapshot,
 ): void {
@@ -4078,6 +4181,12 @@ function updateActiveProjectWorkspace(
 
 function findSessionRecord(sessionId: string): SessionRecord | undefined {
   const reference = resolveSidebarSessionReference(sessionId);
+  const commandSession = reference.project.commandsPanel.sessions.find(
+    (candidate) => candidate.sessionId === reference.sessionId,
+  );
+  if (commandSession) {
+    return commandSession;
+  }
   for (const group of reference.project.workspace.groups) {
     const session = group.snapshot.sessions.find(
       (candidate) => candidate.sessionId === reference.sessionId,
@@ -4093,6 +4202,12 @@ function findSessionRecordInProject(
   project: NativeProject,
   sessionId: string,
 ): SessionRecord | undefined {
+  const commandSession = project.commandsPanel.sessions.find(
+    (session) => session.sessionId === sessionId,
+  );
+  if (commandSession) {
+    return commandSession;
+  }
   for (const group of project.workspace.groups) {
     const session = group.snapshot.sessions.find((candidate) => candidate.sessionId === sessionId);
     if (session) {
@@ -4138,6 +4253,16 @@ function resolveSidebarGroupReference(groupId: string): {
 }
 
 function setTerminalSessionAgentName(sessionId: string, agentName: string | undefined): void {
+  if (activeCommandPanelContainsSession(sessionId)) {
+    const nextAgentName = agentName?.replace(/\s+/g, " ").trim() || undefined;
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      sessions: panel.sessions.map((session) =>
+        session.sessionId === sessionId ? { ...session, agentName: nextAgentName } : session,
+      ),
+    }));
+    return;
+  }
   updateActiveProjectWorkspace(
     (workspace) =>
       setTerminalSessionAgentNameInSimpleWorkspace(workspace, sessionId, agentName).snapshot,
@@ -4148,6 +4273,21 @@ function setTerminalSessionAgentSessionMetadata(
   sessionId: string,
   metadata: { agentSessionId?: string; agentSessionPath?: string },
 ): void {
+  if (activeCommandPanelContainsSession(sessionId)) {
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      sessions: panel.sessions.map((session) =>
+        session.sessionId === sessionId
+          ? {
+              ...session,
+              agentSessionId: metadata.agentSessionId?.trim() || undefined,
+              agentSessionPath: metadata.agentSessionPath?.trim() || undefined,
+            }
+          : session,
+      ),
+    }));
+    return;
+  }
   updateActiveProjectWorkspace(
     (workspace) =>
       setTerminalSessionAgentSessionMetadataInSimpleWorkspace(workspace, sessionId, metadata)
@@ -4159,6 +4299,17 @@ function setTerminalSessionPersistenceName(
   sessionId: string,
   sessionPersistenceName: string | undefined,
 ): void {
+  if (activeCommandPanelContainsSession(sessionId)) {
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      sessions: panel.sessions.map((session) =>
+        session.sessionId === sessionId
+          ? { ...session, sessionPersistenceName: sessionPersistenceName?.trim() || undefined }
+          : session,
+      ),
+    }));
+    return;
+  }
   updateActiveProjectWorkspace(
     (workspace) =>
       setTerminalSessionPersistenceNameInSimpleWorkspace(
@@ -4174,6 +4325,15 @@ function setTerminalSessionPersistenceProvider(
   sessionId: string,
   sessionPersistenceProvider: TerminalSessionPersistenceProvider | undefined,
 ): void {
+  if (activeCommandPanelContainsSession(sessionId)) {
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      sessions: panel.sessions.map((session) =>
+        session.sessionId === sessionId ? { ...session, sessionPersistenceProvider } : session,
+      ),
+    }));
+    return;
+  }
   updateActiveProjectWorkspace(
     (workspace) =>
       setTerminalSessionPersistenceProviderInSimpleWorkspace(
@@ -4250,6 +4410,367 @@ function activeWorkspaceGroup(): SessionGroupRecord {
 
 function activeSnapshot(): SessionGridSnapshot {
   return activeWorkspaceGroup().snapshot;
+}
+
+function commandPanelContainsSession(project: NativeProject, sessionId: string): boolean {
+  return project.commandsPanel.sessions.some((session) => session.sessionId === sessionId);
+}
+
+function activeCommandPanelContainsSession(sessionId: string): boolean {
+  return commandPanelContainsSession(activeProject(), sessionId);
+}
+
+function createCommandTerminal(
+  title = DEFAULT_TERMINAL_SESSION_TITLE,
+  initialInput = "",
+  options: { focusAfterCreate?: boolean; commandId?: string } = {},
+): TerminalSessionRecord | undefined {
+  const project = activeProject();
+  activateWorkspaceSurfaceForProject(project.projectId);
+  const sessionId = createTimestampedSessionId([
+    ...project.commandsPanel.sessions.map((session) => session.sessionId),
+    ...project.workspace.groups.flatMap((group) =>
+      group.snapshot.sessions.map((session) => session.sessionId),
+    ),
+  ]);
+  const session = normalizeSessionRecord(
+    createSessionRecord(project.commandsPanel.sessions.length + 1, project.commandsPanel.sessions.length, {
+      displayId: sessionId,
+      kind: "terminal",
+      sessionId,
+      surface: "commands",
+      terminalEngine: "ghostty-native",
+      title,
+    }),
+  ) as TerminalSessionRecord;
+  const nativeSessionId = rememberNativeSessionMapping(project.projectId, session.sessionId);
+  const sessionStateFilePath = createNativeSessionStateFilePath(project.projectId, session.sessionId);
+  const sessionPersistenceProvider = activeSessionPersistenceProviderFromSettings();
+  const sessionPersistenceName = sessionPersistenceProvider ? undefined : undefined;
+  const commandSession = {
+    ...session,
+    sessionPersistenceName,
+    sessionPersistenceProvider,
+    surface: "commands" as const,
+  };
+  updateActiveProjectCommandsPanel((panel) => addSessionToCommandsPanel(panel, commandSession));
+  terminalStateById.set(commandSession.sessionId, {
+    activity: initialInput.trim() ? "working" : "idle",
+    lifecycleState: "running",
+    sessionPersistenceName,
+    sessionPersistenceProvider,
+    sessionStateFilePath,
+    terminalTitle: title,
+  });
+  postNative({
+    activateOnCreate: false,
+    cwd: project.path,
+    env: createNativeAgentSessionEnvironment({
+      project,
+      sessionId: commandSession.sessionId,
+      sessionStateFilePath,
+    }),
+    initialInput,
+    sessionId: nativeSessionId,
+    sessionPersistenceName,
+    sessionPersistenceProvider,
+    title,
+    type: "createTerminal",
+  });
+  publish();
+  if (options.focusAfterCreate !== false) {
+    postNative({ sessionId: nativeSessionId, type: "focusTerminal" });
+  }
+  return commandSession;
+}
+
+function addSessionToCommandsPanel(
+  panel: CommandsPanelState,
+  session: TerminalSessionRecord,
+): CommandsPanelState {
+  const sessions = [...panel.sessions, session].map((candidate, index) => {
+    const position = getSlotPosition(index);
+    return {
+      ...candidate,
+      column: position.column,
+      row: position.row,
+      slotIndex: index,
+      surface: "commands" as const,
+    };
+  });
+  const paneLayout = appendCommandSessionToPaneLayout(panel.paneLayout, session.sessionId);
+  return normalizeStoredCommandsPanelState({
+    ...panel,
+    activeSessionId: session.sessionId,
+    isVisible: true,
+    mode: panel.mode ?? "pinned",
+    paneLayout,
+    sessions,
+  });
+}
+
+function appendCommandSessionToPaneLayout(
+  layout: SessionPaneLayoutNode | undefined,
+  sessionId: string,
+): SessionPaneLayoutNode {
+  if (!layout) {
+    return { kind: "leaf", sessionId };
+  }
+  if (layout.kind === "leaf") {
+    return {
+      activeSessionId: sessionId,
+      kind: "tabs",
+      sessionIds: layout.sessionId === sessionId ? [sessionId] : [layout.sessionId, sessionId],
+    };
+  }
+  if (layout.kind === "tabs") {
+    return {
+      ...layout,
+      activeSessionId: sessionId,
+      sessionIds: [...layout.sessionIds.filter((id) => id !== sessionId), sessionId],
+    };
+  }
+  return {
+    ...layout,
+    children: [...layout.children, { kind: "leaf", sessionId }],
+  };
+}
+
+function normalizeCommandPaneLayout(
+  layout: SessionPaneLayoutNode | undefined,
+  allowedSessionIds: ReadonlySet<string>,
+  activeSessionId?: string,
+): SessionPaneLayoutNode | undefined {
+  if (!layout) {
+    const firstSessionId = allowedSessionIds.values().next().value as string | undefined;
+    return firstSessionId ? { kind: "leaf", sessionId: firstSessionId } : undefined;
+  }
+  if (layout.kind === "leaf") {
+    return allowedSessionIds.has(layout.sessionId) ? layout : undefined;
+  }
+  if (layout.kind === "tabs") {
+    const sessionIds = layout.sessionIds.filter((sessionId, index, ids) =>
+      allowedSessionIds.has(sessionId) && ids.indexOf(sessionId) === index,
+    );
+    if (sessionIds.length === 0) {
+      return undefined;
+    }
+    if (sessionIds.length === 1) {
+      return { kind: "leaf", sessionId: sessionIds[0]! };
+    }
+    return {
+      activeSessionId:
+        layout.activeSessionId && sessionIds.includes(layout.activeSessionId)
+          ? layout.activeSessionId
+          : activeSessionId && sessionIds.includes(activeSessionId)
+            ? activeSessionId
+            : sessionIds[0],
+      kind: "tabs",
+      sessionIds,
+    };
+  }
+  const children = layout.children
+    .map((child) => normalizeCommandPaneLayout(child, allowedSessionIds, activeSessionId))
+    .filter((child): child is SessionPaneLayoutNode => child !== undefined);
+  if (children.length === 0) {
+    return undefined;
+  }
+  if (children.length === 1) {
+    return children[0];
+  }
+  return { ...layout, children };
+}
+
+function removeCommandSessionFromPaneLayout(
+  layout: SessionPaneLayoutNode | undefined,
+  sessionId: string,
+): SessionPaneLayoutNode | undefined {
+  if (!layout) {
+    return undefined;
+  }
+  if (layout.kind === "leaf") {
+    return layout.sessionId === sessionId ? undefined : layout;
+  }
+  if (layout.kind === "tabs") {
+    const sessionIds = layout.sessionIds.filter((id) => id !== sessionId);
+    if (sessionIds.length === 0) {
+      return undefined;
+    }
+    if (sessionIds.length === 1) {
+      return { kind: "leaf", sessionId: sessionIds[0]! };
+    }
+    return {
+      ...layout,
+      activeSessionId:
+        layout.activeSessionId && sessionIds.includes(layout.activeSessionId)
+          ? layout.activeSessionId
+          : sessionIds[0],
+      sessionIds,
+    };
+  }
+  const children = layout.children
+    .map((child) => removeCommandSessionFromPaneLayout(child, sessionId))
+    .filter((child): child is SessionPaneLayoutNode => child !== undefined);
+  if (children.length === 0) {
+    return undefined;
+  }
+  if (children.length === 1) {
+    return children[0];
+  }
+  return { ...layout, children };
+}
+
+function setActiveCommandSessionInPaneLayout(
+  layout: SessionPaneLayoutNode | undefined,
+  sessionId: string,
+): SessionPaneLayoutNode | undefined {
+  if (!layout) {
+    return undefined;
+  }
+  if (layout.kind === "tabs") {
+    return layout.sessionIds.includes(sessionId) ? { ...layout, activeSessionId: sessionId } : layout;
+  }
+  if (layout.kind === "split") {
+    return {
+      ...layout,
+      children: layout.children.map((child) => setActiveCommandSessionInPaneLayout(child, sessionId) ?? child),
+    };
+  }
+  return layout;
+}
+
+function commandPaneLayoutContainsSession(
+  node: SessionPaneLayoutNode | undefined,
+  sessionId: string,
+): boolean {
+  if (!node) {
+    return false;
+  }
+  if (node.kind === "leaf") {
+    return node.sessionId === sessionId;
+  }
+  if (node.kind === "tabs") {
+    return node.sessionIds.includes(sessionId);
+  }
+  return node.children.some((child) => commandPaneLayoutContainsSession(child, sessionId));
+}
+
+function addCommandSessionToPaneTabGroup(
+  layout: SessionPaneLayoutNode,
+  targetSessionId: string,
+  sourceSessionId: string,
+): SessionPaneLayoutNode | undefined {
+  if (layout.kind === "leaf") {
+    return layout.sessionId === targetSessionId
+      ? {
+          activeSessionId: sourceSessionId,
+          kind: "tabs",
+          sessionIds: [targetSessionId, sourceSessionId],
+        }
+      : undefined;
+  }
+  if (layout.kind === "tabs") {
+    if (!layout.sessionIds.includes(targetSessionId)) {
+      return undefined;
+    }
+    return {
+      ...layout,
+      activeSessionId: sourceSessionId,
+      sessionIds: [...layout.sessionIds.filter((sessionId) => sessionId !== sourceSessionId), sourceSessionId],
+    };
+  }
+  let didAdd = false;
+  const children = layout.children.map((child) => {
+    if (didAdd) {
+      return child;
+    }
+    const nextChild = addCommandSessionToPaneTabGroup(child, targetSessionId, sourceSessionId);
+    if (!nextChild) {
+      return child;
+    }
+    didAdd = true;
+    return nextChild;
+  });
+  return didAdd ? { ...layout, children } : undefined;
+}
+
+function insertCommandSessionBesidePane(
+  layout: SessionPaneLayoutNode,
+  targetSessionId: string,
+  sourceSessionId: string,
+  placeAfterTarget: boolean,
+): SessionPaneLayoutNode | undefined {
+  const sourceLeaf: SessionPaneLayoutNode = { kind: "leaf", sessionId: sourceSessionId };
+  if (layout.kind === "leaf" || layout.kind === "tabs") {
+    if (!commandPaneLayoutContainsSession(layout, targetSessionId)) {
+      return undefined;
+    }
+    return {
+      children: placeAfterTarget ? [layout, sourceLeaf] : [sourceLeaf, layout],
+      direction: "horizontal",
+      kind: "split",
+    };
+  }
+  const children: SessionPaneLayoutNode[] = [];
+  let didInsert = false;
+  for (const child of layout.children) {
+    if (!didInsert && commandPaneLayoutContainsSession(child, targetSessionId)) {
+      if (layout.direction === "horizontal") {
+        children.push(...(placeAfterTarget ? [child, sourceLeaf] : [sourceLeaf, child]));
+        didInsert = true;
+      } else {
+        const nextChild = insertCommandSessionBesidePane(
+          child,
+          targetSessionId,
+          sourceSessionId,
+          placeAfterTarget,
+        );
+        children.push(nextChild ?? child);
+        didInsert = Boolean(nextChild);
+      }
+    } else {
+      children.push(child);
+    }
+  }
+  return didInsert ? { ...layout, children } : undefined;
+}
+
+function reorderCommandSessionInPaneTabGroup(
+  layout: SessionPaneLayoutNode | undefined,
+  sourceSessionId: string,
+  targetSessionId: string,
+  position: SessionPaneTabReorderPosition,
+): SessionPaneLayoutNode | undefined {
+  if (!layout || layout.kind === "leaf") {
+    return undefined;
+  }
+  if (layout.kind === "tabs") {
+    if (!layout.sessionIds.includes(sourceSessionId) || !layout.sessionIds.includes(targetSessionId)) {
+      return undefined;
+    }
+    const sessionIds = layout.sessionIds.filter((sessionId) => sessionId !== sourceSessionId);
+    const targetIndex = sessionIds.indexOf(targetSessionId);
+    sessionIds.splice(position === "before" ? targetIndex : targetIndex + 1, 0, sourceSessionId);
+    return { ...layout, sessionIds };
+  }
+  let didReorder = false;
+  const children = layout.children.map((child) => {
+    if (didReorder) {
+      return child;
+    }
+    const nextChild = reorderCommandSessionInPaneTabGroup(
+      child,
+      sourceSessionId,
+      targetSessionId,
+      position,
+    );
+    if (!nextChild) {
+      return child;
+    }
+    didReorder = true;
+    return nextChild;
+  });
+  return didReorder ? { ...layout, children } : undefined;
 }
 
 function replaceActiveSnapshot(snapshot: SessionGridSnapshot): void {
@@ -4852,6 +5373,15 @@ function ensureVisibleNativeSessions(reason: string): boolean {
    * live sessions that no longer consume a separate split pane.
    */
   for (const project of projects) {
+    if (project.projectId === activeProjectId && project.commandsPanel.sessions.length > 0) {
+      for (const session of project.commandsPanel.sessions) {
+        if (terminalStateById.has(session.sessionId)) {
+          continue;
+        }
+        restoreNativeTerminalSession(project, session, reason);
+        didCreateNativeSession = true;
+      }
+    }
     for (const group of project.workspace.groups) {
       for (const session of group.snapshot.sessions) {
         const isAwakeInActiveWorkspaceGroup =
@@ -4912,21 +5442,32 @@ function restoreNativeTerminalSession(
     session.sessionPersistenceProvider !== sessionPersistenceProvider ||
     session.sessionPersistenceName !== sessionPersistenceName
   ) {
-    updateProjectWorkspace(
-      project.projectId,
-      (workspace) => {
-        const providerUpdate = setTerminalSessionPersistenceProviderInSimpleWorkspace(
-          workspace,
-          session.sessionId,
-          sessionPersistenceProvider,
-        ).snapshot;
-        return setTerminalSessionPersistenceNameInSimpleWorkspace(
-          providerUpdate,
-          session.sessionId,
-          sessionPersistenceName,
-        ).snapshot;
-      },
-    );
+    if (session.surface === "commands") {
+      updateProjectCommandsPanel(project.projectId, (panel) => ({
+        ...panel,
+        sessions: panel.sessions.map((candidate) =>
+          candidate.sessionId === session.sessionId
+            ? { ...candidate, sessionPersistenceName, sessionPersistenceProvider }
+            : candidate,
+        ),
+      }));
+    } else {
+      updateProjectWorkspace(
+        project.projectId,
+        (workspace) => {
+          const providerUpdate = setTerminalSessionPersistenceProviderInSimpleWorkspace(
+            workspace,
+            session.sessionId,
+            sessionPersistenceProvider,
+          ).snapshot;
+          return setTerminalSessionPersistenceNameInSimpleWorkspace(
+            providerUpdate,
+            session.sessionId,
+            sessionPersistenceName,
+          ).snapshot;
+        },
+      );
+    }
   }
   terminalStateById.set(session.sessionId, {
     activity: "idle",
@@ -6701,17 +7242,58 @@ function createNativeSessionInCurrentContext(): void {
   });
 }
 
+function openCommandsPanelForActiveProject(): void {
+  updateActiveProjectCommandsPanel((panel) => ({
+    ...panel,
+    isVisible: true,
+    mode: panel.mode ?? "pinned",
+  }));
+  const activeCommandSessionId = activeProject().commandsPanel.activeSessionId;
+  if (!activeCommandSessionId) {
+    createCommandTerminal("Command Terminal", "", { focusAfterCreate: true });
+    return;
+  }
+  queueNativeLayoutFocusRequest(activeCommandSessionId, "openCommandsPanel");
+  publish();
+  postNative({
+    sessionId: nativeSessionIdForProjectSidebarSession(activeProjectId, activeCommandSessionId),
+    type: "focusTerminal",
+  });
+}
+
+function hideCommandsPanelForActiveProject(): void {
+  updateActiveProjectCommandsPanel((panel) => ({
+    ...panel,
+    isVisible: false,
+  }));
+  publish();
+}
+
+function toggleCommandsPanelForActiveProject(): void {
+  if (activeProject().commandsPanel.isVisible) {
+    hideCommandsPanelForActiveProject();
+    return;
+  }
+  openCommandsPanelForActiveProject();
+}
+
+function setCommandsPanelModeForActiveProject(mode: CommandsPanelMode): void {
+  updateActiveProjectCommandsPanel((panel) => ({
+    ...panel,
+    isVisible: true,
+    mode,
+  }));
+  publish();
+}
+
 function createFullWidthTerminalPaneInCurrentProject(): void {
   /**
-   * CDXC:PaneTabs 2026-05-11-11:51
-   * The legacy-named Settings-row terminal shortcut now follows the same
-   * focused-tab placement as project-header terminal creation. The user expects
-   * any header-level terminal shortcut to keep split sizes and tab groupings
-   * unchanged while focusing the newly created terminal tab.
+   * CDXC:CommandsPanel 2026-05-13-17:02
+   * Legacy sidebar messages still route to the Commands panel shortcut: click
+   * once to reveal/focus the project command surface,
+   * click again to hide it without killing command terminals.
    */
-  createTerminal(DEFAULT_TERMINAL_SESSION_TITLE, "", undefined, undefined, {
-    visiblePlacement: createFocusedTabGroupPlacement(),
-  });
+  toggleCommandsPanelForActiveProject();
 }
 
 function splitFocusedNativePane(direction: "horizontal" | "vertical"): void {
@@ -7400,12 +7982,23 @@ function syncSessionTitleFromNativeTerminalTitle(
     return didCaptureCodexSessionId;
   }
 
-  updateActiveProjectWorkspace(
-    (workspace) =>
-      setSessionTitleInSimpleWorkspace(workspace, sessionId, visibleTitle, {
-        titleSource: "terminal-auto",
-      }).snapshot,
-  );
+  if (session.kind === "terminal" && session.surface === "commands") {
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      sessions: panel.sessions.map((candidate) =>
+        candidate.sessionId === sessionId
+          ? { ...candidate, title: visibleTitle, titleSource: "terminal-auto" }
+          : candidate,
+      ),
+    }));
+  } else {
+    updateActiveProjectWorkspace(
+      (workspace) =>
+        setSessionTitleInSimpleWorkspace(workspace, sessionId, visibleTitle, {
+          titleSource: "terminal-auto",
+        }).snapshot,
+    );
+  }
   appendSessionTitleDebugLog("nativeSidebar.sessionRenameApplied", {
     agentName: terminalState.agentName,
     previousSessionTitle: session.title,
@@ -8017,6 +8610,35 @@ function getNativePromptPreview(prompt: string | undefined): string | undefined 
 function closeTerminal(sessionId: string): void {
   const reference = resolveSidebarSessionReference(sessionId);
   const sessionRecord = findSessionRecordInProject(reference.project, reference.sessionId);
+  if (sessionRecord?.kind === "terminal" && sessionRecord.surface === "commands") {
+    const nativeSessionId = forgetNativeSessionMappingForProject(
+      reference.project.projectId,
+      reference.sessionId,
+    );
+    clearNativeSidebarCommandSessionBySessionId(reference.sessionId);
+    updateProjectCommandsPanel(reference.project.projectId, (panel) => {
+      const sessions = panel.sessions.filter((session) => session.sessionId !== reference.sessionId);
+      const paneLayout = removeCommandSessionFromPaneLayout(panel.paneLayout, reference.sessionId);
+      return {
+        ...panel,
+        activeSessionId:
+          panel.activeSessionId === reference.sessionId
+            ? sessions[0]?.sessionId
+            : panel.activeSessionId,
+        paneLayout,
+        sessions,
+      };
+    });
+    terminalStateById.delete(reference.sessionId);
+    titleDerivedActivityBySessionId.delete(reference.sessionId);
+    nativeActivitySuppressedUntilBySessionId.delete(reference.sessionId);
+    nativeWorkingStartedAtBySessionId.delete(reference.sessionId);
+    nativeAttentionNotificationLastSentAtBySessionId.delete(reference.sessionId);
+    clearDelayedSendTimer(reference.sessionId);
+    postNative({ sessionId: nativeSessionId, type: "closeTerminal" });
+    publish();
+    return;
+  }
   appendSidebarRefreshDebugLog("nativeSidebar.closeSession.before", {
     project: summarizeSidebarRefreshProject(reference.project),
     requestedSessionId: sessionId,
@@ -8060,6 +8682,30 @@ function focusTerminal(sessionId: string): void {
   const reference = resolveSidebarSessionReference(sessionId);
   if (activeProjectId !== reference.project.projectId) {
     focusProject(reference.project.projectId);
+  }
+  if (commandPanelContainsSession(reference.project, reference.sessionId)) {
+    updateProjectCommandsPanel(reference.project.projectId, (panel) => ({
+      ...panel,
+      activeSessionId: reference.sessionId,
+      isVisible: true,
+      paneLayout: setActiveCommandSessionInPaneLayout(panel.paneLayout, reference.sessionId),
+    }));
+    queueNativeLayoutFocusRequest(reference.sessionId, "focusCommandTerminal");
+    if (!terminalStateById.has(reference.sessionId)) {
+      const session = findTerminalSessionInProject(reference.project, reference.sessionId);
+      if (session) {
+        restoreNativeTerminalSession(reference.project, session, "focus-command-session");
+      }
+    }
+    publish();
+    postNative({
+      sessionId: nativeSessionIdForProjectSidebarSession(
+        reference.project.projectId,
+        reference.sessionId,
+      ),
+      type: "focusTerminal",
+    });
+    return;
   }
   activateWorkspaceSurfaceForProject(reference.project.projectId);
   updateActiveProjectWorkspace(
@@ -8188,6 +8834,9 @@ function runNativeHotkeyAction(actionId: zmuxHotkeyActionId): void {
       return;
     case "moveSidebar":
       moveSidebarToOtherSide();
+      return;
+    case "openCommandsPanel":
+      openCommandsPanelForActiveProject();
       return;
     case "openSettings":
       openAppModal({ modal: "settings", type: "open" });
@@ -8558,6 +9207,12 @@ function findTerminalSessionInProject(
   project: NativeProject,
   sessionId: string,
 ): TerminalSessionRecord | undefined {
+  const commandSession = project.commandsPanel.sessions.find(
+    (candidate) => candidate.sessionId === sessionId,
+  );
+  if (commandSession) {
+    return commandSession;
+  }
   for (const group of project.workspace.groups) {
     const session = group.snapshot.sessions.find(
       (candidate) => candidate.sessionId === sessionId,
@@ -9499,9 +10154,9 @@ function runNativeSidebarCommand(
   }
 
   if (command.closeTerminalOnExit) {
-    const session = createTerminal(sessionTitle, "", undefined, undefined, {
+    const session = createCommandTerminal(sessionTitle, "", {
       focusAfterCreate: false,
-      initialPresentation: "background",
+      commandId: command.commandId,
     });
     if (!session) {
       return undefined;
@@ -9525,9 +10180,9 @@ function runNativeSidebarCommand(
 
   const session =
     reusableSession ??
-    createTerminal(sessionTitle, "", undefined, undefined, {
+    createCommandTerminal(sessionTitle, "", {
       focusAfterCreate: false,
-      initialPresentation: "background",
+      commandId: command.commandId,
     });
   if (!session) {
     return undefined;
@@ -10228,6 +10883,7 @@ function closeAllNativeSessions(): void {
   sidebarCommandCommandIdBySessionId.clear();
   projects = projects.map((project) => ({
     ...project,
+    commandsPanel: createDefaultCommandsPanelState(),
     workspace: createDefaultGroupedSessionWorkspaceSnapshot(),
   }));
   previousSessions = [];
@@ -10247,6 +10903,7 @@ function addProject(path: string, name = projectNameFromPath(path)): void {
     projects = [
       ...projects,
       {
+        commandsPanel: createDefaultCommandsPanelState(),
         name: name.trim() || projectNameFromPath(normalizedPath),
         path: normalizedPath,
         projectId,
@@ -10288,6 +10945,7 @@ async function createNativeChat(title = "chat"): Promise<void> {
     projects = orderNativeProjectsForSidebar([
       ...projects,
       {
+        commandsPanel: createDefaultCommandsPanelState(),
         isChat: true,
         name: nativeChatTitleFromDate(createdAt),
         path: chatPath,
@@ -10329,6 +10987,7 @@ async function createNativePluginsBrowserChat(): Promise<void> {
     projects = orderNativeProjectsForSidebar([
       ...projects,
       {
+        commandsPanel: createDefaultCommandsPanelState(),
         isChat: true,
         name: "Plugins",
         path: chatPath,
@@ -10399,6 +11058,7 @@ async function createNativeBrowserChat(): Promise<void> {
     projects = orderNativeProjectsForSidebar([
       ...projects,
       {
+        commandsPanel: createDefaultCommandsPanelState(),
         isChat: true,
         name: "Browser",
         path: chatPath,
@@ -11067,6 +11727,16 @@ function disposeProjectEditorSurface(projectId: string): void {
   if (projectEditorSurfaceByProjectId.size === 0) {
     postNative({ type: "stopCodeServerRuntime" });
   }
+}
+
+function toggleCommandsPanelFromTitlebar(): void {
+  /**
+   * CDXC:CommandsPanel 2026-05-13-22:54
+   * The Commands panel launcher lives in the native titlebar. Keep the actual
+   * panel state transition in the sidebar model so the bottom pane, command
+   * terminals, persistence, and native layout sync all use one owner.
+   */
+  toggleCommandsPanelForActiveProject();
 }
 
 function reorderProjects(projectIds: string[]): void {
@@ -12028,6 +12698,11 @@ function createNativeLayoutSyncKey(command: NativeSetActiveTerminalSetCommand): 
     normalizeNativeLayoutSyncValue({
       activeProjectEditorId: command.activeProjectEditorId,
       activeSessionIds: command.activeSessionIds,
+      commandsPanelActiveSessionIds: command.commandsPanelActiveSessionIds,
+      commandsPanelHeightRatio: command.commandsPanelHeightRatio,
+      commandsPanelIsVisible: command.commandsPanelIsVisible,
+      commandsPanelLayout: command.commandsPanelLayout,
+      commandsPanelMode: command.commandsPanelMode,
       layout: command.layout,
       paneGap: command.paneGap,
     }),
@@ -12059,6 +12734,7 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
     ]),
   );
   const snapshot = activeSnapshot();
+  const commandsPanel = currentProject.commandsPanel;
   const visibleSessionRecordsById = new Map(
     snapshot.sessions.map((session) => [session.sessionId, session]),
   );
@@ -12078,6 +12754,14 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
   const awakeVisibleSessions = visibleSessions.filter((session) => session.isSleeping !== true);
   const visibleSessionIds = awakeVisibleSessions
     .map((session) => nativeSessionIdForSidebarSession(session.sessionId));
+  const commandPanelSessions = commandsPanel.sessions;
+  const commandPanelVisibleSessions = commandPanelSessions;
+  const commandPanelActiveSessions = commandPanelVisibleSessions.filter(
+    (session) => session.isSleeping !== true,
+  );
+  const commandPanelActiveSessionIds = commandPanelActiveSessions.map((session) =>
+    nativeSessionIdForSidebarSession(session.sessionId),
+  );
   const sleepingSessionIds = visibleSessions
     .filter((session) => session.isSleeping === true)
     .map((session) => nativeSessionIdForSidebarSession(session.sessionId));
@@ -12097,7 +12781,7 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
   const sessionTitleBarActions: Record<string, NativeTerminalTitleBarAction[]> = {};
   const sessionTitles: Record<string, string> = {};
   const poppedOutSessionIds: string[] = [];
-  for (const session of visibleSessions) {
+  for (const session of [...visibleSessions, ...commandPanelVisibleSessions]) {
     const nativeSessionId = nativeSessionIdForSidebarSession(session.sessionId);
     sessionTitles[nativeSessionId] = session.title;
     /**
@@ -12129,7 +12813,15 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
     if (session.isSleeping === true) {
       continue;
     }
-    sessionTitleBarActions[nativeSessionId] = getNativePaneTitleBarActions(session);
+    sessionTitleBarActions[nativeSessionId] =
+      session.kind === "terminal" && session.surface === "commands"
+        ? commandsPanel.isVisible
+          ? [
+              commandsPanel.mode === "pinned" ? "unpinCommandsPanel" : "pinCommandsPanel",
+              "closeCommandsPanel",
+            ]
+          : ["expandCommandsPanel"]
+        : getNativePaneTitleBarActions(session);
     if (session.kind !== "terminal") {
       continue;
     }
@@ -12147,13 +12839,28 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
     clampVisibleSessionCount(visibleSessions.length),
     getActiveNativeSplitLayoutHint(snapshot),
   );
+  const commandPanelLayout = buildLayout(
+    commandsPanel.paneLayout,
+    commandPanelVisibleSessions.map((session) => session.sessionId),
+    commandPanelVisibleSessions.map((session) => nativeSessionIdForSidebarSession(session.sessionId)),
+    new Set(commandPanelActiveSessions.map((session) => session.sessionId)),
+    new Set(commandPanelActiveSessionIds),
+    clampVisibleSessionCount(Math.max(1, commandPanelVisibleSessions.length)),
+  );
   const focusedNativeSessionId = snapshot.focusedSessionId
     ? nativeSessionIdForSidebarSession(snapshot.focusedSessionId)
     : undefined;
+  const commandsPanelFocusedNativeSessionId = commandsPanel.activeSessionId
+    ? nativeSessionIdForSidebarSession(commandsPanel.activeSessionId)
+    : undefined;
   const shouldConsumeFocusRequest =
     pendingNativeLayoutFocusRequest !== undefined &&
-    pendingNativeLayoutFocusRequest.sessionId === snapshot.focusedSessionId &&
-    visibleSessions.some((session) => session.sessionId === pendingNativeLayoutFocusRequest?.sessionId);
+    ((pendingNativeLayoutFocusRequest.sessionId === snapshot.focusedSessionId &&
+      visibleSessions.some((session) => session.sessionId === pendingNativeLayoutFocusRequest?.sessionId)) ||
+      (pendingNativeLayoutFocusRequest.sessionId === commandsPanel.activeSessionId &&
+        commandPanelVisibleSessions.some(
+          (session) => session.sessionId === pendingNativeLayoutFocusRequest?.sessionId,
+        )));
   const focusRequestId = shouldConsumeFocusRequest
     ? pendingNativeLayoutFocusRequest?.requestId
     : undefined;
@@ -12178,6 +12885,12 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
    */
   const command: NativeSetActiveTerminalSetCommand = {
     activeSessionIds: visibleSessionIds,
+    commandsPanelActiveSessionIds: commandPanelActiveSessionIds,
+    commandsPanelFocusedSessionId: commandsPanelFocusedNativeSessionId,
+    commandsPanelHeightRatio: commandsPanel.heightRatio,
+    commandsPanelIsVisible: commandsPanel.isVisible,
+    commandsPanelLayout: commandPanelLayout,
+    commandsPanelMode: commandsPanel.mode,
     /**
      * CDXC:ReactTitlebar 2026-05-11-00:22
      * The native React titlebar mirrors the active project header: project
@@ -12532,6 +13245,14 @@ window.addEventListener("zmux-native-host-event", (event) => {
     setProjectEditorLoadState(hostEvent.projectId, hostEvent.status, hostEvent.message);
     return;
   }
+  if (hostEvent.type === "commandsPanelHeightRatioChanged") {
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      heightRatio: hostEvent.heightRatio,
+    }));
+    publish();
+    return;
+  }
   if (hostEvent.type === "paneTabSelected") {
     handleNativePaneTabSelected(sidebarSessionIdForNativeSession(hostEvent.sessionId));
     return;
@@ -12691,6 +13412,17 @@ window.addEventListener("zmux-native-host-event", (event) => {
       previousFocusedSessionId,
       targetGroup: summarizeWorkspaceGroupForPaneLayoutTrace(activeProject().workspace),
     });
+    if (activeCommandPanelContainsSession(sidebarSessionId)) {
+      updateActiveProjectCommandsPanel((panel) => ({
+        ...panel,
+        activeSessionId: sidebarSessionId,
+        isVisible: true,
+        paneLayout: setActiveCommandSessionInPaneLayout(panel.paneLayout, sidebarSessionId),
+      }));
+      acknowledgeNativeTerminalAttention(sidebarSessionId, "native-focus");
+      publish();
+      return;
+    }
     if (previousFocusedSessionId === sidebarSessionId) {
       const acknowledgedAttention = acknowledgeNativeTerminalAttention(
         sidebarSessionId,
@@ -12897,6 +13629,10 @@ function handleNativePaneReorderRequested(
   targetSessionId: string,
   placement?: SessionPaneDropPlacement,
 ): void {
+  if (activeCommandPanelContainsSession(sourceSessionId) || activeCommandPanelContainsSession(targetSessionId)) {
+    handleCommandPanelPaneReorderRequested(sourceSessionId, targetSessionId, placement);
+    return;
+  }
   if (sourceSessionId === targetSessionId) {
     return;
   }
@@ -12987,6 +13723,17 @@ function handleNativePaneReorderRequested(
 }
 
 function handleNativePaneTabSelected(sessionId: string): void {
+  if (activeCommandPanelContainsSession(sessionId)) {
+    updateActiveProjectCommandsPanel((panel) => ({
+      ...panel,
+      activeSessionId: sessionId,
+      isVisible: true,
+      paneLayout: setActiveCommandSessionInPaneLayout(panel.paneLayout, sessionId),
+    }));
+    queueNativeLayoutFocusRequest(sessionId, "commandPaneTabSelected");
+    publish();
+    return;
+  }
   const group = activeWorkspaceGroup();
   const selectedSessionBefore = findSessionRecord(sessionId);
   const wasSleeping = selectedSessionBefore?.isSleeping === true;
@@ -13046,6 +13793,13 @@ function handleNativePaneTabCloseRequested(
   sessionId: string,
   scope: NativePaneTabCloseScope,
 ): void {
+  if (activeCommandPanelContainsSession(sessionId)) {
+    const sessionIds = getCommandPaneTabSessionIds(sessionId, scope);
+    for (const commandSessionId of sessionIds) {
+      closeTerminal(commandSessionId);
+    }
+    return;
+  }
   const sessionIds = getPaneTabCloseSessionIds(sessionId, scope);
   if (sessionIds.length === 0) {
     appendTerminalFocusDebugLog("nativePaneTabClose.missingTargets", {
@@ -13096,6 +13850,10 @@ function handleNativePaneTabReorderRequested(
   targetSessionId: string,
   position: SessionPaneTabReorderPosition,
 ): void {
+  if (activeCommandPanelContainsSession(sourceSessionId) || activeCommandPanelContainsSession(targetSessionId)) {
+    handleCommandPanelPaneTabReorderRequested(sourceSessionId, targetSessionId, position);
+    return;
+  }
   const group = activeWorkspaceGroup();
   const result = reorderSessionInPaneTabGroupInSimpleWorkspace(
     activeProject().workspace,
@@ -13130,6 +13888,91 @@ function handleNativePaneTabReorderRequested(
   publish();
 }
 
+function handleCommandPanelPaneReorderRequested(
+  sourceSessionId: string,
+  targetSessionId: string,
+  placement?: SessionPaneDropPlacement,
+): void {
+  if (
+    !placement ||
+    (placement !== "center" && placement !== "left" && placement !== "right") ||
+    !activeCommandPanelContainsSession(sourceSessionId) ||
+    !activeCommandPanelContainsSession(targetSessionId)
+  ) {
+    return;
+  }
+  let changed = false;
+  updateActiveProjectCommandsPanel((panel) => {
+    const layout =
+      panel.paneLayout ??
+      normalizeCommandPaneLayout(
+        undefined,
+        new Set(panel.sessions.map((session) => session.sessionId)),
+        panel.activeSessionId,
+      );
+    if (!layout || (sourceSessionId === targetSessionId && placement === "center")) {
+      return panel;
+    }
+    const layoutWithoutSource = removeCommandSessionFromPaneLayout(layout, sourceSessionId);
+    if (!layoutWithoutSource) {
+      return panel;
+    }
+    const nextLayout =
+      placement === "center"
+        ? addCommandSessionToPaneTabGroup(layoutWithoutSource, targetSessionId, sourceSessionId)
+        : insertCommandSessionBesidePane(
+            layoutWithoutSource,
+            targetSessionId,
+            sourceSessionId,
+            placement === "right",
+          );
+    if (!nextLayout) {
+      return panel;
+    }
+    changed = true;
+    return {
+      ...panel,
+      activeSessionId: sourceSessionId,
+      isVisible: true,
+      paneLayout: nextLayout,
+    };
+  });
+  if (changed) {
+    publish();
+  }
+}
+
+function handleCommandPanelPaneTabReorderRequested(
+  sourceSessionId: string,
+  targetSessionId: string,
+  position: SessionPaneTabReorderPosition,
+): void {
+  if (
+    sourceSessionId === targetSessionId ||
+    !activeCommandPanelContainsSession(sourceSessionId) ||
+    !activeCommandPanelContainsSession(targetSessionId)
+  ) {
+    return;
+  }
+  let changed = false;
+  updateActiveProjectCommandsPanel((panel) => {
+    const nextLayout = reorderCommandSessionInPaneTabGroup(
+      panel.paneLayout,
+      sourceSessionId,
+      targetSessionId,
+      position,
+    );
+    if (!nextLayout) {
+      return panel;
+    }
+    changed = true;
+    return { ...panel, paneLayout: nextLayout };
+  });
+  if (changed) {
+    publish();
+  }
+}
+
 function getPaneTabCloseSessionIds(
   sessionId: string,
   scope: NativePaneTabCloseScope,
@@ -13160,6 +14003,30 @@ function getPaneTabCloseSessionIds(
       return tabSessionIds.slice(tabIndex + 1);
   }
   return [];
+}
+
+function getCommandPaneTabSessionIds(
+  sessionId: string,
+  scope: NativePaneTabCloseScope,
+): string[] {
+  const tabSessionIds = findPaneTabGroupSessionIds(activeProject().commandsPanel.paneLayout, sessionId);
+  if (!tabSessionIds) {
+    return scope === "close" && activeCommandPanelContainsSession(sessionId) ? [sessionId] : [];
+  }
+  const tabIndex = tabSessionIds.indexOf(sessionId);
+  if (tabIndex < 0) {
+    return [];
+  }
+  switch (scope) {
+    case "close":
+      return [sessionId];
+    case "closeLeft":
+      return tabSessionIds.slice(0, tabIndex);
+    case "closeOthers":
+      return tabSessionIds.filter((tabSessionId) => tabSessionId !== sessionId);
+    case "closeRight":
+      return tabSessionIds.slice(tabIndex + 1);
+  }
 }
 
 function getPaneTabSleepSessionIds(
@@ -13225,6 +14092,27 @@ function handleNativeTerminalTitleBarAction(
   const session = findSessionRecord(sessionId);
   if (!session) {
     return;
+  }
+  if (session.kind === "terminal" && session.surface === "commands") {
+    switch (action) {
+      case "newTerminal":
+        createCommandTerminal(DEFAULT_TERMINAL_SESSION_TITLE, "", { focusAfterCreate: true });
+        return;
+      case "pinCommandsPanel":
+        setCommandsPanelModeForActiveProject("pinned");
+        return;
+      case "unpinCommandsPanel":
+        setCommandsPanelModeForActiveProject("floating");
+        return;
+      case "closeCommandsPanel":
+        hideCommandsPanelForActiveProject();
+        return;
+      case "expandCommandsPanel":
+        openCommandsPanelForActiveProject();
+        return;
+      default:
+        return;
+    }
   }
   /**
    * CDXC:NativeTerminals 2026-04-28-13:20
@@ -13305,6 +14193,11 @@ function handleNativeTerminalTitleBarAction(
         setNativeSessionSleeping(sessionId, true);
       }
       return;
+    case "pinCommandsPanel":
+    case "unpinCommandsPanel":
+    case "closeCommandsPanel":
+    case "expandCommandsPanel":
+      return;
     case "close":
       closeTerminal(sessionId);
       return;
@@ -13343,6 +14236,7 @@ window.__zmux_NATIVE_SIDEBAR__ = {
   openActiveProjectEditorFromTitlebar,
   refreshWorkspaceOpenTargetAvailabilityFromTitlebar,
   rotateActivePaneLayoutClockwiseFromTitlebar,
+  toggleCommandsPanelFromTitlebar,
   runSidebarCommandFromTitlebar,
 };
 

--- a/native/sidebar/titlebar-host.tsx
+++ b/native/sidebar/titlebar-host.tsx
@@ -99,6 +99,7 @@ type NativeTitlebarCommand =
   | { type: "openActiveProjectEditorFromTitlebar" }
   | { type: "refreshWorkspaceOpenTargetAvailabilityFromTitlebar" }
   | { type: "rotateActivePaneLayoutClockwiseFromTitlebar" }
+  | { type: "toggleCommandsPanelFromTitlebar" }
   | { commandId: string; type: "runSidebarCommandFromTitlebar" }
   | {
       targetApp: ZedOverlayTargetApp;
@@ -429,6 +430,10 @@ function App() {
     postNative({ type: "rotateActivePaneLayoutClockwiseFromTitlebar" });
   };
 
+  const toggleCommandsPanel = () => {
+    postNative({ type: "toggleCommandsPanelFromTitlebar" });
+  };
+
   return (
     <TooltipProvider delayDuration={300}>
       <div className="dark" ref={rootRef} style={styles.shell}>
@@ -643,6 +648,21 @@ function App() {
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Open embedded editor</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label="Toggle Commands panel"
+                  className="titlebar-session-button titlebar-command-panel-button"
+                  data-titlebar-hit-region
+                  onClick={toggleCommandsPanel}
+                  type="button"
+                  variant="ghost"
+                >
+                  <IconTerminal2 aria-hidden="true" size={16} stroke={1.8} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Toggle Commands panel</TooltipContent>
             </Tooltip>
           </div>
         </div>
@@ -1025,6 +1045,10 @@ styleElement.textContent = `
     padding: 0;
   }
   .titlebar-rotate-button {
+    width: 28px;
+    padding: 0;
+  }
+  .titlebar-command-panel-button {
     width: 28px;
     padding: 0;
   }

--- a/shared/native-ghostty-host-protocol.ts
+++ b/shared/native-ghostty-host-protocol.ts
@@ -26,17 +26,21 @@ export type NativeTerminalLayout =
 
 export type NativeTerminalTitleBarAction =
   | "close"
+  | "closeCommandsPanel"
   | "delayedSend"
+  | "expandCommandsPanel"
   | "fork"
   | "newTerminal"
   | "openBrowser"
+  | "pinCommandsPanel"
   | "popOut"
   | "reload"
   | "rename"
   | "restorePopOut"
   | "sleep"
   | "splitHorizontal"
-  | "splitVertical";
+  | "splitVertical"
+  | "unpinCommandsPanel";
 
 export type NativeGhosttyHostCommand =
   | {
@@ -162,6 +166,12 @@ export type NativeGhosttyHostCommand =
       activeProjectName?: string;
       activeProjectPath?: string;
       activeSessionIds: string[];
+      commandsPanelActiveSessionIds?: string[];
+      commandsPanelFocusedSessionId?: string;
+      commandsPanelHeightRatio?: number;
+      commandsPanelIsVisible?: boolean;
+      commandsPanelLayout?: NativeTerminalLayout;
+      commandsPanelMode?: "floating" | "pinned";
       /**
        * CDXC:NativeWindowChrome 2026-05-10-14:19
        * Native host commands carry the outer app title separately from pane
@@ -277,6 +287,10 @@ export type NativeGhosttyHostEvent =
   | {
       sessionId: string;
       type: "terminalBell";
+    }
+  | {
+      heightRatio: number;
+      type: "commandsPanelHeightRatioChanged";
     }
   | {
       sessionId: string;

--- a/shared/session-grid-contract-core.ts
+++ b/shared/session-grid-contract-core.ts
@@ -90,6 +90,8 @@ export type SidebarThemeSetting =
 export type SidebarThemeVariant = "light" | "dark";
 
 export type SessionKind = "browser" | "terminal" | "t3";
+export type TerminalSurface = "workspace" | "commands";
+export type CommandsPanelMode = "floating" | "pinned";
 export type TerminalEngine = "ghostty-native";
 export type TerminalSessionPersistenceProvider = "tmux" | "zmx" | "zellij";
 
@@ -147,6 +149,7 @@ export type TerminalSessionRecord = BaseSessionRecord & {
   kind: "terminal";
   sessionPersistenceName?: string;
   sessionPersistenceProvider?: TerminalSessionPersistenceProvider;
+  surface?: TerminalSurface;
   terminalEngine: TerminalEngine;
   /** @deprecated use sessionPersistenceName for tmux, zmx, and zellij providers. */
   tmuxSessionName?: string;
@@ -184,6 +187,7 @@ export type CreateSessionRecordOptions =
       sessionId?: string;
       sessionPersistenceName?: string;
       sessionPersistenceProvider?: TerminalSessionPersistenceProvider;
+      surface?: TerminalSurface;
       terminalEngine?: TerminalEngine;
       /** @deprecated use sessionPersistenceName for tmux, zmx, and zellij providers. */
       tmuxSessionName?: string;
@@ -208,6 +212,15 @@ export type SessionGridSnapshot = {
   visibleCount: VisibleSessionCount;
   visibleSessionIds: string[];
   viewMode: TerminalViewMode;
+};
+
+export type CommandsPanelState = {
+  activeSessionId?: string;
+  heightRatio: number;
+  isVisible: boolean;
+  mode: CommandsPanelMode;
+  paneLayout?: SessionPaneLayoutNode;
+  sessions: TerminalSessionRecord[];
 };
 
 export type SessionGroupRecord = {

--- a/shared/session-grid-contract-session.ts
+++ b/shared/session-grid-contract-session.ts
@@ -16,6 +16,7 @@ import {
   type SidebarThemeSetting,
   type SidebarThemeVariant,
   type TerminalEngine,
+  type TerminalSurface,
   type TerminalSessionPersistenceProvider,
   type TerminalSessionRecord,
   type T3SessionRecord,
@@ -184,6 +185,17 @@ export function createDefaultSessionGridSnapshot(): SessionGridSnapshot {
     visibleCount: 1,
     visibleSessionIds: [],
     viewMode: "grid",
+  };
+}
+
+export function createDefaultCommandsPanelState() {
+  return {
+    activeSessionId: undefined,
+    heightRatio: 0.32,
+    isVisible: false,
+    mode: "pinned" as const,
+    paneLayout: undefined,
+    sessions: [],
   };
 }
 
@@ -403,6 +415,7 @@ export function createSessionRecord(
     sessionPersistenceProvider: normalizeTerminalSessionPersistenceProvider(
       options?.sessionPersistenceProvider,
     ),
+    surface: normalizeTerminalSurface(options?.surface),
     title,
     titleSource,
   };
@@ -455,6 +468,10 @@ export function normalizeTerminalSessionPersistenceProvider(
 
 export function normalizeTerminalEngine(value: string | undefined): TerminalEngine {
   return DEFAULT_TERMINAL_ENGINE;
+}
+
+export function normalizeTerminalSurface(value: TerminalSurface | undefined): TerminalSurface {
+  return value === "commands" ? "commands" : "workspace";
 }
 
 export function isPersistentTerminalEngine(value: TerminalEngine): boolean {

--- a/shared/session-grid-state-helpers.ts
+++ b/shared/session-grid-state-helpers.ts
@@ -11,6 +11,7 @@ import {
   normalizeTerminalSessionAgentName,
   normalizeTerminalSessionPersistenceProvider,
   normalizeTerminalEngine,
+  normalizeTerminalSurface,
   type SessionGridDirection,
   type SessionGridSnapshot,
   type SessionRecord,
@@ -306,6 +307,7 @@ export function normalizeSessionRecord(session: SessionRecord): SessionRecord {
     sessionPersistenceProvider: normalizeTerminalSessionPersistenceProvider(
       session.kind === "terminal" ? session.sessionPersistenceProvider : undefined,
     ),
+    surface: normalizeTerminalSurface(session.kind === "terminal" ? session.surface : undefined),
     title,
     titleSource,
   };

--- a/shared/zmux-hotkeys.ts
+++ b/shared/zmux-hotkeys.ts
@@ -4,6 +4,7 @@ export type zmuxHotkeyActionId =
   | "createSession"
   | "openSettings"
   | "moveSidebar"
+  | "openCommandsPanel"
   | "renameActiveSession"
   | "focusPreviousGroup"
   | "focusNextGroup"
@@ -27,6 +28,7 @@ export type zmuxHotkeyAction =
   | { id: zmuxHotkeyActionId; kind: "focusGroup"; groupIndex: number }
   | { id: zmuxHotkeyActionId; kind: "focusSessionSlot"; slotNumber: number }
   | { id: zmuxHotkeyActionId; kind: "moveSidebar" }
+  | { id: zmuxHotkeyActionId; kind: "openCommandsPanel" }
   | { id: zmuxHotkeyActionId; kind: "openSettings" }
   | { id: zmuxHotkeyActionId; kind: "renameActiveSession" }
   | { id: zmuxHotkeyActionId; kind: "setViewMode"; viewMode: TerminalViewMode }
@@ -59,6 +61,13 @@ export const ZMUX_HOTKEY_DEFINITIONS: readonly zmuxHotkeyDefinition[] = [
     description: "Create a terminal session.",
     id: "createSession",
     title: "Create Session",
+  },
+  {
+    action: { id: "openCommandsPanel", kind: "openCommandsPanel" },
+    defaultKey: "f12",
+    description: "Open the project command terminal panel.",
+    id: "openCommandsPanel",
+    title: "Open Commands Panel",
   },
   {
     action: { id: "openSettings", kind: "openSettings" },

--- a/shared/zmux-settings.test.ts
+++ b/shared/zmux-settings.test.ts
@@ -272,7 +272,7 @@ describe("normalizezmuxSettings", () => {
   });
 
   test("keeps the workspace background color setting", () => {
-    expect(DEFAULT_zmux_SETTINGS.workspaceBackgroundColor).toBe("#121212");
+    expect(DEFAULT_zmux_SETTINGS.workspaceBackgroundColor).toBe("#0e0e0e");
     expect(normalizezmuxSettings({ workspaceBackgroundColor: "#202020" })).toMatchObject({
       workspaceBackgroundColor: "#202020",
     });

--- a/shared/zmux-settings.ts
+++ b/shared/zmux-settings.ts
@@ -288,7 +288,7 @@ export const DEFAULT_zmux_SETTINGS: zmuxSettings = {
   useZpetForCtrlGPromptEditing: false,
   hotkeys: DEFAULT_zmux_HOTKEYS,
   workspaceActivePaneBorderColor: "#3b82f6",
-  workspaceBackgroundColor: "#121212",
+  workspaceBackgroundColor: "#0e0e0e",
   /**
    * CDXC:TitlebarOpenIn 2026-05-11-00:22
    * The titlebar Open In menu is configurable: built-in editor targets can be

--- a/sidebar/sidebar-app.tsx
+++ b/sidebar/sidebar-app.tsx
@@ -2118,10 +2118,9 @@ export function SidebarApp({ messageSource = window, vscode }: SidebarAppProps) 
 
   const createFullWidthTerminalPane = () => {
     /**
-     * CDXC:PaneTabs 2026-05-11-11:51
-     * Header-level terminal shortcuts create focused tabs in the active
-     * session's tab group. Keep this legacy message path for the Settings-row
-     * hover action, but do not describe or request full-width pane placement.
+     * CDXC:CommandsPanel 2026-05-13-17:02
+     * The Settings-row terminal shortcut keeps the legacy message name, but the
+     * native host now uses it as a Commands panel toggle.
      */
     setIsOverflowMenuOpen(false);
     setIsPinnedPromptsOpen(false);
@@ -2696,10 +2695,7 @@ export function SidebarApp({ messageSource = window, vscode }: SidebarAppProps) 
         ) : null}
       </div>
       {isCombinedSidebarMode ? (
-        <SidebarReferenceSettingsButton
-          onCreateFullWidthTerminalPane={createFullWidthTerminalPane}
-          onOpenSettings={openSidebarSettings}
-        />
+        <SidebarReferenceSettingsButton onOpenSettings={openSidebarSettings} />
       ) : null}
       </div>
     </TooltipProvider>
@@ -3040,30 +3036,14 @@ function SidebarReferenceSectionHeader({
 }
 
 function SidebarReferenceSettingsButton({
-  onCreateFullWidthTerminalPane,
   onOpenSettings,
 }: {
-  onCreateFullWidthTerminalPane: () => void;
   onOpenSettings: () => void;
 }) {
   return (
     <div className="reference-sidebar-settings-row">
       <div className="reference-sidebar-nav-item">
         <SidebarReferenceNavButton icon={IconSettings} label="Settings" onClick={onOpenSettings} />
-        <AppTooltip align="end" collisionPadding={4} content="Create terminal tab">
-          <button
-            aria-label="Create terminal tab"
-            className="reference-sidebar-hover-action reference-sidebar-settings-terminal-action"
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onCreateFullWidthTerminalPane();
-            }}
-            type="button"
-          >
-            <IconTerminal2 aria-hidden="true" size={15} stroke={1.9} />
-          </button>
-        </AppTooltip>
       </div>
     </div>
   );


### PR DESCRIPTION
**Summary**
- Rework the native command panel chrome, including border behavior, spacing, sizing, and tab/button styling.
- Fix command panel focus and title handling so terminal events and tab labels follow the intended native paths.
- Update the F12 command-panel hotkey path so it is handled by the app before reaching the terminal.

**Testing**
- Not run (not requested)
- Existing Swift/TypeScript checks were used during implementation to validate the affected native and shared code paths.