### PR TITLE
Fix CLI TDZ crash when commands throw before module evaluation completes

### DIFF
--- a/scripts/ghostex-cli.mjs
+++ b/scripts/ghostex-cli.mjs
@@ -235,6 +235,16 @@ function isDirectCliEntryPoint() {
 }
 
 async function main() {
+  /**
+   * CDXC:CliModuleInitOrder 2026-06-12-13:45:
+   * main() is invoked from the top-level entrypoint block above, which runs
+   * mid-module-evaluation. Command paths that throw synchronously (for example
+   * sendGxserverCliAction's GxserverCliUnsupportedError default) hit the
+   * temporal dead zone for classes declared later in this file and crash with
+   * "Cannot access ... before initialization". Defer one macrotask so command
+   * dispatch always starts after the whole module has evaluated.
+   */
+  await new Promise((resolve) => setImmediate(resolve));
   const argv = process.argv.slice(2);
   /**
    * CDXC:GhostexTui 2026-05-24-19:18:


### PR DESCRIPTION
## Problem

Several `gx`/`ghostex` commands crash with:

```
Cannot access 'GxserverCliUnsupportedError' before initialization
```

Repro: `gx wait-for foo --timeout-ms 1000`, `gx assert-card foo`, `gx automation-state --path .`, `gx edit file.md`, `gx send-key <sel> ctrl-c`.

## Cause

`main()` is invoked from the top-level entrypoint block early in `scripts/ghostex-cli.mjs` (around line 205), while the rest of the module is still evaluating. Async function bodies run synchronously until their first `await`, so any command path that throws synchronously — e.g. `sendGxserverCliAction`'s `default: throw new GxserverCliUnsupportedError(action)` — executes before the error classes declared around line 1496 are initialized, hitting the temporal dead zone. The intended "requires a gxserver API endpoint" message is masked by the TDZ crash.

## Fix

Defer one macrotask at the top of `main()` (`await new Promise((resolve) => setImmediate(resolve))`) so command dispatch always starts after the whole module has evaluated. Same idiom already used in `browserDevToolsMcpCommand`.

## Verification

Before: the commands above crash with the TDZ error.
After: they fail with the intended `GxserverCliUnsupportedError` message and `gx sessions` / `gx state` / `gx read-text` keep working.

Tested by running `node scripts/ghostex-cli.mjs <cmd>` directly against a live gxserver on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)