### PR TITLE
fix(sidebar): prevent section header action overlap

### DIFF
--- a/sidebar/sidebar-app.tsx
+++ b/sidebar/sidebar-app.tsx
@@ -5007,7 +5007,7 @@ function SidebarReferenceSectionHeader({
         onClick={onToggleCollapsed}
         type="button"
       >
-        <span>{title}</span>
+        <span className="reference-sidebar-section-title">{title}</span>
         <IconCaretRightFilled
           aria-hidden="true"
           className="reference-sidebar-section-chevron"

--- a/sidebar/sidebar-section-header-layout-source.test.ts
+++ b/sidebar/sidebar-section-header-layout-source.test.ts
@@ -20,7 +20,9 @@ describe("reference sidebar section header layout source", () => {
      * painting underneath their hover action buttons in the narrow native
      * sidebar.
      */
-    expect(sidebarAppSource).toContain('<span className="reference-sidebar-section-title">{title}</span>');
+    expect(sidebarAppSource).toMatch(
+      /<span\s+className="reference-sidebar-section-title">\s*\{title\}\s*<\/span>/u,
+    );
 
     const sectionRowRule = sourceBetween(
       groupPanelsSource,
@@ -43,7 +45,7 @@ describe("reference sidebar section header layout source", () => {
     const hiddenActionsRule = sourceBetween(
       groupPanelsSource,
       ".reference-sidebar-section-actions {",
-      ".sidebar-reference-layout[data-reference-sidebar=\"true\"]\n  .reference-sidebar-section-actions",
+      ".sidebar-reference-layout[data-reference-sidebar=\"true\"]",
     );
     expect(hiddenActionsRule).toContain("max-width: 0;");
     expect(hiddenActionsRule).toContain("overflow: hidden;");
@@ -51,7 +53,7 @@ describe("reference sidebar section header layout source", () => {
     const visibleActionsRule = sourceBetween(
       groupPanelsSource,
       ".reference-sidebar-section-row:hover .reference-sidebar-section-actions,",
-      "\n\n.reference-sidebar-section-action {",
+      ".reference-sidebar-section-action {",
     );
     expect(visibleActionsRule).toContain(
       "max-width: var(--reference-sidebar-section-actions-max-width);",

--- a/sidebar/sidebar-section-header-layout-source.test.ts
+++ b/sidebar/sidebar-section-header-layout-source.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+const sidebarAppSource = readFileSync(new URL("./sidebar-app.tsx", import.meta.url), "utf8");
+const groupPanelsSource = readFileSync(new URL("./styles/group-panels.css", import.meta.url), "utf8");
+
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+describe("reference sidebar section header layout source", () => {
+  test("collapses Quick and Projects labels when hover actions become visible", () => {
+    /*
+     * CDXC:SidebarHeaderActions 2026-06-17-23:21:
+     * Quick and Projects section labels should shorten like Search instead of
+     * painting underneath their hover action buttons in the narrow native
+     * sidebar.
+     */
+    expect(sidebarAppSource).toContain('<span className="reference-sidebar-section-title">{title}</span>');
+
+    const sectionRowRule = sourceBetween(
+      groupPanelsSource,
+      ".reference-sidebar-section-row {",
+      ".reference-sidebar-section-row[data-reference-section=\"projects\"]",
+    );
+    expect(sectionRowRule).toContain("--reference-sidebar-section-actions-max-width: 132px;");
+    expect(sectionRowRule).toContain("CDXC:SidebarHeaderActions 2026-06-17-23:21");
+
+    const titleRule = sourceBetween(
+      groupPanelsSource,
+      ".reference-sidebar-section-title {",
+      ".reference-sidebar-section-chevron",
+    );
+    expect(titleRule).toContain("min-width: 0;");
+    expect(titleRule).toContain("overflow: hidden;");
+    expect(titleRule).toContain("text-overflow: ellipsis;");
+    expect(titleRule).toContain("white-space: nowrap;");
+
+    const hiddenActionsRule = sourceBetween(
+      groupPanelsSource,
+      ".reference-sidebar-section-actions {",
+      ".sidebar-reference-layout[data-reference-sidebar=\"true\"]\n  .reference-sidebar-section-actions",
+    );
+    expect(hiddenActionsRule).toContain("max-width: 0;");
+    expect(hiddenActionsRule).toContain("overflow: hidden;");
+
+    const visibleActionsRule = sourceBetween(
+      groupPanelsSource,
+      ".reference-sidebar-section-row:hover .reference-sidebar-section-actions,",
+      "\n\n.reference-sidebar-section-action {",
+    );
+    expect(visibleActionsRule).toContain(
+      "max-width: var(--reference-sidebar-section-actions-max-width);",
+    );
+    expect(visibleActionsRule).toContain("overflow: visible;");
+  });
+});

--- a/sidebar/styles/group-panels.css
+++ b/sidebar/styles/group-panels.css
@@ -1529,6 +1529,7 @@ body[data-sidebar-tooltips-suppressed="true"] [data-slot="tooltip-content"] {
 }
 
 .reference-sidebar-section-row {
+  --reference-sidebar-section-actions-max-width: 132px;
   align-items: center;
   background: var(--app-background);
   box-sizing: border-box;
@@ -1558,6 +1559,12 @@ body[data-sidebar-tooltips-suppressed="true"] [data-slot="tooltip-content"] {
    * CDXC:SidebarReferenceBounds 2026-05-31-18:24:
    * Quick and Projects section header contents need another 7px of left inset
    * only, while the right-side spacing and full-width row surface stay fixed.
+   *
+   * CDXC:SidebarHeaderActions 2026-06-17-23:21:
+   * Quick and Projects labels must collapse like the Search row when hover
+   * actions appear. Keep the action buttons in normal flex layout, but remove
+   * their hidden-state width and let the title ellipsize once the visible
+   * action cluster needs room.
    */
 }
 
@@ -1820,6 +1827,13 @@ body[data-sidebar-tooltips-suppressed="true"] [data-slot="tooltip-content"] {
   outline: none;
 }
 
+.reference-sidebar-section-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .reference-sidebar-section-chevron {
   color: #727982;
   flex: none;
@@ -1851,7 +1865,9 @@ body[data-sidebar-tooltips-suppressed="true"] [data-slot="tooltip-content"] {
   display: flex;
   flex: none;
   gap: 2px;
+  max-width: 0;
   opacity: 0;
+  overflow: hidden;
   pointer-events: none;
   transition: opacity 120ms ease;
 }
@@ -1875,7 +1891,9 @@ body[data-sidebar-tooltips-suppressed="true"] [data-slot="tooltip-content"] {
 .reference-sidebar-section-row:hover .reference-sidebar-section-actions,
 .reference-sidebar-section-row:focus-within .reference-sidebar-section-actions,
 .reference-sidebar-section-row[data-actions-always-visible="true"] .reference-sidebar-section-actions {
+  max-width: var(--reference-sidebar-section-actions-max-width);
   opacity: 1;
+  overflow: visible;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary

- Fixes Quick and Projects section headers so hover action buttons no longer cover the section label text.
- Adds a shrinkable section title span with ellipsis behavior, matching the Search row’s hover-action layout.
- Keeps the action buttons in normal flex layout and adds source-level regression coverage for the narrow-sidebar case.

## Context

In narrow sidebars, Quick and Projects labels could paint underneath their hover action clusters, hiding text like “uick” or “ects”. Search already avoids this by shortening the label when its hover actions appear. This applies the same behavior to section headers without adding overlays or hit-test routing.

## Testing

- `npx vitest run native/sidebar/native-pointer-hover-source.test.ts sidebar/sidebar-section-header-layout-source.test.ts`
- `git diff --check`
- Storybook served successfully at `http://localhost:6007/` and `/index.json` returned `200`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved reference sidebar section header title styling, including consistent ellipsis/truncation behavior.
  * Updated header action area behavior so action buttons smoothly reveal/hide using constrained width and overflow control.

* **Tests**
  * Added a new automated test suite to validate reference sidebar section header layout and styling across different states by checking expected CSS behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->