### PR TITLE
feat: auto-promote chat workspaces to projects and disable unusable titlebar tabs

### DIFF
--- a/native/macos/ghostexHost/Sources/ghostexHost/AppDelegate.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/AppDelegate.swift
@@ -5118,6 +5118,9 @@ final class ghostexRootView: NSView {
     if let activeProjectId = command.activeProjectId {
       payload["projectId"] = activeProjectId
     }
+    if let activeProjectIsChat = command.activeProjectIsChat {
+      payload["isChat"] = activeProjectIsChat
+    }
     payload["projectIconDataUrl"] = command.activeProjectIconDataUrl ?? NSNull()
     if let activeProjectName = command.activeProjectName {
       payload["projectName"] = activeProjectName

--- a/native/macos/ghostexHost/Sources/ghostexHost/AppDelegate.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/AppDelegate.swift
@@ -5291,23 +5291,25 @@ final class ghostexRootView: NSView {
     payload["browserTabs"] = workspaceView.titlebarBrowserResourceTabs()
     if let openTargets = command.workspaceOpenTargets {
       let availability = openTargets.availability
-      payload["workspaceOpenTargets"] = [
-        "availability": [
-          "availableTargetIds": availability?.availableTargetIds ?? [],
-          "checkedAtMs": availability?.checkedAtMs ?? 0,
-          "resolvedAppNames": availability?.resolvedAppNames ?? [:],
-          "resolvedCommands": availability?.resolvedCommands ?? [:],
-        ],
-        "customTargets": openTargets.customTargets?.map { target in
-          [
-            "args": target.args ?? [],
-            "command": target.command,
-            "id": target.id,
-            "label": target.label,
-          ] as [String: Any]
-        } ?? [],
-        "hiddenTargetIds": openTargets.hiddenTargetIds ?? [],
+      let availabilityDict: [String: Any] = [
+        "availableTargetIds": availability?.availableTargetIds ?? [],
+        "checkedAtMs": availability?.checkedAtMs ?? 0,
+        "resolvedAppNames": availability?.resolvedAppNames ?? [:],
+        "resolvedCommands": availability?.resolvedCommands ?? [:],
       ]
+      let customTargetsList: [[String: Any]] = openTargets.customTargets?.map { target in
+        [
+          "args": target.args ?? [],
+          "command": target.command,
+          "id": target.id,
+          "label": target.label,
+        ] as [String: Any]
+      } ?? []
+      payload["workspaceOpenTargets"] = [
+        "availability": availabilityDict,
+        "customTargets": customTargetsList,
+        "hiddenTargetIds": openTargets.hiddenTargetIds ?? [],
+      ] as [String: Any]
     }
     guard
       let data = try? JSONSerialization.data(withJSONObject: payload),

--- a/native/macos/ghostexHost/Sources/ghostexHost/HostProtocol.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/HostProtocol.swift
@@ -476,6 +476,7 @@ struct SetActiveTerminalSet: Decodable {
   let activeProjectEditorIsSleeping: Bool?
   let activeProjectEditorStatus: String?
   let activeProjectId: String?
+  let activeProjectIsChat: Bool?
   let activeProjectIconDataUrl: String?
   let activeProjectName: String?
   let activeProjectPath: String?

--- a/native/macos/ghostexHost/Sources/ghostexHost/TerminalWorkspaceView.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/TerminalWorkspaceView.swift
@@ -755,6 +755,11 @@ final class GhostexGhosttyApp {
       surfaceView(from: target)?.setTerminalTitle(action.action.set_title.title)
       return true
     case GHOSTTY_ACTION_PWD:
+      guard let surfaceView = surfaceView(from: target),
+            let pwdPtr = action.action.pwd.pwd,
+            let pwd = String(cString: pwdPtr, encoding: .utf8)
+      else { return true }
+      surfaceView.pwd = pwd
       return true
     case GHOSTTY_ACTION_CELL_SIZE:
       surfaceView(from: target)?.setCellSize(
@@ -2568,6 +2573,14 @@ final class TerminalWorkspaceView: NSView {
             title: title,
             sessionPersistenceName: sessionPersistenceName
           ))
+      }
+      .store(in: &session.cancellables)
+    surfaceView.$pwd
+      .removeDuplicates()
+      .compactMap { $0 }
+      .sink { [weak self] pwd in
+        guard !pwd.isEmpty else { return }
+        self?.sendEvent(.terminalCwdChanged(sessionId: command.sessionId, cwd: pwd))
       }
       .store(in: &session.cancellables)
     surfaceView.$bell
@@ -11858,24 +11871,24 @@ final class TerminalWorkspaceView: NSView {
       available: terminalRect.height,
       padding: actualPadding?.height,
       cell: cellSize.height)
-    let signature = [
-      roundedSignature(paneRect.size.width),
-      roundedSignature(paneRect.size.height),
-      roundedSignature(terminalRect.size.width),
-      roundedSignature(terminalRect.size.height),
-      roundedSignature(session.scrollView.bounds.size.width),
-      roundedSignature(session.scrollView.bounds.size.height),
-      roundedSignature(session.view.frame.size.width),
-      roundedSignature(session.view.frame.size.height),
-      String(surfaceSize?.columns ?? 0),
-      String(surfaceSize?.rows ?? 0),
-      String(estimatedColumns ?? 0),
-      String(estimatedRows ?? 0),
-      String(paddingAwareEstimatedColumns ?? 0),
-      String(paddingAwareEstimatedRows ?? 0),
-      String(surfaceSize?.width_px ?? 0),
-      String(surfaceSize?.height_px ?? 0),
-    ].joined(separator: "x")
+    var signatureParts: [String] = []
+    signatureParts.append(roundedSignature(paneRect.size.width))
+    signatureParts.append(roundedSignature(paneRect.size.height))
+    signatureParts.append(roundedSignature(terminalRect.size.width))
+    signatureParts.append(roundedSignature(terminalRect.size.height))
+    signatureParts.append(roundedSignature(session.scrollView.bounds.size.width))
+    signatureParts.append(roundedSignature(session.scrollView.bounds.size.height))
+    signatureParts.append(roundedSignature(session.view.frame.size.width))
+    signatureParts.append(roundedSignature(session.view.frame.size.height))
+    signatureParts.append(String(surfaceSize?.columns ?? 0))
+    signatureParts.append(String(surfaceSize?.rows ?? 0))
+    signatureParts.append(String(estimatedColumns ?? 0))
+    signatureParts.append(String(estimatedRows ?? 0))
+    signatureParts.append(String(paddingAwareEstimatedColumns ?? 0))
+    signatureParts.append(String(paddingAwareEstimatedRows ?? 0))
+    signatureParts.append(String(surfaceSize?.width_px ?? 0))
+    signatureParts.append(String(surfaceSize?.height_px ?? 0))
+    let signature = signatureParts.joined(separator: "x")
     if resizeLogSignatureBySessionId[session.sessionId] == signature {
       return
     }
@@ -13789,6 +13802,7 @@ final class GhostexGhosttySurfaceView: NSView {
   var onMouseDownFocus: ((GhostexGhosttySurfaceView, NSEvent) -> Void)?
   var onTextInputProbe: ((GhostexGhosttySurfaceView, Any, NSRange) -> Void)?
   @Published private(set) var title = ""
+  @Published var pwd: String?
   @Published private(set) var bell = false
   var onScrollbarChange: (() -> Void)?
   @Published var searchState: GhostexGhosttySearchState? {

--- a/native/macos/ghostexHost/Sources/ghostexHost/TerminalWorkspaceView.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/TerminalWorkspaceView.swift
@@ -6941,7 +6941,7 @@ final class TerminalWorkspaceView: NSView {
            the titlebar or project-header editor button is clicked; keep the
            pane in ghostex's project-scoped startup error state instead.
            */
-          let message = "VS Code did not finish loading within 10 seconds."
+          let message = "VS Code did not finish loading within 10 seconds. Make sure Accessibility is enabled in System Settings \u{2192} Privacy & Security \u{2192} Accessibility."
           session.hostView.setInitialLoadingOverlayError(message, reason: reason)
           self.sendEvent(
             .projectEditorLoadState(

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -412,6 +412,7 @@ type NativeHostCommand =
       activeProjectEditorIsSleeping?: boolean;
 	      activeProjectEditorStatus?: ProjectEditorLoadStatus;
 	      activeProjectId?: string;
+      activeProjectIsChat?: boolean;
       activeProjectIconDataUrl?: string;
       activeProjectName?: string;
       activeProjectPath?: string;
@@ -21886,6 +21887,7 @@ function syncNativeLayout(options: { force?: boolean } = {}): void {
     appTitle: nativeAppTitleForProject(currentProject),
     debuggingMode: settings.debuggingMode,
     activeProjectId: currentProject.projectId,
+    activeProjectIsChat: currentProject.isChat === true,
     activeProjectIconDataUrl: resolveWorkspaceProjectIconDataUrl(currentProject),
     activeProjectEditorId:
       currentProjectEditorSurfaceState?.isOpen === true &&

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -19399,7 +19399,7 @@ function projectEditorErrorMessageForMode(mode: ProjectEditorSurfaceMode): strin
   if (mode === "tasks") {
     return "Project did not finish loading within 10 seconds.";
   }
-  return "VS Code did not finish loading within 10 seconds.";
+  return "VS Code did not finish loading within 10 seconds. Make sure Accessibility is enabled in System Settings \u2192 Privacy & Security \u2192 Accessibility.";
 }
 
 function projectEditorLoadFailureMessageForMode(mode: ProjectEditorSurfaceMode): string {
@@ -19409,7 +19409,7 @@ function projectEditorLoadFailureMessageForMode(mode: ProjectEditorSurfaceMode):
   if (mode === "tasks") {
     return "Project failed to load.";
   }
-  return "VS Code failed to load.";
+  return "VS Code failed to load. Make sure Accessibility is enabled in System Settings \u2192 Privacy & Security \u2192 Accessibility.";
 }
 
 function projectEditorSurfaceTitleForMode(

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -18119,6 +18119,117 @@ async function createNativePluginsBrowserChat(): Promise<void> {
   createNativeBrowserSession(PLUGINS_BROWSER_CHAT_URL);
 }
 
+/**
+ * CDXC:ChatPromotion 2026-05-26-18:30
+ * When a terminal's working directory changes and the session belongs to a
+ * chat workspace, check whether the new CWD is inside a git repository. If
+ * it is, promote the chat into a proper project workspace so the Code, Git,
+ * and Project tabs become functional.
+ *
+ * If a project already exists for the detected repository root, the chat's
+ * terminal sessions are migrated into the existing project and the empty chat
+ * workspace is removed.
+ */
+async function handleTerminalCwdChanged(
+  sidebarSessionId: string,
+  cwd: string,
+): Promise<void> {
+  const reference = resolveSidebarSessionReference(sidebarSessionId);
+  const project = reference.project;
+
+  // Only promote chats — proper projects already have their path set.
+  if (project.isChat !== true) {
+    return;
+  }
+
+  const normalizedCwd = cwd.replace(/\/+$/, "");
+  if (!normalizedCwd) {
+    return;
+  }
+
+  // Check if the CWD is inside a git repository.
+  let repoRoot: string;
+  try {
+    const result = await runNativeProcess("/usr/bin/env", ["git", "rev-parse", "--show-toplevel"], {
+      cwd: normalizedCwd,
+    });
+    if (result.exitCode !== 0) {
+      return;
+    }
+    repoRoot = result.stdout.trim().replace(/\/+$/, "");
+    if (!repoRoot) {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  // Check whether a non-chat project already exists for this repo root.
+  const repoProjectId = createProjectId(repoRoot);
+  const existingProject = projects.find(
+    (candidate) =>
+      candidate.projectId === repoProjectId &&
+      candidate.isChat !== true &&
+      candidate.projectId !== project.projectId,
+  );
+
+  if (existingProject) {
+    // A project for this repo already exists — migrate all chat sessions into
+    // its first group, transfer their native id mappings, then remove the
+    // empty chat workspace without closing terminal surfaces.
+    const targetGroup = existingProject.workspace.groups[0];
+    if (!targetGroup) {
+      return;
+    }
+    for (const group of project.workspace.groups) {
+      for (const session of group.snapshot.sessions) {
+        targetGroup.snapshot = {
+          ...targetGroup.snapshot,
+          sessions: [...targetGroup.snapshot.sessions, session],
+        };
+        // Re-map the native session id from the chat's projectId prefix to the
+        // existing project's projectId prefix so native focus/close events
+        // continue to resolve correctly.
+        const oldNativeSessionId = nativeSessionIdBySidebarSessionId.get(session.sessionId);
+        if (oldNativeSessionId) {
+          sidebarSessionIdByNativeSessionId.delete(oldNativeSessionId);
+          nativeSessionIdBySidebarSessionId.delete(session.sessionId);
+          rememberNativeSessionMapping(existingProject.projectId, session.sessionId);
+        }
+      }
+    }
+    // Remove the chat from the projects list without closing its terminals.
+    disposeProjectEditorSurface(project.projectId);
+    projects = projects.filter((candidate) => candidate.projectId !== project.projectId);
+    removeProjectCommandsState(project.projectId);
+    writeStoredProjects("chatPromotionMigrateToExisting");
+    focusProject(existingProject.projectId);
+  } else {
+    // Promote the chat in-place. Keep the existing projectId so native session
+    // id mappings (which use projectId as a prefix) stay valid. Only update
+    // the display name, path, and isChat flag.
+    const repoName = projectNameFromPath(repoRoot);
+    projects = projects.map((candidate) =>
+      candidate.projectId === project.projectId
+        ? {
+            ...candidate,
+            isChat: false,
+            name: repoName,
+            path: repoRoot,
+          }
+        : candidate,
+    );
+    projects = orderNativeProjectsForSidebar(projects);
+    ensureProjectCommandsState(resolveNativeProjectCommandsOwnerId(project.projectId));
+    writeProjectCommandsStore();
+    writeStoredProjects("chatPromotionInPlace");
+    void refreshGitState();
+    void refreshProjectDiffStats(project.projectId);
+  }
+
+  publish();
+}
+
 async function openAgentsHubFileInDefaultEditor(filePath: string): Promise<void> {
   /**
    * CDXC:AgentsHub 2026-05-12-09:24
@@ -22398,6 +22509,13 @@ window.addEventListener("ghostex-native-host-event", (event) => {
   if (hostEvent.type === "sessionAttentionNotificationClicked") {
     handleNativeSessionAttentionNotificationClicked(
       sidebarSessionIdForNativeSession(hostEvent.sessionId),
+    );
+    return;
+  }
+  if (hostEvent.type === "terminalCwdChanged") {
+    void handleTerminalCwdChanged(
+      sidebarSessionIdForNativeSession(hostEvent.sessionId),
+      hostEvent.cwd,
     );
     return;
   }

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -18142,6 +18142,11 @@ async function handleTerminalCwdChanged(
     return;
   }
 
+  // Respect the settings toggle.
+  if (!settings.autoPromoteChatToProject) {
+    return;
+  }
+
   const normalizedCwd = cwd.replace(/\/+$/, "");
   if (!normalizedCwd) {
     return;

--- a/native/sidebar/titlebar-host.tsx
+++ b/native/sidebar/titlebar-host.tsx
@@ -153,6 +153,7 @@ type TitlebarProjectState = {
   editorIsSleeping: boolean;
   editorStatus: ProjectEditorLoadStatus;
   git: SidebarGitState;
+  isChat?: boolean;
   projectEditorCompanionPaneHidden: boolean;
   projectIconDataUrl?: string | null;
   projectId?: string;
@@ -1093,6 +1094,7 @@ function App() {
           debuggingMode: state.debuggingMode ?? current.debuggingMode,
           diffStats: state.diffStats ?? current.diffStats,
           git: state.git ?? current.git,
+          isChat: state.isChat ?? current.isChat,
           browserTabs: state.browserTabs ?? current.browserTabs,
           projectEditorCompanionPaneHidden:
             state.projectEditorCompanionPaneHidden ?? current.projectEditorCompanionPaneHidden,
@@ -1435,12 +1437,14 @@ function App() {
                    * startup errors belong in the editor page instead of this
                    * segmented-control button.
                    */
+                  disabled: projectState.isChat === true,
                   icon: <IconCode aria-hidden="true" size={14} stroke={1.8} />,
                   label: "Code",
                   onSelect: openCodeMode,
                   value: "code",
                 },
                 {
+                  disabled: projectState.isChat === true,
                   icon: <IconBrandGithub aria-hidden="true" size={14} stroke={1.8} />,
                   label: "Git",
                   onSelect: openGitMode,
@@ -1453,6 +1457,7 @@ function App() {
                    * its coming-soon surface is a broader project workspace for
                    * automations, todos, docs, and more.
                    */
+                  disabled: projectState.isChat === true,
                   icon: <IconChecklist aria-hidden="true" size={14} stroke={1.8} />,
                   label: "Project",
                   onSelect: openTasksMode,
@@ -2363,6 +2368,7 @@ function TitlebarModeSwitcher({
 }: {
   activeMode: TitlebarMode;
   modes: Array<{
+    disabled?: boolean;
     icon: ReactNode;
     label: string;
     meta?: ReactNode;
@@ -2405,13 +2411,16 @@ function TitlebarModeSwitcher({
       */}
       {modes.map((mode) => {
         const isActive = mode.value === activeMode;
+        const isDisabled = mode.disabled === true && !isActive;
         return (
           <button
             aria-selected={isActive}
             className="titlebar-mode-tab"
             data-active={String(isActive)}
+            data-disabled={isDisabled ? "true" : undefined}
+            disabled={isDisabled}
             key={mode.value}
-            onClick={mode.onSelect}
+            onClick={isDisabled ? undefined : mode.onSelect}
             role="tab"
             style={{ transformStyle: "preserve-3d" }}
             type="button"
@@ -2827,6 +2836,12 @@ styleElement.textContent = `
   .titlebar-mode-tab:focus-visible {
     color: rgba(255,255,255,0.92);
     outline: none;
+  }
+  .titlebar-mode-tab[data-disabled="true"],
+  .titlebar-mode-tab:disabled {
+    color: rgba(255,255,255,0.25);
+    cursor: default;
+    pointer-events: none;
   }
   .titlebar-mode-tab[data-active="true"] {
     color: rgba(255,255,255,0.98);

--- a/native/sidebar/titlebar-host.tsx
+++ b/native/sidebar/titlebar-host.tsx
@@ -1436,6 +1436,10 @@ function App() {
                    * diff stats moved to the sidebar project row, and editor
                    * startup errors belong in the editor page instead of this
                    * segmented-control button.
+                   *
+                   * CDXC:ChatPromotion 2026-05-26-19:00:
+                   * Code mode requires a real project path for code-server.
+                   * Disable the tab when the workspace is a chat.
                    */
                   disabled: projectState.isChat === true,
                   icon: <IconCode aria-hidden="true" size={14} stroke={1.8} />,
@@ -1444,7 +1448,16 @@ function App() {
                   value: "code",
                 },
                 {
-                  disabled: projectState.isChat === true,
+                  /**
+                   * CDXC:ChatPromotion 2026-05-26-19:00:
+                   * Git mode requires a git repo with a GitHub origin remote.
+                   * Disable the tab when there is no repo or when the remote
+                   * is not a GitHub URL.
+                   */
+                  disabled:
+                    projectState.isChat === true ||
+                    !projectState.git.isRepo ||
+                    !projectState.git.hasOriginRemote,
                   icon: <IconBrandGithub aria-hidden="true" size={14} stroke={1.8} />,
                   label: "Git",
                   onSelect: openGitMode,

--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -79,6 +79,13 @@ const MAX_GHOSTTY_SCROLLBACK_LIMIT_MB = 200;
 export type ghostexSettings = {
   actionCompletionSound: CompletionSoundSetting;
   /**
+   * CDXC:ChatPromotion 2026-05-26-18:30:
+   * When enabled, chat workspaces auto-promote to proper projects when the
+   * terminal navigates into a git repository. Disabling keeps chats as
+   * standalone workspaces regardless of terminal CWD.
+   */
+  autoPromoteChatToProject: boolean;
+  /**
    * CDXC:SidebarAgents 2026-05-19-10:05:
    * When enabled, built-in and custom agent launches inherit Accept All mode and
    * append each CLI's permission-bypass flag at runtime unless a specific agent
@@ -225,6 +232,7 @@ export const SIDEBAR_SETTINGS_PRESETS: ReadonlyArray<{
  */
 export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
   actionCompletionSound: "shamisenreverb",
+  autoPromoteChatToProject: true,
   agentAcceptAllEnabled: false,
   agentManagerZoomPercent: DEFAULT_AGENT_MANAGER_ZOOM_PERCENT,
   /**
@@ -648,6 +656,11 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
   return {
     actionCompletionSound: clampCompletionSoundSetting(
       readString(source, "actionCompletionSound", DEFAULT_ghostex_SETTINGS.actionCompletionSound),
+    ),
+    autoPromoteChatToProject: readBoolean(
+      source,
+      "autoPromoteChatToProject",
+      DEFAULT_ghostex_SETTINGS.autoPromoteChatToProject,
     ),
     agentAcceptAllEnabled: readBoolean(
       source,

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -982,6 +982,11 @@ export function SettingsModal({
     ]),
     workspace: getSettingsSectionSearch(settingsSearchQuery, "Workspace", [
       {
+        key: "autoPromoteChatToProject",
+        subtitle: "Auto-promote chats to projects when terminal enters a git repo.",
+        title: "Auto-promote chats to projects",
+      },
+      {
         key: "workspacePaneGap",
         subtitle: "Control spacing between panes.",
         title: "Pane Gap",
@@ -1651,6 +1656,15 @@ export function SettingsModal({
 
             {mainSectionVisible("workspace", settingsSearch.workspace) ? (
             <SettingsSection sectionRef={workspaceSectionRef} title="Workspace">
+              {mainSettingVisible(settingsSearch.workspace, "autoPromoteChatToProject") ? (
+              <ToggleField
+                checked={draft.autoPromoteChatToProject}
+                description="Auto-promote chats to projects when terminal enters a git repo."
+                label="Auto-promote chats to projects"
+                {...getSettingModificationProps("autoPromoteChatToProject")}
+                onChange={(checked) => updateDraft("autoPromoteChatToProject", checked)}
+              />
+              ) : null}
               {mainSettingVisible(settingsSearch.workspace, "workspacePaneGap") ? (
               <SliderNumberField
                 description="Control spacing between panes."


### PR DESCRIPTION
## What

This PR fixes several interconnected issues with chat workspaces, project detection, and titlebar mode tabs (Code/Git/Project):

1. **Auto-promote chats to projects** — When a terminal in a chat workspace `cd`s into a git repository, the chat automatically becomes a proper project workspace. Code, Git, and Project tabs become functional immediately.

2. **Ongoing CWD monitoring** — The native Swift side was sending `terminalCwdChanged` only once at terminal creation. Now it observes Ghostty's `GHOSTTY_ACTION_PWD` callback and emits the event on every working directory change via OSC 7.

3. **Disable unusable titlebar tabs** — Code, Git, and Project tabs are grayed out and unclickable when they cannot function:
   - **Code** — disabled for chat workspaces (no project path for code-server)
   - **Git** — disabled for chats, non-git projects, or projects without a GitHub origin remote
   - **Project** — disabled for chat workspaces

4. **Settings toggle** — "Auto-promote chats to projects" in Settings → Workspace (default: on). Users who prefer ephemeral chat workspaces can disable it.

5. **Better VS Code error message** — The timeout error now says "Make sure Accessibility is enabled in System Settings → Privacy & Security → Accessibility" instead of a generic failure message.

6. **Fix Swift type-checker timeouts** — Two pre-existing Swift compiler errors on newer Xcode versions fixed by breaking up complex array/dictionary literals.

## Why

- Chat workspaces landed users in throwaway `~/ghostex/chats/<timestamp>` directories with no way to use Code/Git/Project tabs
- The `terminalCwdChanged` event type was declared in the sidebar but never handled — native sent it once at creation and `GHOSTTY_ACTION_PWD` was silently ignored
- Clicking Code/Git/Project on a chat showed confusing errors or silent failures instead of being visibly disabled
- The VS Code load failure gave no hint about the most common macOS cause (Accessibility permission)

## How

### Chat-to-project promotion (`native-sidebar.tsx`)
- Wired up `terminalCwdChanged` in the event handler
- `handleTerminalCwdChanged()` runs `git rev-parse --show-toplevel` against the new CWD
- **In-place promotion**: if no project exists for the repo root, updates the chat's `name`, `path`, clears `isChat`, keeps the same `projectId` so native session ID mappings stay valid
- **Migration**: if a project already exists, moves all sessions to the existing project, remaps native↔sidebar session IDs, removes the empty chat without closing terminals

### Native CWD monitoring (`TerminalWorkspaceView.swift`)
- `GHOSTTY_ACTION_PWD` now extracts the pwd and sets `surfaceView.pwd`
- Added `@Published var pwd: String?` to `GhostexGhosttySurfaceView`
- Combine `$pwd` subscription emits `terminalCwdChanged` on every change

### Titlebar tab states (`titlebar-host.tsx`)
- Added `disabled` prop to mode switcher tabs with `data-disabled` styling (25% opacity, `pointer-events: none`)
- `isChat` piped from sidebar → native (`HostProtocol.swift`, `AppDelegate.swift`) → titlebar
- Git tab also checks `git.isRepo` and `git.hasOriginRemote`

### Settings (`ghostex-settings.ts`, `settings-modal.tsx`)
- `autoPromoteChatToProject: boolean` (default `true`) added to settings type, defaults, normalization, and Workspace section UI

## Testing

1. Create a new chat → terminal lands in `~/ghostex/chats/...`
2. Code/Git/Project tabs should be grayed out
3. `cd` into any git repo → chat auto-promotes to project, tabs become active
4. Open a project with no git → Git tab should be grayed out
5. Settings → Workspace → toggle "Auto-promote chats to projects" off → chats stay as chats
6. Click Code on a project without code-server → error message mentions Accessibility

## Commits

| Commit | Description |
|--------|-------------|
| `b8e61e7` | Sidebar: handle `terminalCwdChanged`, detect git repos, promote chats |
| `ee7708d` | Native: wire `GHOSTTY_ACTION_PWD` → `$pwd` → `terminalCwdChanged` events, fix Swift type-checker |
| `17b0e56` | Settings: add auto-promote toggle |
| `e0a8fa7` | Titlebar: disable Code/Git/Project tabs for chats, pipe `isChat` through native |
| `7707f7a` | Titlebar: disable Git tab for non-git projects, improve VS Code error message |