### PR TITLE
feat: app icon picker in Settings (file picker + ~/.ghostex/icons drop-in folder)

### DIFF
--- a/native/macos/ghostexHost/Sources/Shared/AppIconImage.swift
+++ b/native/macos/ghostexHost/Sources/Shared/AppIconImage.swift
@@ -1,0 +1,327 @@
+// CDXC:AppIconPicker 2026-06-25-21:50: Self-contained app-icon image utility. It imports only system frameworks so it can compile standalone with swiftc and stay independent of AppDelegate, GhostexAppStorage, or any host bridge type. Callers pass directory URLs in; this file never reaches into shared app storage itself.
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/**
+ CDXC:AppIconPicker 2026-06-25-21:50:
+ AppIconImage validates, normalizes, and squircle-masks user PNGs for the macOS
+ Dock runtime icon (NSApp.applicationIconImage only; the Finder/bundle icon is
+ never touched). Every operation returns nil on any failure so the caller can
+ fall back to the default bundle icon. Privacy: this file logs nothing and never
+ surfaces absolute paths or raw image bytes; callers own privacy-safe logging.
+ */
+enum AppIconImage {
+  // CDXC:AppIconPicker 2026-06-25-21:50: Guardrails shared with the validate step and the folder scan.
+  static let maxFileBytes: Int = 5 * 1024 * 1024
+  static let maxSourceDimension: Int = 2048
+  // CDXC:AppIconPicker 2026-06-25-21:50: The masked Dock icon and cache are normalized to a fixed 1024x1024 square.
+  static let maskedDimension: Int = 1024
+  // CDXC:AppIconPicker 2026-06-25-21:50: Superellipse exponent for the macOS-style squircle. n=5 closely matches the Big Sur app-icon corner curve.
+  static let superellipseExponent: CGFloat = 5.0
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Validate a candidate PNG without decoding the full bitmap: enforce the file
+   byte budget, confirm a real PNG via magic bytes plus UTType, and read the
+   header dimensions from the CGImageSource so oversized images are rejected
+   before any pixel work. Returns true only for a safe square-or-not PNG within
+   guardrails.
+   */
+  static func isValidSourcePNG(at url: URL) -> Bool {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+      let fileSize = (attributes[.size] as? NSNumber)?.intValue,
+      fileSize > 0,
+      fileSize <= maxFileBytes
+    else {
+      return false
+    }
+    guard isPNGMagicBytes(at: url) else {
+      return false
+    }
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+      return false
+    }
+    // CDXC:AppIconPicker 2026-06-25-21:50: Reject anything whose decoded type is not PNG even if the extension/magic looked right.
+    guard let typeId = CGImageSourceGetType(source) as String?,
+      let decodedType = UTType(typeId),
+      decodedType.conforms(to: .png)
+    else {
+      return false
+    }
+    guard let header = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+      let width = header[kCGImagePropertyPixelWidth] as? Int,
+      let height = header[kCGImagePropertyPixelHeight] as? Int,
+      width > 0,
+      height > 0,
+      width <= maxSourceDimension,
+      height <= maxSourceDimension
+    else {
+      return false
+    }
+    return true
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Produce the masked 1024x1024 squircle PNG data for a validated source file:
+   downsample with the ImageIO thumbnail path, center-crop to square, then clip
+   to the superellipse. Returns nil on any failure so the caller can fall back.
+   */
+  static func maskedPNGData(forValidatedSource url: URL) -> Data? {
+    guard let downsampled = downsampledImage(at: url, maxPixelSize: maskedDimension) else {
+      return nil
+    }
+    guard let squared = centerCroppedSquare(downsampled) else {
+      return nil
+    }
+    guard let masked = squircleMasked(squared, dimension: maskedDimension) else {
+      return nil
+    }
+    return pngData(from: masked)
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Self-validating masked cache. The cache file name binds the source filename
+   and its content-modification time, so a stale cache for an edited file is
+   simply a cache miss. On a hit the cached masked PNG is validated as a real
+   PNG before reuse; on a miss the mask is regenerated and written. Returns the
+   masked CGImage, or nil so the caller falls back to the default icon.
+   */
+  static func cachedMaskedImage(
+    sourceId: String,
+    iconsDirectory: URL,
+    cacheDirectory: URL
+  ) -> CGImage? {
+    let sourceURL = iconsDirectory.appendingPathComponent(sourceId, isDirectory: false)
+    guard isValidSourcePNG(at: sourceURL) else {
+      return nil
+    }
+    let mtime = contentModificationEpoch(of: sourceURL)
+    let cacheURL = cacheDirectory.appendingPathComponent(
+      cacheFileName(sourceId: sourceId, mtimeEpoch: mtime), isDirectory: false)
+
+    if isPNGMagicBytes(at: cacheURL),
+      let cachedImage = cgImage(fromPNGFile: cacheURL)
+    {
+      return cachedImage
+    }
+
+    guard let maskedData = maskedPNGData(forValidatedSource: sourceURL) else {
+      return nil
+    }
+    try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    // CDXC:AppIconPicker 2026-06-25-21:50: Best-effort cache write; a failed write only forces regeneration next launch and must never block applying the icon.
+    try? maskedData.write(to: cacheURL, options: [.atomic])
+    return cgImage(fromPNGData: maskedData)
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Convenience for applying the Dock icon: returns a runtime NSImage built from
+   the cached masked square, or nil to signal a default-icon fallback. Setting
+   NSApp.applicationIconImage = nil restores the bundle icon and is the caller's
+   responsibility.
+   */
+  static func maskedDockImage(
+    sourceId: String,
+    iconsDirectory: URL,
+    cacheDirectory: URL
+  ) -> NSImage? {
+    guard let cgImage = cachedMaskedImage(
+      sourceId: sourceId, iconsDirectory: iconsDirectory, cacheDirectory: cacheDirectory)
+    else {
+      return nil
+    }
+    let size = NSSize(width: maskedDimension, height: maskedDimension)
+    return NSImage(cgImage: cgImage, size: size)
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Small masked thumbnail data URL for the sidebar picker list. The thumbnail is
+   derived from the same validate+square+squircle pipeline at a reduced size so
+   the list and the applied Dock icon look identical. Returns nil on failure.
+   */
+  static func maskedThumbnailDataURL(
+    forValidatedSource url: URL,
+    dimension: Int = 128
+  ) -> String? {
+    guard let downsampled = downsampledImage(at: url, maxPixelSize: dimension),
+      let squared = centerCroppedSquare(downsampled),
+      let masked = squircleMasked(squared, dimension: dimension),
+      let data = pngData(from: masked)
+    else {
+      return nil
+    }
+    return "data:image/png;base64,\(data.base64EncodedString())"
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Content-modification epoch (seconds) used to key the masked cache; 0 when unavailable so the cache simply regenerates.
+  static func contentModificationEpoch(of url: URL) -> Int {
+    let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+    return Int((values?.contentModificationDate ?? Date(timeIntervalSince1970: 0)).timeIntervalSince1970)
+  }
+
+  // MARK: - Internal pipeline
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Confirm the first eight bytes are the PNG signature before trusting any extension or decoder.
+  private static func isPNGMagicBytes(at url: URL) -> Bool {
+    guard let handle = try? FileHandle(forReadingFrom: url) else {
+      return false
+    }
+    defer { try? handle.close() }
+    guard let header = try? handle.read(upToCount: 8), header.count == 8 else {
+      return false
+    }
+    let signature: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    return Array(header) == signature
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Downsample using CGImageSourceCreateThumbnailAtIndex so large source PNGs are
+   decoded directly to the target size instead of holding a full-resolution
+   bitmap in memory.
+   */
+  private static func downsampledImage(at url: URL, maxPixelSize: Int) -> CGImage? {
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+      return nil
+    }
+    let options: [CFString: Any] = [
+      kCGImageSourceCreateThumbnailFromImageAlways: true,
+      kCGImageSourceCreateThumbnailWithTransform: true,
+      kCGImageSourceShouldCacheImmediately: true,
+      kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+    ]
+    return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Center-crop to the largest centered square so non-square PNGs are masked without distortion.
+  private static func centerCroppedSquare(_ image: CGImage) -> CGImage? {
+    let side = min(image.width, image.height)
+    guard side > 0 else {
+      return nil
+    }
+    if image.width == image.height {
+      return image
+    }
+    let originX = (image.width - side) / 2
+    let originY = (image.height - side) / 2
+    let cropRect = CGRect(x: originX, y: originY, width: side, height: side)
+    return image.cropping(to: cropRect)
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Clip the square image to a superellipse (n=5) squircle and render onto a
+   transparent square via an NSBitmapImageRep-backed context, producing the
+   masked CGImage. Builds the superellipse path with NSBezierPath.
+   */
+  private static func squircleMasked(_ image: CGImage, dimension: Int) -> CGImage? {
+    guard dimension > 0 else {
+      return nil
+    }
+    guard let bitmap = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: dimension,
+      pixelsHigh: dimension,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    ) else {
+      return nil
+    }
+
+    guard let context = NSGraphicsContext(bitmapImageRep: bitmap) else {
+      return nil
+    }
+    let previousContext = NSGraphicsContext.current
+    NSGraphicsContext.current = context
+    context.cgContext.clear(CGRect(x: 0, y: 0, width: dimension, height: dimension))
+
+    let rect = CGRect(x: 0, y: 0, width: dimension, height: dimension)
+    let path = superellipsePath(in: rect, exponent: superellipseExponent)
+    path.addClip()
+    context.cgContext.draw(image, in: rect)
+
+    context.flushGraphics()
+    NSGraphicsContext.current = previousContext
+
+    return bitmap.cgImage
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Build a superellipse |x|^n + |y|^n = 1 path inscribed in rect. n=5 gives the
+   rounded-square squircle used by macOS app icons. Sampled at fixed resolution
+   for a smooth outline.
+   */
+  private static func superellipsePath(in rect: CGRect, exponent: CGFloat) -> NSBezierPath {
+    let path = NSBezierPath()
+    let centerX = rect.midX
+    let centerY = rect.midY
+    let halfWidth = rect.width / 2.0
+    let halfHeight = rect.height / 2.0
+    let segments = 720
+    let inverseExponent = 1.0 / exponent
+
+    func point(forAngle theta: CGFloat) -> CGPoint {
+      let cosT = cos(theta)
+      let sinT = sin(theta)
+      let x = pow(abs(cosT), inverseExponent) * halfWidth * (cosT < 0 ? -1 : 1)
+      let y = pow(abs(sinT), inverseExponent) * halfHeight * (sinT < 0 ? -1 : 1)
+      return CGPoint(x: centerX + x, y: centerY + y)
+    }
+
+    for index in 0...segments {
+      let theta = (CGFloat(index) / CGFloat(segments)) * 2.0 * CGFloat.pi
+      let pt = point(forAngle: theta)
+      if index == 0 {
+        path.move(to: pt)
+      } else {
+        path.line(to: pt)
+      }
+    }
+    path.close()
+    return path
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Encode a masked CGImage to PNG via NSBitmapImageRep.
+  private static func pngData(from image: CGImage) -> Data? {
+    let rep = NSBitmapImageRep(cgImage: image)
+    return rep.representation(using: .png, properties: [:])
+  }
+
+  private static func cgImage(fromPNGFile url: URL) -> CGImage? {
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+      return nil
+    }
+    return CGImageSourceCreateImageAtIndex(source, 0, nil)
+  }
+
+  private static func cgImage(fromPNGData data: Data) -> CGImage? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+      return nil
+    }
+    return CGImageSourceCreateImageAtIndex(source, 0, nil)
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Cache file name binds source filename + mtime so an edited source is a clean cache miss. Source filename is sanitized to filesystem-safe characters.
+  private static func cacheFileName(sourceId: String, mtimeEpoch: Int) -> String {
+    let safe = sourceId.unicodeScalars.map { scalar -> Character in
+      let isSafe =
+        (scalar >= "A" && scalar <= "Z") || (scalar >= "a" && scalar <= "z")
+        || (scalar >= "0" && scalar <= "9") || scalar == "-" || scalar == "_" || scalar == "."
+      return isSafe ? Character(scalar) : "_"
+    }
+    return "\(String(safe))-\(mtimeEpoch).masked.png"
+  }
+}

--- a/native/macos/ghostexHost/Sources/Shared/GhostexAppStorage.swift
+++ b/native/macos/ghostexHost/Sources/Shared/GhostexAppStorage.swift
@@ -67,6 +67,101 @@ enum GhostexAppStorage {
     sharedRootDirectory.appendingPathComponent("state", isDirectory: true)
   }
 
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   User-supplied app icons live in ~/.ghostex/icons (the shared home, so
+   ghostex-dev keeps its own ~/.ghostex-dev/icons). Masked 1024² squircle PNGs
+   are cached under a sibling cache directory keyed to source filename+mtime.
+   Both directories are created lazily, mirroring the ~/.ghostex state-dir
+   handling above.
+   */
+  static var iconsDirectory: URL {
+    sharedRootDirectory.appendingPathComponent("icons", isDirectory: true)
+  }
+
+  static var maskedIconCacheDirectory: URL {
+    sharedStateDirectory.appendingPathComponent("app-icon-cache", isDirectory: true)
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Create the icons and masked-cache directories on first run so the picker, file copy, Finder reveal, and cache writes all have a stable home. Best-effort; failures fall back to the default icon.
+  @discardableResult
+  static func ensureAppIconDirectories() -> Bool {
+    do {
+      try FileManager.default.createDirectory(
+        at: iconsDirectory, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(
+        at: maskedIconCacheDirectory, withIntermediateDirectories: true)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Folder scan for the sidebar picker. Enumerate *.png in ~/.ghostex/icons,
+   keep only files that pass the AppIconImage guardrails (PNG magic bytes,
+   <=5MB, header dims <=2048), sort by contentModificationDate descending with a
+   filename tiebreak, take the 10 most recent, then always include the selected
+   id if it is a valid file not already in that set. Returns just filenames; no
+   absolute paths leave this function.
+   */
+  static func scanAppIconFileNames(selectedId: String) -> [String] {
+    ensureAppIconDirectories()
+    let directory = iconsDirectory
+    guard let entries = try? FileManager.default.contentsOfDirectory(
+      at: directory,
+      includingPropertiesForKeys: [.contentModificationDateKey],
+      options: [.skipsHiddenFiles]
+    ) else {
+      return appendSelectedAppIconIfValid(to: [], selectedId: selectedId)
+    }
+
+    struct AppIconFileEntry {
+      let fileName: String
+      let modifiedAt: TimeInterval
+    }
+
+    let validEntries: [AppIconFileEntry] = entries.compactMap { url in
+      guard url.pathExtension.lowercased() == "png" else {
+        return nil
+      }
+      guard AppIconImage.isValidSourcePNG(at: url) else {
+        return nil
+      }
+      let modifiedAt =
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)?
+        .timeIntervalSince1970 ?? 0
+      return AppIconFileEntry(fileName: url.lastPathComponent, modifiedAt: modifiedAt)
+    }
+
+    let sorted = validEntries.sorted { lhs, rhs in
+      if lhs.modifiedAt != rhs.modifiedAt {
+        return lhs.modifiedAt > rhs.modifiedAt
+      }
+      return lhs.fileName < rhs.fileName
+    }
+
+    let topFileNames = sorted.prefix(10).map { $0.fileName }
+    return appendSelectedAppIconIfValid(to: Array(topFileNames), selectedId: selectedId)
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Always include the persisted selection so a selected-but-older icon never disappears from the list even when 10 newer icons exist. Ignores "" (default) and invalid/missing files.
+  private static func appendSelectedAppIconIfValid(
+    to fileNames: [String],
+    selectedId: String
+  ) -> [String] {
+    let trimmed = selectedId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, !fileNames.contains(trimmed) else {
+      return fileNames
+    }
+    let url = iconsDirectory.appendingPathComponent(trimmed, isDirectory: false)
+    guard AppIconImage.isValidSourcePNG(at: url) else {
+      return fileNames
+    }
+    return fileNames + [trimmed]
+  }
+
   static var logsDirectory: URL {
     diagnosticsRootDirectory.appendingPathComponent("logs", isDirectory: true)
   }

--- a/native/macos/ghostexHost/Sources/ghostexHost/AppDelegate.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/AppDelegate.swift
@@ -1077,6 +1077,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, SPUU
     MainActor.assumeIsolated {
       installMainMenu()
       /**
+       CDXC:AppIconPicker 2026-06-25-21:50:
+       Apply the persisted custom Dock icon before window creation so the Dock
+       and Cmd-Tab switcher show the chosen icon immediately at launch. This sets
+       only NSApp.applicationIconImage at runtime; the bundle/Finder icon is
+       never modified.
+       */
+      Self.applyAppIcon(sourceId: Self.readPersistedAppIconSourceId())
+      /**
        CDXC:NativeTerminals 2026-04-28-12:06
        Persistent helper mode was removed by request. Native terminals now
        always use the in-process embedded Ghostty SurfaceView backend from
@@ -3759,6 +3767,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, SPUU
       break
     case .pickWorkspaceIcon:
       break
+    // CDXC:AppIconPicker 2026-06-25-21:50: The WebSocket host-bridge path forwards app-icon picker commands to the root view, which owns the NSOpenPanel, ~/.ghostex/icons copies, Finder reveal, and the appIconState emit.
+    case .listAppIcons, .setAppIcon, .pickAppIconFile, .revealAppIconsFolder:
+      (window?.contentView as? ghostexRootView)?.handleAppIconHostCommand(command)
     case .showMessage(let command):
       showMessage(command)
     case .appendAgentDetectionDebugLog(let command):
@@ -4901,6 +4912,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, SPUU
         }
       }
     }
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Read the persisted appIconSourceId (default "") from the shared native
+   sidebar settings file. Used at launch so the Dock icon is correct before the
+   window appears. Privacy: returns only the id; never logs paths or bytes.
+   */
+  static func readPersistedAppIconSourceId() -> String {
+    guard let data = try? Data(contentsOf: GhostexAppStorage.sharedSidebarSettingsURL),
+      let object = try? JSONSerialization.jsonObject(with: data),
+      let settings = object as? [String: Any],
+      let sourceId = settings["appIconSourceId"] as? String
+    else {
+      return ""
+    }
+    return sourceId.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   Apply the runtime Dock icon for a source id. "" resets NSApp to the bundle
+   icon (applicationIconImage = nil). A non-empty id loads, validates, and masks
+   the matching file in ~/.ghostex/icons through the self-validating cache; any
+   failure falls back to the default bundle icon. Only NSApp.applicationIconImage
+   changes here — the Finder/bundle icon is never touched. Logging is
+   privacy-safe (id presence and success boolean only).
+   */
+  @MainActor static func applyAppIcon(sourceId: String) {
+    let trimmed = sourceId.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      NSApp.applicationIconImage = nil
+      if NativeDebugLogging.isEnabled {
+        logger.info("AppIcon applied default bundle icon hasSource=false")
+      }
+      return
+    }
+    GhostexAppStorage.ensureAppIconDirectories()
+    guard let image = AppIconImage.maskedDockImage(
+      sourceId: trimmed,
+      iconsDirectory: GhostexAppStorage.iconsDirectory,
+      cacheDirectory: GhostexAppStorage.maskedIconCacheDirectory
+    ) else {
+      // CDXC:AppIconPicker 2026-06-25-21:50: Invalid/missing source falls back to the default bundle icon instead of leaving a stale custom icon.
+      NSApp.applicationIconImage = nil
+      if NativeDebugLogging.isEnabled {
+        logger.info("AppIcon fell back to default; masked image unavailable hasSource=true ok=false")
+      }
+      return
+    }
+    NSApp.applicationIconImage = image
+    if NativeDebugLogging.isEnabled {
+      logger.info("AppIcon applied custom icon hasSource=true ok=true")
+    }
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Human-friendly picker label derived from the icon filename (extension stripped, separators spaced). No path is exposed.
+  static func appIconDisplayName(forFileName fileName: String) -> String {
+    let base = (fileName as NSString).deletingPathExtension
+    let spaced = base
+      .replacingOccurrences(of: "-", with: " ")
+      .replacingOccurrences(of: "_", with: " ")
+      .trimmingCharacters(in: .whitespaces)
+    return spaced.isEmpty ? fileName : spaced
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Sanitize a chosen file's base name to filesystem-safe characters before copying into ~/.ghostex/icons.
+  static func sanitizedAppIconFileName(_ rawName: String) -> String {
+    let cleaned = rawName.unicodeScalars.map { scalar -> Character in
+      let isSafe =
+        (scalar >= "A" && scalar <= "Z") || (scalar >= "a" && scalar <= "z")
+        || (scalar >= "0" && scalar <= "9") || scalar == "-" || scalar == "_"
+      return isSafe ? Character(scalar) : "-"
+    }
+    let collapsed = String(cleaned).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    return collapsed.isEmpty ? "app-icon" : collapsed
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Thumbnail data URL for the always-present "Default" row. Uses the immutable bundle icon (never NSApp.applicationIconImage, which may already hold a custom runtime icon) so the picker shows the true default. Returns "" if rendering fails; the sidebar treats an empty data URL as no preview.
+  @MainActor static func defaultAppIconThumbnailDataURL() -> String {
+    let bundleIcon = NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
+    let target = NSSize(width: 128, height: 128)
+    let output = NSImage(size: target)
+    output.lockFocus()
+    NSColor.clear.setFill()
+    NSRect(origin: .zero, size: target).fill()
+    bundleIcon.draw(
+      in: NSRect(origin: .zero, size: target), from: .zero, operation: .sourceOver, fraction: 1.0)
+    output.unlockFocus()
+    guard let tiff = output.tiffRepresentation,
+      let bitmap = NSBitmapImageRep(data: tiff),
+      let png = bitmap.representation(using: .png, properties: [:])
+    else {
+      return ""
+    }
+    return "data:image/png;base64,\(png.base64EncodedString())"
   }
 
   private static func javascriptStringLiteral(_ value: String) -> String? {
@@ -6300,6 +6407,8 @@ final class ghostexRootView: NSView {
   private let setGxserverAlwaysStartFromTitlebar: (Bool) -> Void
   private let sendHostEvent: (HostEvent) -> Void
   private let nativeSettingsStore = NativeSettingsStore()
+  // CDXC:AppIconPicker 2026-06-25-21:50: In-memory override of the selected app-icon source id, set immediately after a setAppIcon/pick so the emitted appIconState reflects the new selection before React persists appIconSourceId. nil means defer to the persisted settings value.
+  private var pendingAppIconSelectedId: String?
   private var activeAppModalKind: String?
   private var appModalPresentationPending = false
   private var activeNativeAppModalKind: String?
@@ -9486,6 +9595,15 @@ final class ghostexRootView: NSView {
       presentWorkspaceFolderPicker()
     case .pickWorkspaceIcon(let command):
       presentWorkspaceIconPicker(command)
+    // CDXC:AppIconPicker 2026-06-25-21:50: Route the WKWebView sidebar app-icon picker commands to their native handlers in this view.
+    case .listAppIcons:
+      handleListAppIcons()
+    case .setAppIcon(let command):
+      handleSetAppIcon(command)
+    case .pickAppIconFile:
+      handlePickAppIconFile()
+    case .revealAppIconsFolder:
+      handleRevealAppIconsFolder()
     case .showMessage(let command):
       showMessage(command)
     case .appendAgentDetectionDebugLog(let command):
@@ -12820,6 +12938,161 @@ final class ghostexRootView: NSView {
         window.__ghostex_NATIVE_WORKSPACE_BAR__?.setProjectIcon(icon.projectId, icon.iconDataUrl);
       })();
       """)
+  }
+
+  /**
+   CDXC:AppIconPicker 2026-06-25-21:50:
+   App-icon picker command handlers live alongside the workspace icon picker
+   because they share the native NSOpenPanel/Finder pattern and the postHostEvent
+   sidebar bus. The selected source id is read from the React-persisted settings
+   (default ""), overridden in-memory after a setAppIcon/pick so the immediately
+   emitted appIconState reflects the new selection before React persists it.
+   */
+  private func currentAppIconSelectedId() -> String {
+    if let pendingAppIconSelectedId {
+      return pendingAppIconSelectedId
+    }
+    return AppDelegate.readPersistedAppIconSourceId()
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Build and push the appIconState host event: ensure dirs, scan the folder (10 most-recent valid PNGs plus the selected id), and attach masked squircle thumbnail data URLs. Mirrors how requestOSIntegrationStatus pushes status via postHostEvent.
+  private func emitAppIconState(ok: Bool, error: String?) {
+    GhostexAppStorage.ensureAppIconDirectories()
+    let selectedId = currentAppIconSelectedId()
+    let fileNames = GhostexAppStorage.scanAppIconFileNames(selectedId: selectedId)
+
+    var icons: [AppIconDescriptor] = []
+    // CDXC:AppIconPicker 2026-06-25-21:50: The default/bundle icon is always offered first as id "".
+    icons.append(AppIconDescriptor(
+      id: "",
+      name: "Default",
+      thumbnailDataUrl: AppDelegate.defaultAppIconThumbnailDataURL(),
+      selected: selectedId.isEmpty))
+
+    for fileName in fileNames {
+      let url = GhostexAppStorage.iconsDirectory.appendingPathComponent(fileName, isDirectory: false)
+      guard let thumbnail = AppIconImage.maskedThumbnailDataURL(forValidatedSource: url) else {
+        continue
+      }
+      icons.append(AppIconDescriptor(
+        id: fileName,
+        name: AppDelegate.appIconDisplayName(forFileName: fileName),
+        thumbnailDataUrl: thumbnail,
+        selected: fileName == selectedId))
+    }
+
+    postHostEvent(.appIconState(ok: ok, error: error, selectedId: selectedId, icons: icons))
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Internal forwarder so the WebSocket host-bridge path (AppDelegate.handle) can reach the same app-icon handlers as the WKWebView sidebar path without exposing each private method.
+  func handleAppIconHostCommand(_ command: HostCommand) {
+    switch command {
+    case .listAppIcons:
+      handleListAppIcons()
+    case .setAppIcon(let setCommand):
+      handleSetAppIcon(setCommand)
+    case .pickAppIconFile:
+      handlePickAppIconFile()
+    case .revealAppIconsFolder:
+      handleRevealAppIconsFolder()
+    default:
+      break
+    }
+  }
+
+  private func handleListAppIcons() {
+    emitAppIconState(ok: true, error: nil)
+  }
+
+  private func handleSetAppIcon(_ command: SetAppIcon) {
+    let trimmed = command.sourceId.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      pendingAppIconSelectedId = ""
+      AppDelegate.applyAppIcon(sourceId: "")
+      emitAppIconState(ok: true, error: nil)
+      return
+    }
+    GhostexAppStorage.ensureAppIconDirectories()
+    let url = GhostexAppStorage.iconsDirectory.appendingPathComponent(trimmed, isDirectory: false)
+    guard AppIconImage.isValidSourcePNG(at: url) else {
+      // CDXC:AppIconPicker 2026-06-25-21:50: An invalid/missing id is ignored and reported; selection stays on whatever was already applied so the Dock icon never breaks.
+      emitAppIconState(ok: false, error: "iconUnavailable")
+      return
+    }
+    pendingAppIconSelectedId = trimmed
+    AppDelegate.applyAppIcon(sourceId: trimmed)
+    emitAppIconState(ok: true, error: nil)
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: NSOpenPanel for a PNG, mirroring presentWorkspaceIconPicker/setWorkspaceIcon. On pick, validate then copy into ~/.ghostex/icons, select it, apply the Dock icon, and emit state.
+  private func handlePickAppIconFile() {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = false
+    panel.canChooseFiles = true
+    panel.allowsMultipleSelection = false
+    panel.allowedContentTypes = [.png]
+    panel.prompt = "Choose Icon"
+    panel.message = "Choose a PNG icon for the Ghostex app."
+
+    let completion: (NSApplication.ModalResponse) -> Void = { [weak self] response in
+      guard let self else {
+        return
+      }
+      guard response == .OK, let url = panel.url else {
+        return
+      }
+      guard AppIconImage.isValidSourcePNG(at: url) else {
+        // CDXC:AppIconPicker 2026-06-25-21:50: Reject non-PNG, oversized (>2048px), or >5MB picks before copying anything into the icons folder.
+        self.showMessage(ShowMessage(
+          level: .error,
+          message: "That image cannot be used. Pick a PNG up to 2048px and 5MB."))
+        self.emitAppIconState(ok: false, error: "invalidPick")
+        return
+      }
+      guard let copiedFileName = self.copyPickedAppIcon(from: url) else {
+        self.showMessage(ShowMessage(level: .error, message: "Could not save the chosen app icon."))
+        self.emitAppIconState(ok: false, error: "copyFailed")
+        return
+      }
+      self.pendingAppIconSelectedId = copiedFileName
+      AppDelegate.applyAppIcon(sourceId: copiedFileName)
+      self.emitAppIconState(ok: true, error: nil)
+    }
+
+    if let window {
+      panel.beginSheetModal(for: window, completionHandler: completion)
+    } else {
+      completion(panel.runModal())
+    }
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Copy a validated picked PNG into ~/.ghostex/icons with a unique, sanitized name. Returns the destination filename (the new source id) or nil on failure. No absolute paths are logged.
+  private func copyPickedAppIcon(from sourceURL: URL) -> String? {
+    GhostexAppStorage.ensureAppIconDirectories()
+    let baseName = AppDelegate.sanitizedAppIconFileName(sourceURL.deletingPathExtension().lastPathComponent)
+    let manager = FileManager.default
+    var candidate = "\(baseName).png"
+    var destinationURL = GhostexAppStorage.iconsDirectory.appendingPathComponent(
+      candidate, isDirectory: false)
+    var suffix = 1
+    while manager.fileExists(atPath: destinationURL.path) {
+      candidate = "\(baseName)-\(suffix).png"
+      destinationURL = GhostexAppStorage.iconsDirectory.appendingPathComponent(
+        candidate, isDirectory: false)
+      suffix += 1
+    }
+    do {
+      try manager.copyItem(at: sourceURL, to: destinationURL)
+      return candidate
+    } catch {
+      return nil
+    }
+  }
+
+  // CDXC:AppIconPicker 2026-06-25-21:50: Reveal ~/.ghostex/icons in Finder, mirroring openWorkspaceInFinder. Creates the folder first so the reveal never fails on first run.
+  private func handleRevealAppIconsFolder() {
+    GhostexAppStorage.ensureAppIconDirectories()
+    NSWorkspace.shared.open(GhostexAppStorage.iconsDirectory)
   }
 
   private func openExternalUrl(_ command: OpenExternalUrl) {

--- a/native/macos/ghostexHost/Sources/ghostexHost/HostProtocol.swift
+++ b/native/macos/ghostexHost/Sources/ghostexHost/HostProtocol.swift
@@ -35,6 +35,11 @@ enum HostCommand: Decodable {
   case setTerminalVisibility(SetTerminalVisibility)
   case pickWorkspaceFolder
   case pickWorkspaceIcon(PickWorkspaceIcon)
+  // CDXC:AppIconPicker 2026-06-25-21:50: Sidebar app-icon picker commands cross the host bridge so AppKit owns NSApp.applicationIconImage, ~/.ghostex/icons file copies, and Finder reveal while React only sends the selected source id.
+  case listAppIcons
+  case setAppIcon(SetAppIcon)
+  case pickAppIconFile
+  case revealAppIconsFolder
   case showMessage(ShowMessage)
   case appendAgentDetectionDebugLog(AppendAgentDetectionDebugLog)
   case appendLayoutLayeringDebugLog(AppendLayoutLayeringDebugLog)
@@ -147,6 +152,11 @@ enum HostCommand: Decodable {
     case setTerminalVisibility
     case pickWorkspaceFolder
     case pickWorkspaceIcon
+    // CDXC:AppIconPicker 2026-06-25-21:50: Register the app-icon picker command type strings exactly as the parallel TS sidebar emits them.
+    case listAppIcons
+    case setAppIcon
+    case pickAppIconFile
+    case revealAppIconsFolder
     case showMessage
     case appendAgentDetectionDebugLog
     case appendLayoutLayeringDebugLog
@@ -292,6 +302,15 @@ enum HostCommand: Decodable {
       self = .pickWorkspaceFolder
     case .pickWorkspaceIcon:
       self = .pickWorkspaceIcon(try PickWorkspaceIcon(from: decoder))
+    // CDXC:AppIconPicker 2026-06-25-21:50: Decode the app-icon picker commands; only setAppIcon carries a payload (the selected source id).
+    case .listAppIcons:
+      self = .listAppIcons
+    case .setAppIcon:
+      self = .setAppIcon(try SetAppIcon(from: decoder))
+    case .pickAppIconFile:
+      self = .pickAppIconFile
+    case .revealAppIconsFolder:
+      self = .revealAppIconsFolder
     case .showMessage:
       self = .showMessage(try ShowMessage(from: decoder))
     case .appendAgentDetectionDebugLog:
@@ -1147,6 +1166,11 @@ struct PickWorkspaceIcon: Decodable {
   let projectId: String
 }
 
+// CDXC:AppIconPicker 2026-06-25-21:50: The selected app-icon source id is a filename inside ~/.ghostex/icons, or "" for the default/bundle Dock icon. No paths or image bytes cross this boundary.
+struct SetAppIcon: Decodable {
+  let sourceId: String
+}
+
 struct ShowMessage: Decodable {
   let level: MessageLevel
   let message: String
@@ -1636,6 +1660,8 @@ enum HostEvent: Encodable {
     remoteMachineId: String, requestId: String, ok: Bool, hasPassword: Bool, error: String?)
   case sidebarCliResult(requestId: String, ok: Bool, payloadJson: String)
   case gxserverStatus(payloadJson: String)
+  // CDXC:AppIconPicker 2026-06-25-21:50: The native app-icon state pushes the current selection and the masked thumbnail list back to the sidebar over the typed host-event bus, matching how requestOSIntegrationStatus pushes its status. Thumbnails are base64 data URLs only; no absolute paths are ever encoded.
+  case appIconState(ok: Bool, error: String?, selectedId: String, icons: [AppIconDescriptor])
 
   private enum CodingKeys: String, CodingKey {
     case exitCode
@@ -1703,6 +1729,9 @@ enum HostEvent: Encodable {
     case targetSessionId
     case tmuxSessionName
     case remoteMachineId
+    // CDXC:AppIconPicker 2026-06-25-21:50: appIconState carries the selected source id and the masked icon descriptor list.
+    case selectedId
+    case icons
   }
 
   func encode(to encoder: Encoder) throws {
@@ -2134,8 +2163,28 @@ enum HostEvent: Encodable {
        */
       try container.encode("gxserverStatus", forKey: .type)
       try container.encode(payloadJson, forKey: .payloadJson)
+    case .appIconState(let ok, let error, let selectedId, let icons):
+      /**
+       CDXC:AppIconPicker 2026-06-25-21:50:
+       Encode only stable UI fields: ok/error booleans and strings, the selected
+       source id, and per-icon descriptors whose thumbnails are base64 data URLs.
+       Never encode absolute filesystem paths or raw source image bytes.
+       */
+      try container.encode("appIconState", forKey: .type)
+      try container.encode(ok, forKey: .ok)
+      try container.encodeIfPresent(error, forKey: .error)
+      try container.encode(selectedId, forKey: .selectedId)
+      try container.encode(icons, forKey: .icons)
     }
   }
+}
+
+// CDXC:AppIconPicker 2026-06-25-21:50: One row in the sidebar app-icon picker. id is a ~/.ghostex/icons filename or "" for the default/bundle icon; thumbnailDataUrl is a masked squircle PNG data URL.
+struct AppIconDescriptor: Encodable {
+  let id: String
+  let name: String
+  let thumbnailDataUrl: String
+  let selected: Bool
 }
 
 enum TerminalTitleBarAction: String, Codable, Hashable {

--- a/native/sidebar/modal-host.tsx
+++ b/native/sidebar/modal-host.tsx
@@ -45,6 +45,8 @@ import type {
   SidebarGhostexCliStatusMessage,
   SidebarGhostexFolderStatsMessage,
   SidebarOSIntegrationStatusMessage,
+  // CDXC:AppIconPicker 2026-06-25-21:50: App Icon state flows to Settings through the modal-state relay.
+  SidebarAppIconStateMessage,
   SidebarToExtensionMessage,
 } from "../../shared/session-grid-contract";
 import {
@@ -102,6 +104,8 @@ type AgentsHubFileContentMessage = Extract<
 type AgentHookStatusMessage = Extract<ExtensionToSidebarMessage, { type: "agentHookStatus" }>;
 type GhostexCliStatusMessage = Extract<ExtensionToSidebarMessage, { type: "ghostexCliStatus" }>;
 type OSIntegrationStatusMessage = Extract<ExtensionToSidebarMessage, { type: "osIntegrationStatus" }>;
+// CDXC:AppIconPicker 2026-06-25-21:50: App Icon state message threaded through modal state into Settings.
+type AppIconStateMessage = Extract<ExtensionToSidebarMessage, { type: "appIconState" }>;
 
 type AppModalHostMessage =
   | {
@@ -2008,6 +2012,8 @@ function AppModalHost() {
     ghostexCliStatus,
     ghostexFolderStats,
     osIntegrationStatus,
+    // CDXC:AppIconPicker 2026-06-25-21:50: Pull relayed App Icon state for the Settings modal.
+    appIconState,
     portlessSetup,
     settingsInitialSection,
     settingsInitialRemoteMachineId,
@@ -2801,6 +2807,8 @@ function AppModalHost() {
         ghostexFolderStatsLoading={ghostexFolderStatsLoading}
         osIntegrationStatus={osIntegrationStatus}
         osIntegrationStatusLoading={osIntegrationStatusLoading}
+        // CDXC:AppIconPicker 2026-06-25-21:50: Prop-driven App Icon state for Settings (mirrors osIntegrationStatus).
+        appIconState={appIconState}
       />
       <DiscoverGhostexModal
         isOpen={activeModal === "discoverGhostex"}
@@ -3070,6 +3078,8 @@ function useModalStateFromNative() {
   const [ghostexCliStatus, setGhostexCliStatus] = useState<GhostexCliStatusMessage>();
   const [ghostexFolderStats, setGhostexFolderStats] = useState<SidebarGhostexFolderStatsMessage>();
   const [osIntegrationStatus, setOSIntegrationStatus] = useState<OSIntegrationStatusMessage>();
+  // CDXC:AppIconPicker 2026-06-25-21:50: Latest native App Icon state passed to Settings.
+  const [appIconState, setAppIconState] = useState<AppIconStateMessage>();
   const [settingsInitialSection, setSettingsInitialSection] =
     useState<MainSettingsInitialSectionId>();
   const [settingsInitialRemoteMachineId, setSettingsInitialRemoteMachineId] = useState<string>();
@@ -3098,6 +3108,8 @@ function useModalStateFromNative() {
     setPortlessSetup(undefined);
     setGhostexFolderStats(undefined);
     setOSIntegrationStatus(undefined);
+    // CDXC:AppIconPicker 2026-06-25-21:50: Drop stale App Icon state when the modal closes.
+    setAppIconState(undefined);
     setAgentsHubCatalog(undefined);
     setAgentsHubFileContent(undefined);
     setCommandPaletteCollapsedGroupsById({});
@@ -3781,6 +3793,11 @@ function useModalStateFromNative() {
             setOSIntegrationStatus(message.message);
             return;
           }
+          // CDXC:AppIconPicker 2026-06-25-21:50: Route relayed App Icon state into Settings modal state.
+          if (isAppIconStateMessage(message.message)) {
+            setAppIconState(message.message);
+            return;
+          }
           if (isPreviousSessionsResultMessage(message.message)) {
             window.postMessage(message.message, "*");
             return;
@@ -3851,6 +3868,8 @@ function useModalStateFromNative() {
     ghostexCliStatus,
     ghostexFolderStats,
     osIntegrationStatus,
+    // CDXC:AppIconPicker 2026-06-25-21:50: Expose App Icon state to the modal component.
+    appIconState,
     settingsInitialSection,
     settingsInitialRemoteMachineId,
     settingsInitialSearchQuery,
@@ -3891,6 +3910,16 @@ function isOSIntegrationStatusMessage(message: unknown): message is SidebarOSInt
       typeof message === "object" &&
       "type" in message &&
       message.type === "osIntegrationStatus",
+  );
+}
+
+// CDXC:AppIconPicker 2026-06-25-21:50: Narrow relayed sidebarState payloads to the App Icon contract.
+function isAppIconStateMessage(message: unknown): message is SidebarAppIconStateMessage {
+  return Boolean(
+    message &&
+      typeof message === "object" &&
+      "type" in message &&
+      message.type === "appIconState",
   );
 }
 

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -105,6 +105,9 @@ import {
   type SidebarGhostexCliStatusMessage,
   type SidebarGhostexFolderStatsMessage,
   type SidebarOSIntegrationStatusMessage,
+  // CDXC:AppIconPicker 2026-06-25-21:50: App Icon state is relayed to the modal host like OS Integration status.
+  type SidebarAppIconStateMessage,
+  type SidebarAppIconInfo,
   type TerminalSessionPersistenceProvider,
   type TerminalSessionRecord,
   type T3SessionRecord,
@@ -1049,6 +1052,19 @@ type NativeHostEvent =
     }
   | (ProjectBoardBridgeRequest & { type: "projectBoardRequest" })
   | { payloadJson: string; type: "osIntegrationStatus" }
+  /*
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * The Swift app-icon host event carries the app icon state as direct fields
+   * (ok, error, selectedId, icons) rather than a payloadJson string, so it can
+   * be relayed to the modal host without an intermediate JSON parse.
+   */
+  | {
+      error?: string | null;
+      icons?: SidebarAppIconInfo[];
+      ok?: boolean;
+      selectedId?: string;
+      type: "appIconState";
+    }
   | {
       activeTabId?: string;
       projectId: string;
@@ -5142,6 +5158,17 @@ function postGhostexCliStatus(message: SidebarGhostexCliStatusMessage): void {
 }
 
 function postOSIntegrationStatus(message: SidebarOSIntegrationStatusMessage): void {
+  sidebarBus.post(message);
+  postAppModalHost({ message, type: "sidebarState" });
+}
+
+/*
+ * CDXC:AppIconPicker 2026-06-25-21:50:
+ * App Icon state follows the exact OS Integration relay: post to the main
+ * sidebar bus and relay to the modal-host child window through the sidebarState
+ * message, since Settings (the App Icon consumer) renders in that child window.
+ */
+function postAppIconState(message: SidebarAppIconStateMessage): void {
   sidebarBus.post(message);
   postAppModalHost({ message, type: "sidebarState" });
 }
@@ -46153,6 +46180,24 @@ window.addEventListener("ghostex-native-host-event", (event) => {
         type: "osIntegrationStatus",
       });
     }
+    return;
+  }
+  /*
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * The Swift app-icon host event carries direct fields, so coerce them into the
+   * SidebarAppIconStateMessage contract and relay it through the same
+   * main-bus + modal-host path used for OS Integration status. Defensive
+   * coercion keeps a malformed native payload from breaking the Settings UI.
+   */
+  if (hostEvent.type === "appIconState") {
+    const icons = Array.isArray(hostEvent.icons) ? hostEvent.icons : [];
+    postAppIconState({
+      error: typeof hostEvent.error === "string" ? hostEvent.error : null,
+      icons,
+      ok: hostEvent.ok === true,
+      selectedId: typeof hostEvent.selectedId === "string" ? hostEvent.selectedId : "",
+      type: "appIconState",
+    });
     return;
   }
   if (hostEvent.type === "projectBoardRequest") {

--- a/shared/ghostex-settings.test.ts
+++ b/shared/ghostex-settings.test.ts
@@ -294,6 +294,26 @@ describe("normalizeghostexSettings", () => {
     });
   });
 
+  test("normalizes the app icon source id", () => {
+    /*
+     * CDXC:AppIconPicker 2026-06-25-21:50:
+     * The app icon source id is a trimmed filename, or "" for the default
+     * bundled icon. Missing or non-string values fall back to the default.
+     */
+    expect(DEFAULT_ghostex_SETTINGS.appIconSourceId).toBe("");
+    expect(normalizeghostexSettings({})).toMatchObject({
+      appIconSourceId: "",
+    });
+    expect(normalizeghostexSettings({ appIconSourceId: "  panda.icns  " })).toMatchObject({
+      appIconSourceId: "panda.icns",
+    });
+    expect(
+      normalizeghostexSettings({ appIconSourceId: 42 as unknown as string }),
+    ).toMatchObject({
+      appIconSourceId: "",
+    });
+  });
+
   test("previews session title generation commands", () => {
     /*
     CDXC:GxserverSessionTitle 2026-06-04-22:44:

--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -481,6 +481,13 @@ export type ghostexSettings = {
   codeServerLinkVscodeUserConfig: boolean;
   codeServerUseVscodeInsidersUserConfig: boolean;
   customDefaultEditorCommand: string;
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50: Persisted id of the selected Dock /
+   * app-switcher icon. Empty string means the default bundled app icon. The
+   * value is a filename living in the native icons folder; native confirms the
+   * selection via an appIconState ok event before the sidebar persists it.
+   */
+  appIconSourceId: string;
   defaultEditorCommand: DefaultEditorCommand;
   hideProjectHeaderDiffStats: boolean;
   showProjectEditorDiffFileCount: boolean;
@@ -853,6 +860,8 @@ export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
    * commands for users who prefer a different editor.
    */
   customDefaultEditorCommand: "",
+  // CDXC:AppIconPicker 2026-06-25-21:50: New installs use the default bundled app icon (empty source id).
+  appIconSourceId: "",
   defaultEditorCommand: "code",
   /**
    * CDXC:ProjectDiffStats 2026-05-16-08:46:
@@ -1566,6 +1575,10 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
         DEFAULT_ghostex_SETTINGS.customDefaultEditorCommand,
       ),
     ),
+    // CDXC:AppIconPicker 2026-06-25-21:50: Coerce stored app icon source id to a trimmed string, defaulting to the bundled icon.
+    appIconSourceId: normalizeAppIconSourceId(
+      readString(source, "appIconSourceId", DEFAULT_ghostex_SETTINGS.appIconSourceId),
+    ),
     /**
      * CDXC:ProjectDiffStats 2026-05-16-08:46:
      * Missing project-header visibility now follows the Codex preset, which
@@ -2271,6 +2284,11 @@ function normalizeDefaultEditorCommand(value: string | undefined): DefaultEditor
 }
 
 function normalizeCustomDefaultEditorCommand(value: string | undefined): string {
+  return (value ?? "").trim().slice(0, 240);
+}
+
+// CDXC:AppIconPicker 2026-06-25-21:50: Empty string means default icon; otherwise a bounded filename id.
+function normalizeAppIconSourceId(value: string | undefined): string {
   return (value ?? "").trim().slice(0, 240);
 }
 

--- a/shared/session-grid-contract-sidebar.ts
+++ b/shared/session-grid-contract-sidebar.ts
@@ -881,6 +881,33 @@ export type SidebarNativeHotkeyMessage = {
   type: "nativeHotkey";
 };
 
+/**
+ * CDXC:AppIconPicker 2026-06-25-21:50:
+ * One available Dock/app-switcher icon as reported by native. thumbnailDataUrl
+ * is a self-contained data: URL so the picker grid renders without native file
+ * reads, and `selected` mirrors which entry native currently has applied.
+ */
+export type SidebarAppIconInfo = {
+  id: string;
+  name: string;
+  thumbnailDataUrl: string;
+  selected: boolean;
+};
+
+/**
+ * CDXC:AppIconPicker 2026-06-25-21:50:
+ * Native -> Settings App Icon state. Already trimmed by native to the newest 10
+ * icons plus the selected one. `ok: false` with `error` describes a failed list
+ * or swap; the sidebar persists appIconSourceId only when ok is true.
+ */
+export type SidebarAppIconStateMessage = {
+  error: string | null;
+  icons: SidebarAppIconInfo[];
+  ok: boolean;
+  selectedId: string;
+  type: "appIconState";
+};
+
 export type ExtensionToSidebarMessage =
   | SidebarHydrateMessage
   | SidebarSessionStateMessage
@@ -905,7 +932,9 @@ export type ExtensionToSidebarMessage =
   | SidebarShowSessionRenameModalMessage
   | SidebarShowT3ThreadIdModalMessage
   | SidebarPreviousSessionsResultMessage
-  | SidebarRemoteMachineStatusMessage;
+  | SidebarRemoteMachineStatusMessage
+  // CDXC:AppIconPicker 2026-06-25-21:50: Native pushes App Icon list/selection state into Settings.
+  | SidebarAppIconStateMessage;
 
 export type SidebarToExtensionMessage =
   | {
@@ -2079,6 +2108,28 @@ export type SidebarToExtensionMessage =
       requestId: string;
       type: "syncSidebarAgentOrder";
       agentIds: string[];
+    }
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * Settings -> App Icon talks to native through these four messages. Native
+   * owns the icons folder, file picking, and the live Dock/app-switcher icon;
+   * the sidebar only requests state and selections. sourceId is a filename in
+   * the icons folder, or "" to restore the default bundled icon. The sidebar
+   * waits for an ok appIconState event before persisting appIconSourceId
+   * (confirm-before-persist) so a failed native swap never sticks in settings.
+   */
+  | {
+      type: "listAppIcons";
+    }
+  | {
+      type: "setAppIcon";
+      sourceId: string;
+    }
+  | {
+      type: "pickAppIconFile";
+    }
+  | {
+      type: "revealAppIconsFolder";
     };
 
 export type SidebarHudSnapshot = Pick<

--- a/sidebar/settings-modal-source.test.ts
+++ b/sidebar/settings-modal-source.test.ts
@@ -452,6 +452,89 @@ describe("settings modal source", () => {
     expect(nativeSidebarSource).toContain("worktreeParentProjectId: worktree.parentProjectId");
   });
 
+  test("wires the App Icon picker to the native wire contract with prop-driven confirm-before-persist", () => {
+    /*
+     * CDXC:AppIconPicker 2026-06-25-21:50:
+     * The App Icon section must speak the exact native wire-contract messages,
+     * receive appIconState as a PROP relayed through the modal host (mirroring
+     * osIntegrationStatus, not direct host-event listeners), only persist
+     * appIconSourceId after an ok state (confirm-before-persist), and show the
+     * Dock-only disclaimer.
+     */
+    const settingsNavigation = sourceBetween(
+      settingsModalSource,
+      "const mainSettingsSectionNavigation",
+      "const hasVisibleMainSettings",
+    );
+    const appIconSearch = sourceBetween(
+      settingsModalSource,
+      'appIcon: getSettingsSectionSearch(settingsSearchQuery, "App Icon", [',
+      'browser: getSettingsSectionSearch(settingsSearchQuery, "Browser", [',
+    );
+    const appIconField = sourceBetween(
+      settingsModalSource,
+      "function AppIconPickerField",
+      "function AppIconPickerTile",
+    );
+
+    // Section is registered in the sidebar navigation as an appearance section.
+    expect(settingsNavigation).toContain('id: "appIcon"');
+    expect(appIconSearch).toContain("appIconSourceId");
+
+    // Exact outbound wire-contract messages (these sends stay direct).
+    expect(settingsModalSource).toContain('vscode.postMessage({ type: "listAppIcons" });');
+    expect(settingsModalSource).toContain('vscode.postMessage({ type: "setAppIcon", sourceId });');
+    expect(settingsModalSource).toContain('vscode.postMessage({ type: "pickAppIconFile" });');
+    expect(settingsModalSource).toContain('vscode?.postMessage({ type: "revealAppIconsFolder" });');
+
+    // Inbound appIconState is prop-driven (relayed via the modal host like
+    // osIntegrationStatus), NOT direct window host-event listeners.
+    expect(settingsModalSource).toContain("appIconState?: SidebarAppIconStateMessage;");
+    expect(settingsModalSource).toContain("}, [appIconState]);");
+    expect(settingsModalSource).not.toContain("handleAppIconHostEvent");
+    expect(settingsModalSource).not.toContain("isSidebarAppIconStateMessage");
+
+    // Confirm-before-persist: only an ok prop state writes appIconSourceId.
+    expect(settingsModalSource).toContain("if (appIconState.ok) {");
+    expect(settingsModalSource).toContain("commitAppIconSourceIdRef.current(confirmedSourceId);");
+    expect(settingsModalSource).toContain('updateDraft("appIconSourceId", sourceId);');
+
+    // Reset selects the empty/default source id and the disclaimer is visible.
+    expect(settingsModalSource).toContain('const resetAppIcon = () => {');
+    expect(appIconField).toContain("Choose File");
+    expect(appIconField).toContain("Reveal in Finder");
+    expect(appIconField).toContain("Reset to default");
+    expect(appIconField).toContain(
+      "Changes the Dock &amp; app-switcher icon only — not the Finder icon.",
+    );
+  });
+
+  test("relays appIconState through the modal host like osIntegrationStatus", () => {
+    /*
+     * CDXC:AppIconPicker 2026-06-25-21:50:
+     * SettingsModal renders in the modal-host child window, so the native
+     * appIconState host event must be relayed to the modal host through the same
+     * main-bus + sidebarState plumbing used by osIntegrationStatus, then exposed
+     * by useModalStateFromNative and passed to SettingsModal as a prop.
+     */
+    const modalHostSource = readFileSync(
+      new URL("../native/sidebar/modal-host.tsx", import.meta.url),
+      "utf8",
+    );
+
+    // native-sidebar.tsx: host-event handler + relay that posts to the bus and
+    // the modal host, reading the Swift event's DIRECT fields (no payloadJson).
+    expect(nativeSidebarSource).toContain('if (hostEvent.type === "appIconState") {');
+    expect(nativeSidebarSource).toContain("postAppIconState({");
+    expect(nativeSidebarSource).toContain("function postAppIconState(message: SidebarAppIconStateMessage)");
+    expect(nativeSidebarSource).toContain('postAppModalHost({ message, type: "sidebarState" });');
+
+    // modal-host.tsx: route the relayed message into modal state and pass it on.
+    expect(modalHostSource).toContain("isAppIconStateMessage(message.message)");
+    expect(modalHostSource).toContain("setAppIconState(message.message);");
+    expect(modalHostSource).toContain("appIconState={appIconState}");
+  });
+
   test("keeps the open project selector neutral", () => {
     /*
      * CDXC:ProjectSettings 2026-06-19-12:22:

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -102,6 +102,8 @@ import {
   IconInfoCircle,
   IconMinus,
   IconPalette,
+  // CDXC:AppIconPicker 2026-06-25-21:50: Placeholder glyph for the default-icon tile and missing thumbnails.
+  IconPhoto,
   IconPencil,
   IconPlayerPlay,
   IconPlus,
@@ -117,6 +119,9 @@ import { COMPLETION_SOUND_OPTIONS, type CompletionSoundSetting } from "../shared
 import { GHOSTEX_RECOMMENDED_GHOSTTY_CONFIG_LINES } from "../shared/ghostty-config-actions";
 import {
   resolveSidebarTheme,
+  // CDXC:AppIconPicker 2026-06-25-21:50: App Icon picker consumes native state + per-icon info shapes.
+  type SidebarAppIconInfo,
+  type SidebarAppIconStateMessage,
   type SidebarAgentHookStatusMessage,
   type SidebarAgentHookStatusItem,
   type SidebarGhostexCliStatusMessage,
@@ -498,6 +503,8 @@ type MainSettingsSectionId =
   | "agents"
   | "sidebar"
   | "theming"
+  // CDXC:AppIconPicker 2026-06-25-21:50: App Icon is an appearance section that sits next to Theming.
+  | "appIcon"
   | "sidebarTags"
   | "statusIndicators"
   | "sessionCards"
@@ -543,6 +550,8 @@ const MAIN_SETTINGS_SECTION_SETTING_KEYS: Record<
     "customSidebarTitlebarBackgroundDarknessPercent",
     "customSidebarTitlebarBackgroundTintColor",
   ],
+  // CDXC:AppIconPicker 2026-06-25-21:50: App Icon owns the persisted Dock icon source id selection.
+  appIcon: ["appIconSourceId"],
   sidebarTags: ["sidebarSessionTagListItems"],
   /*
    * CDXC:BrowserSettings 2026-05-22-09:18:
@@ -942,6 +951,8 @@ export type SettingsModalProps = {
   ghostexFolderStatsLoading?: boolean;
   osIntegrationStatus?: SidebarOSIntegrationStatusMessage;
   osIntegrationStatusLoading?: boolean;
+  // CDXC:AppIconPicker 2026-06-25-21:50: Native App Icon state arrives prop-driven via the modal-state relay.
+  appIconState?: SidebarAppIconStateMessage;
   portless?: SidebarPortlessState;
 };
 
@@ -990,6 +1001,8 @@ export function SettingsModal({
   ghostexFolderStatsLoading = false,
   osIntegrationStatus,
   osIntegrationStatusLoading = false,
+  // CDXC:AppIconPicker 2026-06-25-21:50: Prop-driven App Icon state replaces direct host-event listeners.
+  appIconState,
   portless,
 }: SettingsModalProps) {
   const isFirstLaunchSetup = presentation === "firstLaunchSetup";
@@ -1038,6 +1051,8 @@ export function SettingsModal({
   const agentsOnboardingSectionRef = useRef<HTMLDivElement>(null);
   const sidebarSectionRef = useRef<HTMLDivElement>(null);
   const themingSectionRef = useRef<HTMLDivElement>(null);
+  // CDXC:AppIconPicker 2026-06-25-21:50: Anchor ref so the App Icon section participates in Settings nav scrolling.
+  const appIconSectionRef = useRef<HTMLDivElement>(null);
   const sidebarTagsSectionRef = useRef<HTMLDivElement>(null);
   const soundsSectionRef = useRef<HTMLDivElement>(null);
   const storageSectionRef = useRef<HTMLDivElement>(null);
@@ -1049,6 +1064,17 @@ export function SettingsModal({
   const hotkeyProjectsSectionRef = useRef<HTMLDivElement>(null);
   const hotkeySessionSlotsSectionRef = useRef<HTMLDivElement>(null);
   const hasRequestedStorageStatsRef = useRef(false);
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * The App Icon picker is prop-driven: native pushes appIconState through the
+   * modal-state relay (mirroring osIntegrationStatus), so this component only
+   * holds the local error string and the in-flight pending selection. The
+   * pending source id lets confirm-before-persist write the user's selection on
+   * the next ok state instead of native's reported selectedId.
+   */
+  const [appIconError, setAppIconError] = useState<string | undefined>(undefined);
+  const pendingAppIconSourceIdRef = useRef<string | undefined>(undefined);
+  const hasRequestedAppIconsRef = useRef(false);
   const modalTheme = resolveSidebarTheme(draft.sidebarTheme, getSidebarThemeVariant(theme));
   const isModalDarkTheme = getSidebarThemeVariant(modalTheme) === "dark";
   const rememberActiveScrollPosition = () => {
@@ -1272,6 +1298,15 @@ export function SettingsModal({
    * want to choose, not only by the visible setting label.
    */
   const settingsSearch = {
+    // CDXC:AppIconPicker 2026-06-25-21:50: Make the App Icon section findable by Settings search.
+    appIcon: getSettingsSectionSearch(settingsSearchQuery, "App Icon", [
+      {
+        key: "appIconSourceId",
+        subtitle:
+          "Choose the macOS Dock and app-switcher icon. Changes the Dock & app-switcher icon only, not the Finder icon.",
+        title: "App Icon",
+      },
+    ]),
     browser: getSettingsSectionSearch(settingsSearchQuery, "Browser", [
       {
         key: "browserFeedbackTool",
@@ -1907,6 +1942,8 @@ export function SettingsModal({
   }> = [
     { id: "sidebar", ref: sidebarSectionRef, searchResult: settingsSearch.sidebar, title: "Sidebar" },
     { id: "theming", ref: themingSectionRef, searchResult: settingsSearch.theming, title: "Theming" },
+    // CDXC:AppIconPicker 2026-06-25-21:50: App Icon nav entry sits below Theming in the Settings sidebar.
+    { id: "appIcon", ref: appIconSectionRef, searchResult: settingsSearch.appIcon, title: "App Icon" },
     {
       id: "statusIndicators",
       ref: statusIndicatorsSectionRef,
@@ -2140,6 +2177,8 @@ export function SettingsModal({
 	      terminalScrolling: ghosttyScrollingSectionRef,
 	      terminalDevServers: terminalDevServersSectionRef,
 	      theming: themingSectionRef,
+	      // CDXC:AppIconPicker 2026-06-25-21:50: Allow titlebar/deep-link navigation to scroll to App Icon.
+	      appIcon: appIconSectionRef,
 	      workspace: workspaceSectionRef,
 	      agents: agentsOnboardingSectionRef,
 	    });
@@ -2236,6 +2275,63 @@ export function SettingsModal({
     ghostexFolderStatsLoading,
   ]);
 
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * Keep a stable ref to the latest persist closure so the host-event listener
+   * below can subscribe once per open without re-binding every render. The ref
+   * always reflects the current draft, so confirm-before-persist writes the
+   * native-confirmed source id on top of the freshest settings.
+   */
+  const commitAppIconSourceIdRef = useRef<(sourceId: string) => void>(() => {});
+
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * Request the current icon list once whenever the App Icon settings surface
+   * opens, mirroring the lazy native-data requests used elsewhere in Settings.
+   * Native answers through the appIconState prop (relayed via the modal host).
+   */
+  useEffect(() => {
+    if (!isOpen || activeTab !== "settings" || !vscode) {
+      hasRequestedAppIconsRef.current = false;
+      return;
+    }
+    if (hasRequestedAppIconsRef.current) {
+      return;
+    }
+    hasRequestedAppIconsRef.current = true;
+    vscode.postMessage({ type: "listAppIcons" });
+  }, [activeTab, isOpen, vscode]);
+
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * Confirm-before-persist is prop-driven: native relays appIconState into this
+   * component through the modal-state plumbing (exactly like osIntegrationStatus),
+   * so react to each new prop value. On an ok state, persist the in-flight
+   * pending selection (falling back to native's selectedId) and clear any error;
+   * on a failed state, drop the pending id and surface the error without writing
+   * appIconSourceId.
+   */
+  useEffect(() => {
+    if (!appIconState) {
+      return;
+    }
+    if (appIconState.ok) {
+      setAppIconError(undefined);
+      const pendingSourceId = pendingAppIconSourceIdRef.current;
+      const confirmedSourceId =
+        pendingSourceId !== undefined ? pendingSourceId : appIconState.selectedId;
+      pendingAppIconSourceIdRef.current = undefined;
+      commitAppIconSourceIdRef.current(confirmedSourceId);
+      return;
+    }
+    pendingAppIconSourceIdRef.current = undefined;
+    setAppIconError(
+      typeof appIconState.error === "string" && appIconState.error.trim()
+        ? appIconState.error.trim()
+        : "Could not update the app icon.",
+    );
+  }, [appIconState]);
+
   useEffect(() => {
     return () => {
       if (pendingTimeoutRef.current) {
@@ -2308,6 +2404,46 @@ export function SettingsModal({
     value: ghostexSettings[Key],
   ) => {
     applySettingsDebounced({ ...(pendingSettingsRef.current ?? draft), [key]: value });
+  };
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * Refresh the confirm-before-persist closure each render so the host-event
+   * listener writes appIconSourceId onto the current draft only after native
+   * confirms the icon swap with an ok: true state.
+   */
+  commitAppIconSourceIdRef.current = (sourceId: string) => {
+    if ((pendingSettingsRef.current ?? draft).appIconSourceId === sourceId) {
+      return;
+    }
+    updateDraft("appIconSourceId", sourceId);
+  };
+  /**
+   * CDXC:AppIconPicker 2026-06-25-21:50:
+   * Selecting, choosing a file, revealing the folder, and resetting all post the
+   * exact wire-contract messages to native. The selection messages record the
+   * pending source id and clear any prior error; the sidebar persists nothing
+   * until the matching ok: true appIconState arrives.
+   */
+  const selectAppIcon = (sourceId: string) => {
+    if (!vscode) {
+      return;
+    }
+    pendingAppIconSourceIdRef.current = sourceId;
+    setAppIconError(undefined);
+    vscode.postMessage({ type: "setAppIcon", sourceId });
+  };
+  const chooseAppIconFile = () => {
+    if (!vscode) {
+      return;
+    }
+    setAppIconError(undefined);
+    vscode.postMessage({ type: "pickAppIconFile" });
+  };
+  const revealAppIconsFolder = () => {
+    vscode?.postMessage({ type: "revealAppIconsFolder" });
+  };
+  const resetAppIcon = () => {
+    selectAppIcon("");
   };
   const activeSidebarSettingsPresetId = getSidebarSettingsPresetId(
     pendingSettingsRef.current ?? draft,
@@ -2742,6 +2878,34 @@ export function SettingsModal({
                   />
                 ) : null}
               </SettingsSection>
+            ) : null}
+
+            {/*
+             * CDXC:AppIconPicker 2026-06-25-21:50:
+             * App Icon swaps only the macOS Dock and app-switcher icon via native.
+             * The section shows the live native preview, a grid of the newest
+             * icons plus the selected one, a native file picker, a reveal action,
+             * and a reset, plus the required disclaimer. Persistence is
+             * confirm-before-persist: appIconSourceId is written only after native
+             * returns an ok appIconState (handled in the host-event listener).
+             */}
+            {mainSectionVisible("appIcon", settingsSearch.appIcon) ? (
+            <SettingsSection
+              description="Changes the Dock & app-switcher icon only — not the Finder icon."
+              sectionRef={appIconSectionRef}
+              title="App Icon"
+            >
+              {mainSettingVisible(settingsSearch.appIcon, "appIconSourceId") ? (
+              <AppIconPickerField
+                error={appIconError}
+                onChooseFile={chooseAppIconFile}
+                onResetToDefault={resetAppIcon}
+                onReveal={revealAppIconsFolder}
+                onSelect={selectAppIcon}
+                state={appIconState}
+              />
+              ) : null}
+            </SettingsSection>
             ) : null}
 
             {mainSectionVisible("statusIndicators", settingsSearch.statusIndicators) ? (
@@ -9011,6 +9175,172 @@ function PetPickerField({
         </div>
       </div>
     </SettingRow>
+  );
+}
+
+/**
+ * CDXC:AppIconPicker 2026-06-25-21:50:
+ * App Icon picker field. State is owned by the parent (driven by native
+ * appIconState events); this component only renders the live preview, the grid
+ * of native-provided icons (already trimmed to the newest 10 plus the selected
+ * one), the action buttons, an error notice, and the Dock-only disclaimer. The
+ * Default tile and Reset both select the empty source id. Selection posts to
+ * native; persistence happens upstream after native confirms.
+ */
+function AppIconPickerField({
+  error,
+  onChooseFile,
+  onResetToDefault,
+  onReveal,
+  onSelect,
+  state,
+}: {
+  error?: string;
+  onChooseFile: () => void;
+  onResetToDefault: () => void;
+  onReveal: () => void;
+  onSelect: (sourceId: string) => void;
+  state: SidebarAppIconStateMessage | undefined;
+}) {
+  const icons: SidebarAppIconInfo[] = state?.icons ?? [];
+  const selectedId = state?.selectedId ?? "";
+  const isDefaultSelected = selectedId === "";
+  const selectedIcon = icons.find((icon) => icon.id === selectedId);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-none border border-border bg-muted/30">
+          {selectedIcon ? (
+            <img
+              alt={selectedIcon.name}
+              className="size-full object-contain"
+              src={selectedIcon.thumbnailDataUrl}
+            />
+          ) : (
+            <IconPhoto aria-hidden="true" className="size-7 text-muted-foreground" />
+          )}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="truncate text-sm">
+            {isDefaultSelected ? "Default app icon" : selectedIcon?.name ?? selectedId}
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            {isDefaultSelected
+              ? "Using the bundled Ghostex icon."
+              : "Custom Dock & app-switcher icon."}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(64px,1fr))] gap-2">
+        {/*
+         * CDXC:AppIconPicker 2026-06-25-21:50:
+         * The first tile always restores the default bundled icon (empty source
+         * id), then the native-provided icons follow newest-first.
+         */}
+        <AppIconPickerTile
+          label="Default"
+          onSelect={() => onSelect("")}
+          selected={isDefaultSelected}
+        />
+        {icons.map((icon) => (
+          <AppIconPickerTile
+            key={icon.id}
+            label={icon.name}
+            onSelect={() => onSelect(icon.id)}
+            selected={icon.selected || icon.id === selectedId}
+            thumbnailDataUrl={icon.thumbnailDataUrl}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button className="h-9 rounded-none px-3 text-sm" onClick={onChooseFile} type="button" variant="outline">
+          <IconDownload aria-hidden="true" data-icon="inline-start" />
+          Choose File…
+        </Button>
+        <Button className="h-9 rounded-none px-3 text-sm" onClick={onReveal} type="button" variant="outline">
+          <IconFolderOpen aria-hidden="true" data-icon="inline-start" />
+          Reveal in Finder
+        </Button>
+        <Button
+          className="h-9 rounded-none px-3 text-sm"
+          disabled={isDefaultSelected}
+          onClick={onResetToDefault}
+          type="button"
+          variant="outline"
+        >
+          <IconRefresh aria-hidden="true" data-icon="inline-start" />
+          Reset to default
+        </Button>
+      </div>
+
+      {error ? (
+        <div className="flex items-start gap-2 rounded-none border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <IconAlertTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+          <span className="min-w-0">{error}</span>
+        </div>
+      ) : null}
+
+      {/*
+       * CDXC:AppIconPicker 2026-06-25-21:50:
+       * Required visible disclaimer so users know this only affects the Dock and
+       * app-switcher icon, not the Finder application icon.
+       */}
+      <p className="m-0 text-xs text-muted-foreground">
+        Changes the Dock &amp; app-switcher icon only — not the Finder icon.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * CDXC:AppIconPicker 2026-06-25-21:50:
+ * One selectable App Icon tile. The Default tile renders a placeholder glyph
+ * because native does not ship a thumbnail for the bundled icon.
+ */
+function AppIconPickerTile({
+  label,
+  onSelect,
+  selected,
+  thumbnailDataUrl,
+}: {
+  label: string;
+  onSelect: () => void;
+  selected: boolean;
+  thumbnailDataUrl?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            aria-label={label}
+            aria-pressed={selected}
+            className={cn(
+              "relative flex aspect-square items-center justify-center overflow-hidden rounded-none border bg-muted/30",
+              selected ? "border-primary ring-2 ring-primary" : "border-border hover:border-primary/60",
+            )}
+            onClick={onSelect}
+            type="button"
+          >
+            {thumbnailDataUrl ? (
+              <img alt={label} className="size-full object-contain" src={thumbnailDataUrl} />
+            ) : (
+              <IconPhoto aria-hidden="true" className="size-6 text-muted-foreground" />
+            )}
+            {selected ? (
+              <IconCircleCheckFilled
+                aria-hidden="true"
+                className="absolute right-0.5 top-0.5 size-4 text-primary"
+              />
+            ) : null}
+          </button>
+        }
+      />
+      <TooltipContent sideOffset={6}>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
## What

Adds an **App Icon** picker to Settings so users can change the macOS Dock / app-switcher icon, either by:
- **Choosing a PNG file**, or
- **Dropping PNGs into `~/.ghostex/icons`** (auto-discovered)

You approved both on Discord 🙏 — opening it for you to check on your side.

## Behaviour & guardrails

- Square PNGs are auto-masked to the macOS **superellipse squircle**, so any square image looks native — no design work needed (handy for AI-generated icons).
- Validation: **PNG-only, ≤2048px, ≤5 MB**; invalid/unreadable files are ignored and fall back to the default bundle icon.
- The folder grid shows the **10 most-recently-modified** icons plus the currently-selected one.
- The file picker **copies** the chosen PNG into `~/.ghostex/icons`, so the folder is the single source of truth.
- **Runtime only:** sets `NSApp.applicationIconImage`; the signed bundle / Finder icon is intentionally not modified (the UI says so).

## How it's wired

- **Native (Swift):** 4 host-bridge commands (`listAppIcons` / `setAppIcon` / `pickAppIconFile` / `revealAppIconsFolder`) + an `appIconState` event. Applied early at launch (before the window) via a **self-validating masked cache**. New self-contained `AppIconImage` util; `~/.ghostex/icons` + masked cache in `GhostexAppStorage`.
- **Sidebar (TS/React):** App Icon section in Settings; `appIconSourceId` setting; `appIconState` relayed to the modal-host child window **exactly like `osIntegrationStatus`**; confirm-before-persist (only saves after native confirms success).
- `CDXC:` comments on every touched block, per `AGENTS.md`. No `ghostty/` files touched.

## Files

- New: `native/macos/ghostexHost/Sources/Shared/AppIconImage.swift`
- Swift: `GhostexAppStorage.swift`, `AppDelegate.swift`, `HostProtocol.swift`
- TS: `shared/ghostex-settings.ts`, `shared/session-grid-contract-sidebar.ts`, `sidebar/settings-modal.tsx`, `native/sidebar/native-sidebar.tsx`, `native/sidebar/modal-host.tsx`
- Tests: `shared/ghostex-settings.test.ts`, `sidebar/settings-modal-source.test.ts`

## Verification

- ✅ `bun run typecheck` — no new errors (the 2 in `native/sidebar/gxserver-client.ts` are pre-existing on `main`, untouched here).
- ✅ `vitest` — 61 tests pass, incl. new App Icon coverage.
- ✅ `AppIconImage.swift` compiles standalone via `swiftc -typecheck`.
- ⚠️ **I could not build the full native app locally** (no Xcode + limited disk), so the Swift integration is verified by review + isolated compile only. Could you build/test the native side, as discussed? Happy to iterate on anything.

## Notes for review

- Persistence: `appIconSourceId` lives in the existing settings JSON (React-owned), read by native at launch — no separate file, no race.
- Non-square images are center-cropped before masking.
- Default / Reset map to `sourceId: ""` (the bundle icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an App Icon picker in Settings for choosing a custom Dock/app switcher icon.
  * Shows a live preview, recent icon tiles, and options to reset to the default icon, pick a file, or reveal the icon folder.
  * Custom icons are now applied at app launch and persist across restarts.

* **Bug Fixes**
  * Improved icon validation and selection handling so invalid files are ignored and the chosen icon stays available even when newer icons are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->