### PR TITLE
fix(native): start browser panes on initial URL

### DIFF
--- a/native/macos/ghostexHost/Sources/ghostexHost/GhostexCEFBridge.mm
+++ b/native/macos/ghostexHost/Sources/ghostexHost/GhostexCEFBridge.mm
@@ -1599,6 +1599,8 @@ static void GhostexCEFGrantTrustedClipboardContentSetting(CefRefPtr<CefRequestCo
   }
 
   client_ = new GhostexCEFBrowserClient(self);
+  NSString* creationURL = initialURL_.length > 0 ? initialURL_ : @"about:blank";
+  didGiveInitialURLToBrowserCreate_ = initialURL_.length > 0;
   bool runsUnderGPUI = NSApp && [NSStringFromClass([NSApp class]) isEqualToString:@"GPUIApplication"];
   if (runsUnderGPUI) {
     /*
@@ -1608,8 +1610,6 @@ static void GhostexCEFGrantTrustedClipboardContentSetting(CefRefPtr<CefRequestCo
     CDXC:GPUIPhase1 2026-06-14-13:15:
     Async GPUI browser creation must receive the intended initial URL directly. Creating about:blank first and loading from OnAfterCreated can lose the first navigation while Chromium is still finishing browser-info wiring, leaving the main browser target blank even though later address-bar navigation works.
     */
-    NSString* creationURL = initialURL_.length > 0 ? initialURL_ : @"about:blank";
-    didGiveInitialURLToBrowserCreate_ = initialURL_.length > 0;
     bool started = CefBrowserHost::CreateBrowser(
       windowInfo,
       client_,
@@ -1631,10 +1631,14 @@ static void GhostexCEFGrantTrustedClipboardContentSetting(CefRefPtr<CefRequestCo
     return;
   }
 
+  /*
+  CDXC:ChromiumBrowserPanes 2026-06-18-23:58:
+  Cmd+N browser panes in the normal app should start CEF on the requested page, not about:blank followed by a second LoadURL. Passing the initial URL into CreateBrowserSync removes one visible blank-render turn while preserving the GPUI async behavior above.
+  */
   browser_ = CefBrowserHost::CreateBrowserSync(
     windowInfo,
     client_,
-    CefString("about:blank"),
+    CefString([creationURL UTF8String]),
     browserSettings,
     nullptr,
     requestContext);
@@ -1657,7 +1661,7 @@ static void GhostexCEFGrantTrustedClipboardContentSetting(CefRefPtr<CefRequestCo
   [self setNeedsLayout:YES];
   [self ghostexCEFApplyPreferredColorSchemeIfPossible];
 
-  if (initialURL_.length > 0) {
+  if (initialURL_.length > 0 && !didGiveInitialURLToBrowserCreate_) {
     [self loadURLString:initialURL_];
   }
 }

--- a/native/sidebar/chromium-browser-source.test.ts
+++ b/native/sidebar/chromium-browser-source.test.ts
@@ -126,11 +126,14 @@ describe("chromium browser source", () => {
     expect(cefBridgeSource).not.toContain("[cefView_ scrollWheel:event]");
   });
 
-  test("creates async CEF browser panes with a real frame and the first URL", () => {
+  test("creates CEF browser panes with a real frame and the first URL", () => {
     /*
      * CDXC:ChromiumBrowserPanes 2026-06-15-23:10:
      * Cmd+N browser panes can appear as a black surface when async GPUI CEF creation starts before AppKit assigns a real child-view frame, or when the requested URL is replayed after Chromium is already bootstrapping the first navigation.
      * Keep the first browser load attached to CEF creation itself and guard creation until the wrapper has non-zero bounds so the rendered page and address bar are initialized from the same navigation.
+     *
+     * CDXC:ChromiumBrowserPanes 2026-06-18-23:58:
+     * The production CreateBrowserSync path needs the same first-URL behavior as GPUI async creation. Starting on about:blank and then calling LoadURL adds a visible blank render turn when Cmd+N opens a new browser pane.
      */
     const didCreateBrowserSource = sourceBetween(
       cefBridgeSource,
@@ -156,6 +159,8 @@ describe("chromium browser source", () => {
     expect(createBrowserSource).toContain("didGiveInitialURLToBrowserCreate_ = initialURL_.length > 0;");
     expect(createBrowserSource).toContain("CefBrowserHost::CreateBrowser(");
     expect(createBrowserSource).toContain("CefString([creationURL UTF8String])");
+    expect(createBrowserSource).toContain("CefBrowserHost::CreateBrowserSync(");
+    expect(createBrowserSource).not.toContain('CefString("about:blank")');
     expect(didCreateBrowserSource).toContain(
       "if (initialURL_.length > 0 && !didGiveInitialURLToBrowserCreate_)",
     );


### PR DESCRIPTION
## Summary

- Starts production CEF browser panes with the requested initial URL instead of creating about:blank and issuing a second LoadURL.
- Keeps the GPUI async first-URL behavior unchanged while sharing the initial URL selection with the normal sync creation path.
- Extends the existing Chromium browser source regression test to cover CreateBrowserSync.

## Context

Cmd+N browser panes already had a guard for zero-size CEF creation and GPUI async initial navigation, but the normal app path still created Chromium on about:blank before loading the requested URL. That extra initial navigation can leave a newly opened Browser pane showing a blank render turn before the real page starts.

Passing the URL directly into CreateBrowserSync starts the renderer on the intended page immediately and keeps the existing replay guard for paths that did not receive an initial URL.

## Testing

- npx vitest run native/sidebar/chromium-browser-source.test.ts
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-navigation issue during browser initialization, improving initial load performance and responsiveness
  * Optimized initial URL handling for more reliable first-page rendering

* **Tests**
  * Enhanced browser initialization tests to validate the corrected URL handling behavior and creation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->