### PR TITLE
Fix Ghostex Homebrew macOS dependency syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,7 @@
 
 ## 3.22.0 - 2026-05-29
 
-- Fixed Homebrew installs on newer macOS releases by keeping the Ghostex cask minimum requirement at macOS Ventura (`>= :ventura`) instead of an exact Ventura match that blocked installation on later systems.
+- Fixed Homebrew installs on newer macOS releases by keeping the Ghostex cask minimum requirement at macOS Ventura.
 - Improved the titlebar update button tooltip so it opens to the side and no longer sits under the promoted sidebar layer.
 
 ## 3.21.0 - 2026-05-29

--- a/docs/dual-arch-macos-release-handover.md
+++ b/docs/dual-arch-macos-release-handover.md
@@ -384,7 +384,7 @@ cask "ghostex" do
   desc "Workspace and session UI for agent terminals"
   homepage "https://github.com/maddada/ghostex"
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "ghostex.app"
   binary "#{appdir}/ghostex.app/Contents/Resources/CLI/ghostex"

--- a/docs/product/AllFeatures.md
+++ b/docs/product/AllFeatures.md
@@ -109,7 +109,7 @@
 - macOS workspace chrome no longer exposes Pane Gap; native panes default to zero spacing with flush tab bars, square status indicators, and workarea separators.
 - Sidebar and project-header tooltips open below their triggers with a consistent square bordered surface.
 - Native Sparkle updates for macOS releases.
-- Homebrew installs require macOS Ventura or newer with explicit `>= :ventura` cask syntax so newer macOS releases are not blocked by an exact Ventura match.
+- Homebrew installs require macOS Ventura or newer.
 - Cursor Agent can generate session titles, Git prompts, worktree prompts, and Project board ticket titles when it is the selected prompt agent.
 - Project header actions use portaled sidebar tooltips that stay visible inside narrow native webviews.
 - Session attention and working updates refresh native pane chrome without disturbing terminal keyboard focus or broad layout sync.

--- a/scripts/release-ghostex.mjs
+++ b/scripts/release-ghostex.mjs
@@ -1445,21 +1445,17 @@ async function updateHomebrew(version, artifacts, options) {
    generator inserts the gx preflight block. Auto-fix those before the strict
    style check so a successful GitHub release is not blocked by formatting.
 
-   CDXC:ReleaseAutomation 2026-05-29-20:59:
-   Preserve explicit `depends_on macos: ">= :ventura"` syntax for older
-   Homebrew clients that can treat the symbol shorthand as exact Ventura.
-
    CDXC:HomebrewRelease 2026-06-10-09:47:
    Homebrew's API install path can fail on macOS beta host identifiers before it
    reads the freshly pushed tap cask. Disable install-from-API for style/info/fetch
    validation and treat unrelated brew update failures as non-blocking once the
    Ghostex cask validates directly.
    */
-  await run(`HOMEBREW_NO_INSTALL_FROM_API=1 brew style --fix --except-cops Homebrew/OSDependsOn ${shellQuote(config.caskPath)}`, { cwd: tapDir });
-  await run(`HOMEBREW_NO_INSTALL_FROM_API=1 brew style --except-cops Homebrew/OSDependsOn ${shellQuote(config.caskPath)}`, { cwd: tapDir });
+  await run(`HOMEBREW_NO_INSTALL_FROM_API=1 brew style --fix ${shellQuote(config.caskPath)}`, { cwd: tapDir });
+  await run(`HOMEBREW_NO_INSTALL_FROM_API=1 brew style ${shellQuote(config.caskPath)}`, { cwd: tapDir });
   cask = await readFile(caskFile, "utf8");
-  if (!cask.includes('depends_on macos: ">= :ventura"')) {
-    throw new ReleaseError("Ghostex cask must require macOS Ventura or newer with explicit >= syntax.");
+  if (!cask.includes("depends_on macos: :ventura")) {
+    throw new ReleaseError("Ghostex cask must require macOS Ventura or newer.");
   }
   if (!cask.includes("depends_on arch: :arm64")) {
     throw new ReleaseError("Ghostex cask must be arm64-only for future macOS releases.");
@@ -1489,7 +1485,7 @@ async function updateHomebrew(version, artifacts, options) {
       `sha256 "${arm.sha256}"`,
       'url "https://github.com/maddada/Ghostex/releases/download/v#{version}/ghostex-#{version}-arm64.dmg"',
       "depends_on arch: :arm64",
-      'depends_on macos: ">= :ventura"',
+      "depends_on macos: :ventura",
     ]) {
       if (!liveCask.includes(required)) {
         throw new ReleaseError(`Live Homebrew cask is missing required stanza: ${required}`);
@@ -1514,9 +1510,8 @@ async function updateHomebrew(version, artifacts, options) {
  *
  * CDXC:MacRelease 2026-05-29-20:59:
  * The cask must require macOS Ventura as a minimum floor, matching the Sparkle
- * 13.0 appcast requirement. Keep the explicit string form because older
- * Homebrew clients can parse the symbol shorthand as exact Ventura and block
- * newer macOS releases such as 26.x before Homebrew can install Ghostex.
+ * 13.0 appcast requirement. Use Homebrew's symbolic macOS syntax so tap and
+ * install do not emit deprecated string-comparison warnings.
  *
  * CDXC:CliInstall 2026-06-07-13:53:
  * CLI resources now live under Contents/Resources/CLI. Normalize both old
@@ -1556,7 +1551,7 @@ function normalizeGhostexCliCask(cask) {
       /\n  # CDXC:CliBranding 2026-05-26-15:11: Install gx only when another tool does not already own that command name\.\n(?:  # CDXC:CliInstall 2026-06-07-13:53: Homebrew links the app-owned CLI from(?: Contents\/Resources\/CLI, matching direct DMG auto-linking\.|(?:\n  # Contents\/Resources\/CLI, matching direct DMG auto-linking\.))\n)?  preflight do[\s\S]*?\n  end(?=\n\n  zap trash:|\n  binary "#\{appdir\}\/ghostex\.app\/Contents\/Resources\/(?:Web\/cli|CLI)\/gx")/g,
       "",
     )
-    .replace(/^  depends_on macos: :ventura$/m, '  depends_on macos: ">= :ventura"')
+    .replace(/^  depends_on macos: ">= :ventura"$/m, "  depends_on macos: :ventura")
     .replace(/^  binary "#\{appdir\}\/ghostex\.app\/Contents\/Resources\/Web\/cli\/gtx"\n/gm, "")
     .replace(/^  binary "#\{appdir\}\/ghostex\.app\/Contents\/Resources\/Web\/cli\/gx"\n/gm, "")
     .replace(/^  binary "#\{appdir\}\/ghostex\.app\/Contents\/Resources\/CLI\/gx"\n/gm, "");
@@ -1579,8 +1574,8 @@ function normalizeGhostexCliCask(cask) {
   if (!next.includes(gxBinary) || next.includes("/Resources/Web/cli")) {
     throw new ReleaseError("Failed to normalize Ghostex cask CLI binary aliases.");
   }
-  if (!next.includes('depends_on macos: ">= :ventura"')) {
-    throw new ReleaseError("Ghostex cask must require macOS Ventura or newer with explicit >= syntax.");
+  if (!next.includes("depends_on macos: :ventura")) {
+    throw new ReleaseError("Ghostex cask must require macOS Ventura or newer.");
   }
   return next;
 }
@@ -1592,8 +1587,8 @@ function normalizeArm64OnlyCask(cask) {
 
   if (!next.includes("  depends_on arch: :arm64\n")) {
     next = next.replace(
-      /^  depends_on macos: ">= :ventura"\n/m,
-      '  depends_on arch: :arm64\n  depends_on macos: ">= :ventura"\n',
+      /^  depends_on macos: :ventura\n/m,
+      "  depends_on arch: :arm64\n  depends_on macos: :ventura\n",
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #15.

Updates Ghostex release automation and docs to use Homebrew's supported symbolic macOS cask dependency syntax:

```ruby
depends_on macos: :ventura
```

This keeps generated Ghostex casks aligned with the public tap fix and prevents future releases from reintroducing deprecated string-comparison warnings from:

```ruby
depends_on macos: ">= :ventura"
```

## Changes

- Remove the `Homebrew/OSDependsOn` style exception from Homebrew release validation.
- Require `depends_on macos: :ventura` in generated and live Ghostex cask checks.
- Normalize older casks forward from `depends_on macos: ">= :ventura"` to `depends_on macos: :ventura`.
- Update release handover, product docs, and changelog wording so they no longer recommend the deprecated syntax.

## Validation

```sh
node --check scripts/release-ghostex.mjs
rg -n 'depends_on macos: ">= :|OSDependsOn|explicit `?>=|symbol shorthand|exact Ventura|string comparison format' scripts/release-ghostex.mjs docs CHANGELOG.md
```

The remaining `">= :ventura"` occurrence is the migration normalizer that converts old casks to the supported symbolic form.