### PR TITLE
fix(sidebar): don't rename an established Beads issue prefix when the board is shared between projects

### DIFF
--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -261,4 +261,33 @@ describe("project board issue prefix", () => {
 
     expect(requests).toEqual([{ action: "configGetIssuePrefix", value: undefined }]);
   });
+
+  test("keeps an established issue_prefix that differs from the project prefix", async () => {
+    /*
+     * CDXC:ProjectBoardBeads 2026-07-31:
+     * A shared beadsDirectory serves several projects; an established prefix is durable data, not
+     * stale bootstrap config, so focusing a differently named project must not rename the board.
+     */
+    const requests: Array<{ action: string; value?: string }> = [];
+    await ensureIssuePrefix(async (request) => {
+      requests.push({ action: request.action, value: request.value });
+      return { value: "agent-bo" };
+    }, "email-cleaner");
+
+    expect(requests).toEqual([{ action: "configGetIssuePrefix", value: undefined }]);
+  });
+
+  test("adopts the project prefix when issue_prefix is unset", async () => {
+    const requests: Array<{ action: string; value?: string }> = [];
+    await ensureIssuePrefix(async (request) => {
+      requests.push({ action: request.action, value: request.value });
+      return request.action === "configGetIssuePrefix" ? { value: "" } : {};
+    }, "email-cleaner");
+
+    expect(requests).toEqual([
+      { action: "configGetIssuePrefix", value: undefined },
+      { action: "renamePrefix", value: "email-cl-" },
+    ]);
+  });
 });
+

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -205,19 +205,29 @@ export function normalizeIssuePrefix(value: string | undefined): string {
   return /^[a-z]/u.test(normalized) ? normalized : `p-${normalized}`;
 }
 
+/*
+ * CDXC:ProjectBoardBeads 2026-07-31:
+ * Prefix reconciliation exists to replace stale bootstrap defaults (for example gxserver, or an
+ * unset value that normalizes to zmux) with the active project's prefix. A board that already has
+ * any other established prefix must keep it: projectBoardConfig.beadsDirectory can point several
+ * projects at one shared board, and renaming it to whichever project was focused last mass-renames
+ * every issue id and all text references on each board load — which also breaks the beadId values
+ * persisted in beadConversationLinks.
+ */
+const BOOTSTRAP_ISSUE_PREFIXES = new Set(["gxserver", "zmux"]);
+
 export async function ensureIssuePrefix(
   runBeads: (request: Omit<BeadsBridgeRequest, "cwd" | "requestId">) => Promise<unknown>,
   desiredPrefix: string,
 ): Promise<void> {
-  /*
-   * CDXC:ProjectBoardBeads 2026-06-10-20:27:
-   * Project-board ticket creation must use the active project's Beads issue prefix, not a stale repository YAML/default prefix such as gxserver.
-   * Reconcile issue_prefix through Beads rename-prefix before board mutations so the real Beads ids and the visible project board scope stay aligned.
-   */
   const normalizedDesiredPrefix = normalizeIssuePrefix(desiredPrefix);
   const payload = await runBeads({ action: "configGetIssuePrefix" });
   const currentValue = normalizeBeadsConfigString(payload);
-  if (normalizeIssuePrefix(currentValue) !== normalizedDesiredPrefix) {
+  const normalizedCurrentPrefix = normalizeIssuePrefix(currentValue);
+  if (
+    normalizedCurrentPrefix !== normalizedDesiredPrefix &&
+    BOOTSTRAP_ISSUE_PREFIXES.has(normalizedCurrentPrefix)
+  ) {
     await runBeads({ action: "renamePrefix", value: beadsRenamePrefixValue(normalizedDesiredPrefix) });
   }
 }
@@ -724,3 +734,4 @@ export function formatShortDate(value?: string): string {
   }
   return date.toLocaleDateString(undefined, { day: "numeric", month: "short" });
 }
+


### PR DESCRIPTION
## The problem

`ensureIssuePrefix` (native/sidebar/project-board-shared.ts) reconciles the board's
`issue_prefix` toward the focused project's name on every board load and before every
ticket creation. When `projectBoardConfig.beadsDirectory` points several projects at one
shared Beads board — the natural setup for a cross-project agent task queue — that
reconciliation executes `bd rename-prefix <project> --repair` against the shared database
each time a differently named project's board loads. Every issue id in the database is
renamed, including all text references.

Observed on a real workspace with 7 projects sharing one board:

- 37 `bd: rename-prefix (auto-commit)` commits in the board's Dolt history over 3 weeks,
  the prefix ping-ponging between `agent-bo`, `agent-co`, `hermes-v`, `hermes-c`,
  `email-cl`, `quickcha` — each an 8-char normalization of a Ghostex project name,
  rewriting ~200 issue ids per flip. Three flips on a single day, two of them 17 seconds
  apart during ordinary tab switching.
- Every stored issue id becomes a time bomb: ids cited in issue comments, in external
  automation state, and in `beadConversationLinks` inside `projectBoardConfigJson` itself
  stop resolving after the next tab switch. Our state.db has links with `beadId`
  values from several incompatible prefix eras (`agent-board-236`, `agent-bo-8f6e776c`)
  in a single project's config.
- `bd rename-prefix` upstream describes itself as "a rare operation — most users never
  need this command"; here it runs multiple times a day.

## The fix

Keep the original intent — the 2026-06-10 comment says the reconciliation exists to
replace "a stale repository YAML/default prefix such as gxserver" — but only fire the
rename when the current prefix actually is such a bootstrap default (`gxserver`, or an
unset value, which `normalizeIssuePrefix` maps to `zmux`). A board with any other
established prefix keeps it, even when it differs from the focused project's name:
an established prefix is durable data (ids are references), not stale config.

The existing scenario still works: a fresh or gxserver-prefixed board adopts the
project's prefix on first load. What changes is that an already-prefixed board is never
mass-renamed again — neither by a shared-board sibling project nor after a project
rename.

- `native/sidebar/project-board-shared.ts`: gate the `renamePrefix` call on the current
  prefix being in `BOOTSTRAP_ISSUE_PREFIXES` (`gxserver`, `zmux`).
- `native/sidebar/project-board-shared.test.ts`: two new tests — an established
  non-matching prefix is kept; an unset prefix still adopts the project prefix. The
  three existing prefix tests pass unchanged.

## Alternative considered

Gating on "board directory is project-local" (skip the rename whenever
`projectBoardConfig.beadsDirectory` is configured) would also work and is arguably
stricter, but the sidebar doesn't currently receive that fact — it would need a new URL
param through each webview bridge (WKWebView + CEF), or a guard in the Rust executor
(`gxserver-rs/src/typed_operations.rs`, which would then need to no-op rather than error
so `ensureIssuePrefix` callers don't fail board loads). Happy to do that variant or add
it as defense-in-depth if you prefer.

## Repro

1. Create two Ghostex projects with different names; point both
   `projectBoardConfig.beadsDirectory` at the same Beads workspace.
2. Open the project board in project A, then in project B.
3. Before this fix: `bd list` shows every issue id renamed to B's prefix (and the Dolt
   log gains a `rename-prefix` commit per switch). After: ids are stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved established issue prefixes when they differ from the current project prefix.
  - Automatically adopted the project-derived prefix when no meaningful prefix had been configured.
  - Prevented routine project updates from unexpectedly renaming existing issue identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->