### PR TITLE
fix(sidebar): normalize hydrated settings so Settings cannot open blank

### DIFF
--- a/gpui/src/main.rs
+++ b/gpui/src/main.rs
@@ -29425,6 +29425,62 @@ impl GhostexGpuiApp {
             "toast" => {
                 self.receive_gpui_app_toast_bridge_message(&message, window, cx);
             }
+            /*
+            CDXC:SettingsModalBlankUnnormalizedHydrate 2026-07-29:
+            The shared React modal host already reports its uncaught renderer
+            exceptions (`logError`, installed by
+            `installAppModalGlobalErrorLogging`) and its Settings lifecycle
+            breadcrumbs (`debugLog`) over this same app-owned bridge, and the CEF
+            shim installs the `ghostexAppModalHost` handler both helpers post
+            through. GPUI had no arm for either message, so both fell through to
+            the no-op below: a render error that blanked the Settings window left
+            no trace anywhere under `~/.ghostex/logs`, which is why a blank
+            Settings report could not be diagnosed from a user's machine at all.
+
+            Persist both through the existing sanitized AppModal writer. The error
+            event name contains `error`, so `event_is_important_diagnostic` keeps
+            recording it even while the routine `gpui.app.modal` scenario is off,
+            while routine breadcrumbs stay opt-in behind that scenario. Stacks
+            carry paths and URLs, so they are reported as a presence flag and
+            never stored; `details` is parsed back into structured JSON so the
+            writer can sanitize each bounded field instead of redacting one long
+            string wholesale.
+            */
+            "logError" => {
+                let current_modal_id = self.app_modal_window.clone().and_then(|handle| {
+                    handle
+                        .update(cx, |host, _window, _cx| host.current_modal.modal_id())
+                        .ok()
+                });
+                support_logs::append(
+                    support_logs::GpuiSupportLog::AppModal,
+                    "gpui.appModal.rendererError",
+                    serde_json::json!({
+                        "area": message.get("area").and_then(serde_json::Value::as_str),
+                        "errorMessage": message.get("message").and_then(serde_json::Value::as_str),
+                        "errorName": message.get("name").and_then(serde_json::Value::as_str),
+                        "hasStack": message
+                            .get("stack")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(|stack| !stack.trim().is_empty()),
+                        "modal": current_modal_id,
+                    }),
+                );
+            }
+            "debugLog" => {
+                support_logs::append(
+                    support_logs::GpuiSupportLog::AppModal,
+                    message
+                        .get("event")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("gpui.appModal.debugLog"),
+                    message
+                        .get("details")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(|details| serde_json::from_str::<serde_json::Value>(details).ok())
+                        .unwrap_or(serde_json::Value::Null),
+                );
+            }
             _ => {}
         }
     }

--- a/sidebar/sidebar-store.test.ts
+++ b/sidebar/sidebar-store.test.ts
@@ -651,6 +651,46 @@ describe("sidebar store", () => {
       "2026-07-30T09:00:00.000Z",
     );
   });
+
+  /*
+  CDXC:SettingsModalBlankUnnormalizedHydrate 2026-07-29:
+  The GPUI hydrate carries the shared settings file verbatim, so a file only ever
+  written by titlebar code paths arrives without whole nested schema objects. The
+  app-modal Settings render read `settings.workspaceOpenTargetAvailability
+  .availableTargetIds` directly and threw, blanking the window permanently.
+  */
+  test("should normalize a partial hydrated settings object into the full schema shape", () => {
+    const partialSettingsFromDisk = {
+      gpuiTitlebarOpenTargetByProject: { P70t8: "finder" },
+      gpuiTitlebarTipsReadIds: ["command-palette-all-actions"],
+    };
+    const message = createHydrateMessage([]);
+
+    useSidebarStore.getState().applySidebarMessage({
+      ...message,
+      hud: {
+        ...message.hud,
+        settings: partialSettingsFromDisk as unknown as typeof message.hud.settings,
+      },
+    });
+
+    const settings = useSidebarStore.getState().hud.settings;
+    expect(settings).toBeDefined();
+
+    // The exact read that threw: a missing nested object must arrive complete.
+    expect(settings?.workspaceOpenTargetAvailability.availableTargetIds).toBeInstanceOf(Array);
+    expect(settings?.hotkeys).toBeDefined();
+    expect(settings?.diagnosticLogging).toBeDefined();
+
+    // Values the user already had must survive normalization.
+    expect(settings?.gpuiTitlebarOpenTargetByProject).toEqual({ P70t8: "finder" });
+
+    // Keys the schema does not model must survive so a later full save cannot
+    // silently drop them.
+    expect(
+      (settings as unknown as { gpuiTitlebarTipsReadIds?: string[] }).gpuiTitlebarTipsReadIds,
+    ).toEqual(["command-palette-all-actions"]);
+  });
 });
 
 function createHydrateMessage(

--- a/sidebar/sidebar-store.ts
+++ b/sidebar/sidebar-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { createDefaultSidebarAgentButtons } from "../shared/sidebar-agents";
 import { createDefaultSidebarCommandButtons } from "../shared/sidebar-commands";
 import { DEFAULT_COMPLETION_SOUND, getCompletionSoundLabel } from "../shared/completion-sound";
-import { DEFAULT_ghostex_SETTINGS } from "../shared/ghostex-settings";
+import { DEFAULT_ghostex_SETTINGS, normalizeghostexSettings } from "../shared/ghostex-settings";
 import { createDefaultSidebarGitState, type SidebarGitFileDiffDraft } from "../shared/sidebar-git";
 import type {
   SidebarCommandRunStateClearedMessage,
@@ -279,6 +279,37 @@ function getInitialSidebarTheme(): SidebarHudState["theme"] {
     : "dark-blue";
 }
 
+/*
+CDXC:SettingsModalBlankUnnormalizedHydrate 2026-07-29:
+A hydrate carries whatever the shared settings file happens to hold. The GPUI
+writer parses that JSON with no defaults (`read_settings_object_from_path`), so a
+file only ever written by titlebar code paths arrives missing entire nested
+objects such as `workspaceOpenTargetAvailability`, `hotkeys`, and
+`diagnosticLogging`. Consumers of `hud.settings` read the documented schema shape
+directly (for example `settings.workspaceOpenTargetAvailability.availableTargetIds`),
+so one absent nested object threw during the app-modal Settings render and left
+that window permanently blank — with no way to save a first full settings file
+from the UI, because Settings is the UI that could not open.
+
+Normalize hydrated settings through the same shared schema the GPUI sidebar
+handoff already applies (`createGpuiSidebarSettings`), so every hydrate consumer
+sees the complete documented shape instead of the raw file. Keys the schema does
+not model (for example `gpuiTitlebarTipsReadIds`) are kept ahead of the
+normalized values so a later full-settings save cannot drop them, and an absent
+`settings` stays absent so host readiness gates keep their current meaning.
+*/
+function normalizeHydratedSidebarHud(hud: SidebarHudState): SidebarHudState {
+  return {
+    ...hud,
+    projectSettingsProjects: hud.projectSettingsProjects ?? [],
+    recentProjects: hud.recentProjects ?? [],
+    settings:
+      hud.settings === undefined
+        ? undefined
+        : { ...hud.settings, ...normalizeghostexSettings(hud.settings) },
+  };
+}
+
 function applySidebarMessageState(
   state: SidebarStoreState,
   message: SidebarHydrateMessage | SidebarSessionStateMessage,
@@ -300,11 +331,10 @@ function applySidebarMessageState(
     state.pendingFocusedSessionId,
   );
   const normalizedGroups = normalizeSidebarGroups(state, reconciledGroups.groups);
-  const nextHud = preserveSidebarHudReferences(state.hud, {
-    ...message.hud,
-    projectSettingsProjects: message.hud.projectSettingsProjects ?? [],
-    recentProjects: message.hud.recentProjects ?? [],
-  });
+  const nextHud = preserveSidebarHudReferences(
+    state.hud,
+    normalizeHydratedSidebarHud(message.hud),
+  );
   return {
     commandRunStates: reconcileSidebarCommandRunFeedbackStates(
       state.commandRunStates,
@@ -334,11 +364,10 @@ function applyHudChangedMessageState(
     return state;
   }
 
-  const nextHud = preserveSidebarHudReferences(state.hud, {
-    ...message.hud,
-    projectSettingsProjects: message.hud.projectSettingsProjects ?? [],
-    recentProjects: message.hud.recentProjects ?? [],
-  });
+  const nextHud = preserveSidebarHudReferences(
+    state.hud,
+    normalizeHydratedSidebarHud(message.hud),
+  );
   return {
     commandRunStates: reconcileSidebarCommandRunFeedbackStates(
       state.commandRunStates,


### PR DESCRIPTION
## Problem

The GPUI app-modal **Settings window opens permanently blank** on installs whose shared settings file has never been written by a full Settings save. Reported from a notarized `6.9.0` Homebrew Cask install on macOS arm64.

It could not be reproduced by the maintainer because any machine where Settings has ever been saved already has the key that throws.

## Root cause

`gpui/src/shared_settings.rs` → `read_settings_object_from_path` parses the shared settings JSON and fills **no defaults**:

```rust
let object = serde_json::from_slice::<Value>(&bytes).ok()
    .and_then(|value| match value { Value::Object(object) => Some(object), _ => None })
    .unwrap_or_default();
```

That raw map goes straight into the app-modal hydrate as `hud.settings`. On the reporting machine `~/.ghostex/state/native-sidebar-settings.json` held **2 of the schema's 134 keys** — only the two the titlebar writes:

```json
{ "gpuiTitlebarOpenTargetByProject": { "P70t8": "finder" },
  "gpuiTitlebarTipsReadIds": [ "…11 ids…" ] }
```

Six nested schema objects were absent: `workspaceOpenTargetAvailability`, `hotkeys`, `diagnosticLogging`, `settingsModalNavigation`, `sidebarProjectGroupingOverrides`, `gpuiTitlebarActionCommandByProject`.

Consumers inside the modal host read the documented shape directly — `sidebar/command-palette.tsx:423`:

```ts
const availableTargetIds = new Set(settings.workspaceOpenTargetAvailability.availableTargetIds);
```

so the render threw inside a `useMemo`:

```
TypeError: Cannot read properties of undefined (reading 'availableTargetIds')
    at jDe (…/sidebar/modal-host.html:185:21664)
    at Object.WV [as useMemo] (…)
```

`native/sidebar/modal-host.tsx:2943` mounts with `createRoot(...).render(<AppModalHost />)` and **no error boundary**, so React unmounted the whole tree → `#root` empty → blank window. The state is self-sustaining: Settings is the only UI that writes a full settings file, so the user cannot save the key that would fix it.

**The sidebar never hit this** because its handoff already normalizes — `gpui/sidebar/gxserver-runtime.ts:15445`:

```ts
const settings = normalizeghostexSettings(runtimeSettings?.settings);
```

The app-modal host had no equivalent. That asymmetry is the bug.

## Evidence

Captured by attaching to the running production app's CEF surface (remote debugging defaults to 9334, `gpui/src/cef/shell.rs:4281`).

Blank Settings surface, after its hydrate arrived:

| probe | value |
|---|---|
| `readyState` | `complete` |
| React container on `#root` | `__reactContainer$…` (mounted) |
| `rootChildCount` / `rootHtmlLength` | `0` / `0` |
| `hasBridge` | `true` |

Messages the surface actually received (recorded read-only, nothing injected):

```json
{"envelopeType":"sidebarState","innerMessage":{"type":"hydrate","revision":1,"hasHudSettings":true,"hudKeys":24}}
{"envelopeType":"open","modal":"settings","inlineHydrate":{"type":"hydrate","revision":1,"hasHudSettings":true,"hudKeys":24}}
```

Every renderability gate passed — `revision: 1` so `hasNativeSettingsHydrated` was true, `hud.settings` present, `activeModal: "settings"`. The window was not waiting on hydration; it rendered and threw. A sibling modal-host surface in the same app rendered fine (`rootChildCount: 3`), isolating the failure to the Settings render path. The same exception was captured from two independent blank windows.

## Why there was no log to look at

Both diagnostics the modal host already emits were being discarded by GPUI:

- `logAppModalError` (installed by `installAppModalGlobalErrorLogging`) posts `{type:"logError"}` through `window.webkit.messageHandlers.ghostexAppModalHost`. The CEF shim **does** install that handler for `modal-host.html`, so the message reached Rust — but `receive_app_modal_host_bridge_event` had **no `logError` arm** and it fell through `_ => {}`.
- `postSettingsModalDebugLog` posts `{type:"debugLog"}` carrying the `modalHost.settings.renderState` breadcrumbs built for this exact bug. Also no arm.
- The Rust-side breadcrumbs that do exist are gated on `gpui.app.modal`, which `default_enabled()` returns false for.

Net effect: a render error that blanked Settings produced **zero bytes** anywhere under `~/.ghostex/logs`. Compounding it, the missing `diagnosticLogging` key made the React-side gate (`isDiagnosticLoggingScenarioEnabled(undefined, …)` → `false`) disable app-modal logging on precisely the machines that hit the bug.

## Changes

1. **`sidebar/sidebar-store.ts`** — normalize hydrated settings through the shared schema at both boundaries (`applySidebarMessageState`, `applyHudChangedMessageState`) via one `normalizeHydratedSidebarHud` helper. Deliberately:
   - unknown keys are spread **before** the normalized values, so `gpuiTitlebarTipsReadIds` (not modeled by the schema — `normalizeghostexSettings` drops it) survives a later full-settings save instead of being silently lost;
   - an absent `settings` stays absent, so host readiness gates keep their current meaning;
   - `preserveIfEqual("settings")` already deep-compares, so no reference churn is added on the perf-sensitive sidebar path.

2. **`gpui/src/main.rs`** — handle `logError` and `debugLog`. The error event is named `gpui.appModal.rendererError`; `event_is_important_diagnostic` matches `error`, so it records even while the routine `gpui.app.modal` scenario is off. Stacks contain paths, so only a `hasStack` flag is stored; `details` is parsed back into structured JSON so `sanitize_json_value` sanitizes each bounded field instead of redacting one long string.

3. **`sidebar/sidebar-store.test.ts`** — regression test built from the real 2-key file. With the normalization removed it fails with the identical production message.

No fallbacks were added at the call sites: the fix is at the one boundary where the shape contract is owed, matching what the sidebar handoff already does.

## Verification

- `cargo check --bin ghostex-gpui` → `Finished dev profile in 1m 25s`, 0 errors (the 169 warnings are pre-existing dead-code in `windows_terminal_backend.rs`).
- `tsc --noEmit` → 0 errors.
- `vitest run sidebar/sidebar-store.test.ts` → 17/17 pass.
- Full `vitest run` → 1200 pass. The same 3 failures across 4 files occur on unmodified `main` (verified by baseline); all are source-inspection tests unrelated to this change.

Per `AGENTS.md` no tests were added under `gpui/` or the deprecated macOS app trees.

## Suggested follow-ups (not in this PR)

- **Add an error boundary around the modal host root.** A render throw currently unmounts everything into a silent blank window; an honest in-window error state would have made this self-reporting.
- **Reconsider the `gpui.app.modal` default**, or make a missing `diagnosticLogging` key fall back to the shared defaults rather than "off", so the machines most likely to hit a bug are not the ones with logging disabled.
- **`~/Library/LaunchAgents/com.madda.ghostex.gxserver.plist` can end up pinned to a build directory.** On the reporting machine it pointed at `…/Desktop/Ghostex/gpui/build/macos/Ghostex.app/…/bin/gxserver` with `RunAtLoad=false` / `KeepAlive=false`. While that path was not running, the release app took `ERR_CONNECTION_REFUSED` on every `127.0.0.1:58744/api/*` call even though it logged `gxserverBootstrap.launchdAgent {bootstrapped:true, kickstarted:true}` and `launchctl` reported `runs = 1`. Unrelated to this bug, but a release install probably should not inherit a daemon registration pointing into a checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of application modal errors and diagnostic messages, including safer structured logging.
  * Fixed sidebar settings hydration so partially configured settings retain existing values and receive required defaults.
  * Preserved additional settings fields during sidebar updates instead of dropping unrecognized values.

* **Tests**
  * Added coverage for restoring and normalizing incomplete sidebar settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->