### PR TITLE
feat(actions): show flagged quick actions on sidebar project rows

### DIFF
--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -14141,8 +14141,15 @@ class GpuiSidebarRuntime {
     }
     if (targetProjectId && targetProjectId !== this.activeProjectId) {
       this.focusProjectId(targetProjectId);
-      this.postGxserverPresentationFocusState();
-      this.postActiveProjectContext();
+      /*
+       * Publish a presentation patch rather than posting focus state and
+       * active-project context directly: both read `latestGroups`, which only
+       * `publishPresentation` refreshes, so posting them alone would leave the
+       * sidebar's active-row highlight on the previous project until an
+       * unrelated delta arrived. This matches every other project-switching
+       * call site in this file.
+       */
+      this.publishPresentation("patch");
     }
     if (this.postSidebarCommandAction(command, selectionMessage)) {
       return;
@@ -15183,14 +15190,29 @@ function createGpuiSidebarHudState({
       ? ([...sidebarHud.agents] as SidebarAgentButton[])
       : createSidebarAgentButtons([], [])
   ).filter((agent) => agent.agentId !== "t3");
+  /*
+   * CDXC:ProjectActions 2026-08-01:
+   * `showOnProjectRow` is optional on the gxserver contract because a daemon
+   * older than the app drops fields it does not know, so a legacy response
+   * yields `undefined` where SidebarCommandButton promises a boolean. Normalize
+   * at the surface boundary instead of casting the gap away, so row rendering
+   * and the Settings toggle both see a real boolean.
+   */
+  const normalizeHudCommands = (
+    hudCommands: readonly GxserverSidebarHudResponse["commands"][number][],
+  ): ReturnType<typeof createSidebarCommandButtons> =>
+    hudCommands.map((command) => ({
+      ...command,
+      showOnProjectRow: command.showOnProjectRow === true,
+    })) as ReturnType<typeof createSidebarCommandButtons>;
   const commands = sidebarHud
-    ? ([...sidebarHud.commands] as ReturnType<typeof createSidebarCommandButtons>)
+    ? normalizeHudCommands(sidebarHud.commands)
     : createSidebarCommandButtons([], [], []);
   const commandsByProject = sidebarHud?.commandsByProject
     ? Object.fromEntries(
         Object.entries(sidebarHud.commandsByProject).map(([projectId, projectCommands]) => [
           projectId,
-          [...projectCommands] as ReturnType<typeof createSidebarCommandButtons>,
+          normalizeHudCommands(projectCommands),
         ]),
       )
     : undefined;

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -553,7 +553,12 @@ const GPUI_SIDEBAR_COMMAND_ACTION_MESSAGE_VERSION = 1;
 const GPUI_SIDEBAR_COMMAND_ACTION_MESSAGE_TYPE = "ghostex.gpui.sidebar.commandAction";
 const GPUI_SIDEBAR_COMMAND_RUN_END_MESSAGE_VERSION = 1;
 const GPUI_SIDEBAR_COMMAND_RUN_END_MESSAGE_TYPE = "ghostex.gpui.sidebar.commandRunEnd";
-const GPUI_SIDEBAR_COMMAND_SELECTOR_MESSAGE_KEYS = new Set(["commandId", "runMode", "type"]);
+const GPUI_SIDEBAR_COMMAND_SELECTOR_MESSAGE_KEYS = new Set([
+  "commandId",
+  "groupId",
+  "runMode",
+  "type",
+]);
 const GPUI_SIDEBAR_GXSERVER_FOCUS_STATE_MESSAGE_VERSION = 1;
 const GPUI_SIDEBAR_GXSERVER_FOCUS_STATE_MESSAGE_TYPE =
   "ghostex.gpui.sidebar.gxserverPresentationFocusState";
@@ -13201,6 +13206,7 @@ class GpuiSidebarRuntime {
       name,
       playCompletionSound: message.actionType === "terminal" ? message.playCompletionSound : false,
       operation: "save",
+      showOnProjectRow: message.showOnProjectRow,
       target: "command",
       url,
     });
@@ -14025,6 +14031,37 @@ class GpuiSidebarRuntime {
     return commands.find((command) => command.commandId === normalizedCommandId);
   }
 
+  /*
+  CDXC:ProjectActions 2026-08-01:
+  Project-row Action clicks resolve against the clicked project's own command
+  list from the HUD's commandsByProject block, never the active project's list,
+  so two projects with different Actions cannot cross-launch. A project id with
+  no per-project entry only falls back to the flat active list when it IS the
+  active project; otherwise the click is an unsupported no-op.
+  */
+  private resolveSidebarCommandForProject(
+    commandId: string,
+    projectId: string | undefined,
+  ): SidebarCommandButton | undefined {
+    if (!projectId) {
+      return this.resolveSidebarCommand(commandId);
+    }
+    const normalizedCommandId = commandId.trim();
+    if (!normalizedCommandId) {
+      return undefined;
+    }
+    const projectCommands = this.sidebarHud?.commandsByProject?.[projectId];
+    if (projectCommands) {
+      return ([...projectCommands] as SidebarCommandButton[]).find(
+        (command) => command.commandId === normalizedCommandId,
+      );
+    }
+    if (projectId !== this.activeProjectId) {
+      return undefined;
+    }
+    return this.resolveSidebarCommand(commandId);
+  }
+
   private createSidebarCommandSelectionMessage(
     commandId: string,
     originalMessage: SidebarToExtensionMessage,
@@ -14072,13 +14109,28 @@ class GpuiSidebarRuntime {
      *
      * CDXC:GPUICommandPane 2026-06-27-07:54:
      * Treat selector shape as part of the Action contract before looking up the HUD command. Extra launch/run-state fields are unsupported no-ops, not sanitized launches, while valid configured-but-empty selectors still reach Settings like macOS.
+     *
+     * CDXC:ProjectActions 2026-08-01:
+     * Project-row Action buttons pass the row's group id. Resolve the Action
+     * from that project's own command list and activate the project through
+     * the existing focus flow before dispatching, so the launch bridge payload
+     * stays project-blind and the command pane opens in the project the user
+     * clicked — the same ordering as clicking the row and then the titlebar
+     * action by hand.
      */
     const selectionMessage = this.createSidebarCommandSelectionMessage(commandId, originalMessage);
     if (!selectionMessage) {
       this.handleUnsupportedSidebarMessage(originalMessage);
       return;
     }
-    const command = this.resolveSidebarCommand(commandId);
+    const groupId =
+      originalMessage.type === "runSidebarCommand"
+        ? normalizeNonEmptyString(originalMessage.groupId ?? "")
+        : undefined;
+    const targetProjectId = groupId
+      ? parseGxserverPresentationProjectGroupId(groupId)
+      : undefined;
+    const command = this.resolveSidebarCommandForProject(commandId, targetProjectId);
     if (!command) {
       this.handleUnsupportedSidebarMessage(originalMessage);
       return;
@@ -14086,6 +14138,11 @@ class GpuiSidebarRuntime {
     if (!isSidebarCommandConfigured(command)) {
       this.openAppModal("settings");
       return;
+    }
+    if (targetProjectId && targetProjectId !== this.activeProjectId) {
+      this.focusProjectId(targetProjectId);
+      this.postGxserverPresentationFocusState();
+      this.postActiveProjectContext();
     }
     if (this.postSidebarCommandAction(command, selectionMessage)) {
       return;
@@ -14117,7 +14174,17 @@ class GpuiSidebarRuntime {
      * renderer. Apply the returned canonical project rows and HUD projection so
      * Settings rows and sidebar buttons refresh from the same daemon contract.
      */
-    const response = await client.mutateSidebarHudSettings(params);
+    const response = await client.mutateSidebarHudSettings({
+      ...params,
+      /*
+       * CDXC:ProjectActions 2026-08-01:
+       * The mutation result replaces the whole HUD snapshot, so every settings
+       * mutation must carry the per-project command block the sidebar rows
+       * render from — otherwise an agent or action save would blank them
+       * until the next full HUD poll.
+       */
+      includeAllProjectCommands: true,
+    });
     if (this.client !== client) {
       return undefined;
     }
@@ -14401,10 +14468,15 @@ class GpuiGxserverClient {
 
   async fetchSidebarHud(activeProjectId: string | undefined): Promise<GxserverSidebarHudResponse> {
     const normalizedActiveProjectId = activeProjectId?.trim();
-    return this.rpc<GxserverSidebarHudResponse>(
-      "/api/readSidebarHud",
-      normalizedActiveProjectId ? { activeProjectId: normalizedActiveProjectId } : {},
-    );
+    /*
+     * CDXC:ProjectActions 2026-08-01:
+     * The GPUI sidebar renders showOnProjectRow quick actions on every project
+     * row, so the HUD read always asks for the per-project command block.
+     */
+    return this.rpc<GxserverSidebarHudResponse>("/api/readSidebarHud", {
+      includeAllProjectCommands: true,
+      ...(normalizedActiveProjectId ? { activeProjectId: normalizedActiveProjectId } : {}),
+    });
   }
 
   async mutateSidebarHudSettings(
@@ -15114,6 +15186,14 @@ function createGpuiSidebarHudState({
   const commands = sidebarHud
     ? ([...sidebarHud.commands] as ReturnType<typeof createSidebarCommandButtons>)
     : createSidebarCommandButtons([], [], []);
+  const commandsByProject = sidebarHud?.commandsByProject
+    ? Object.fromEntries(
+        Object.entries(sidebarHud.commandsByProject).map(([projectId, projectCommands]) => [
+          projectId,
+          [...projectCommands] as ReturnType<typeof createSidebarCommandButtons>,
+        ]),
+      )
+    : undefined;
   const focusedSession = groups
     .flatMap((group) => group.sessions)
     .find(
@@ -15129,6 +15209,7 @@ function createGpuiSidebarHudState({
     agentManagerZoomPercent: settings.agentManagerZoomPercent,
     agents,
     commands,
+    ...(commandsByProject ? { commandsByProject } : {}),
     commandSessionIndicators: createGpuiSidebarCommandSessionIndicators(
       commands,
       commandPaneSessions,

--- a/gpui/src/main.rs
+++ b/gpui/src/main.rs
@@ -97467,6 +97467,7 @@ struct GpuiStoredSidebarCommand {
     is_default: bool,
     name: String,
     play_completion_sound: bool,
+    show_on_project_row: bool,
     url: Option<String>,
 }
 
@@ -97632,6 +97633,7 @@ enum GpuiSidebarCommandMetadataWrite {
         icon: Option<String>,
         name: String,
         play_completion_sound: bool,
+        show_on_project_row: bool,
         url: Option<String>,
     },
     Delete {
@@ -98129,6 +98131,7 @@ fn gpui_default_sidebar_command_button_value(
         "isDefault": true,
         "name": command.name,
         "playCompletionSound": true,
+        "showOnProjectRow": false,
     })
 }
 
@@ -98166,6 +98169,10 @@ fn gpui_sidebar_command_button_value(command: &GpuiStoredSidebarCommand) -> serd
     button.insert(
         "playCompletionSound".to_string(),
         serde_json::Value::Bool(command.play_completion_sound),
+    );
+    button.insert(
+        "showOnProjectRow".to_string(),
+        serde_json::Value::Bool(command.show_on_project_row),
     );
     if let Some(url) = command.url.as_ref() {
         button.insert("url".to_string(), serde_json::Value::String(url.clone()));
@@ -98346,6 +98353,11 @@ fn gpui_normalized_stored_sidebar_commands(
             .unwrap_or(false)
             || gpui_is_default_sidebar_command_id(command_id);
 
+        let show_on_project_row = item
+            .get("showOnProjectRow")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+
         if action_type == "browser" {
             let Some(url) = url else {
                 continue;
@@ -98359,6 +98371,7 @@ fn gpui_normalized_stored_sidebar_commands(
                 is_default,
                 name,
                 play_completion_sound: false,
+                show_on_project_row,
                 url: Some(url),
             });
             seen_command_ids.insert(command_id.to_string());
@@ -98387,6 +98400,7 @@ fn gpui_normalized_stored_sidebar_commands(
                 .get("playCompletionSound")
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(true),
+            show_on_project_row,
             url: None,
         });
         seen_command_ids.insert(command_id.to_string());
@@ -98551,6 +98565,10 @@ fn gpui_sidebar_command_metadata_write_from_command(
                         .get("playCompletionSound")
                         .and_then(serde_json::Value::as_bool)
                         .unwrap_or(true),
+                show_on_project_row: command
+                    .get("showOnProjectRow")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
                 url: (action_type == "browser").then_some(url).flatten(),
             })
         }
@@ -98676,6 +98694,7 @@ fn gpui_sidebar_command_mutation_params(
             icon,
             name,
             play_completion_sound,
+            show_on_project_row,
             url,
         } => {
             params.insert(
@@ -98701,6 +98720,10 @@ fn gpui_sidebar_command_mutation_params(
             params.insert(
                 "playCompletionSound".to_string(),
                 serde_json::Value::Bool(*play_completion_sound),
+            );
+            params.insert(
+                "showOnProjectRow".to_string(),
+                serde_json::Value::Bool(*show_on_project_row),
             );
             gpui_insert_optional_nonempty_string(&mut params, "url", url.as_deref());
         }
@@ -98994,6 +99017,7 @@ fn gpui_next_sidebar_command_metadata_state(
             icon,
             name,
             play_completion_sound,
+            show_on_project_row,
             url,
             ..
         } => {
@@ -99015,6 +99039,7 @@ fn gpui_next_sidebar_command_metadata_state(
                 is_default: gpui_is_default_sidebar_command_id(&next_command_id),
                 name,
                 play_completion_sound: action_type == "terminal" && play_completion_sound,
+                show_on_project_row,
                 url: (action_type == "browser").then_some(url).flatten(),
             };
             gpui_reject_duplicate_sidebar_command_title(
@@ -99408,6 +99433,10 @@ fn gpui_stored_sidebar_commands_value(commands: &[GpuiStoredSidebarCommand]) -> 
                 item.insert(
                     "playCompletionSound".to_string(),
                     serde_json::Value::Bool(command.play_completion_sound),
+                );
+                item.insert(
+                    "showOnProjectRow".to_string(),
+                    serde_json::Value::Bool(command.show_on_project_row),
                 );
                 if let Some(url) = command.url.as_ref() {
                     item.insert("url".to_string(), serde_json::Value::String(url.clone()));

--- a/gxserver-rs/src/ghostex_cli/actions.rs
+++ b/gxserver-rs/src/ghostex_cli/actions.rs
@@ -479,6 +479,10 @@ fn save_gxserver_command(payload: &Value, flags: &Flags) -> CliResult<Value> {
                 && payload.get("playCompletionSound") != Some(&Value::Bool(false))
         ),
     );
+    saved_command.insert(
+        "showOnProjectRow".to_string(),
+        json!(payload.get("showOnProjectRow") == Some(&Value::Bool(true))),
+    );
     if action_type == "browser" {
         saved_command.insert("url".to_string(), json!(url));
     } else {
@@ -1054,6 +1058,16 @@ fn parse_save_command(rest: &[String], flags: &Flags) -> Value {
                 .get("playCompletionSound")
                 .map(parse_boolean)
                 .unwrap_or(true),
+        ),
+    );
+    map.insert(
+        "showOnProjectRow".to_string(),
+        Value::Bool(
+            flags
+                .0
+                .get("showOnProjectRow")
+                .map(parse_boolean)
+                .unwrap_or(false),
         ),
     );
     set_or_remove(&mut map, "url", flag_json(flags, "url"));
@@ -1993,6 +2007,7 @@ mod tests {
                 "commandId": "dev",
                 "name": "Dev Server",
                 "playCompletionSound": true,
+                "showOnProjectRow": false,
             })
         );
     }

--- a/gxserver-rs/src/ghostex_cli/actions.rs
+++ b/gxserver-rs/src/ghostex_cli/actions.rs
@@ -2013,6 +2013,22 @@ mod tests {
     }
 
     #[test]
+    fn save_command_preserves_enabled_show_on_project_row() {
+        // The flag is opt-in, so the enabled path needs its own coverage: a
+        // default-only assertion would still pass if the flag were hardcoded.
+        let (rest, flags) = parsed(&[
+            "--showOnProjectRow",
+            "true",
+            "lazygit",
+            "Lazygit",
+            "lazygit",
+        ]);
+        let payload = parse_save_command(&rest, &flags);
+        assert_eq!(payload.get("showOnProjectRow"), Some(&json!(true)));
+        assert_eq!(payload.get("commandId"), Some(&json!("lazygit")));
+    }
+
+    #[test]
     fn browser_open_reuse_and_new() {
         let (rest, flags) = parsed(&["https://example.com", "--new", "--active-project"]);
         let payload = parse_browser_open(&rest, &flags);

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -2254,7 +2254,27 @@ async fn route_http(
                     updated_projects.push(project);
                 }
                 let projects = repository.list_projects()?;
-                let hud = read_sidebar_hud(&projects, hud_active_project_id.as_deref());
+                let mut hud = read_sidebar_hud(&projects, hud_active_project_id.as_deref());
+                /*
+                CDXC:ProjectActions 2026-08-01:
+                Clients that render per-project quick actions (GPUI sidebar rows)
+                replace their whole HUD snapshot with this response, so the
+                mutation mirrors readSidebarHud's opt-in commandsByProject block.
+                Without it a Settings save would drop the per-project rows until
+                the next full HUD poll.
+                */
+                if params
+                    .get("includeAllProjectCommands")
+                    .and_then(Value::as_bool)
+                    == Some(true)
+                {
+                    if let Some(hud) = hud.as_object_mut() {
+                        hud.insert(
+                            "commandsByProject".to_string(),
+                            read_sidebar_hud_commands_by_project(&projects),
+                        );
+                    }
+                }
                 let mut result = Map::new();
                 result.insert("hud".to_string(), hud);
                 if let Some(item_ids) = item_ids {

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -1503,6 +1503,34 @@ fn static_status_response(status: StatusCode) -> RoutedResponse {
     }
 }
 
+/*
+CDXC:ProjectActions 2026-08-01:
+Both the HUD read and the HUD settings mutation answer the same opt-in
+`includeAllProjectCommands` request, because clients that render per-project
+quick actions replace their whole HUD snapshot from either response. Keep the
+opt-in in one place so the two cannot drift apart and silently blank project
+rows after a Settings save.
+*/
+fn apply_commands_by_project_if_requested(
+    hud: &mut Value,
+    projects: &[Value],
+    params: &Map<String, Value>,
+) {
+    if params
+        .get("includeAllProjectCommands")
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return;
+    }
+    if let Some(hud) = hud.as_object_mut() {
+        hud.insert(
+            "commandsByProject".to_string(),
+            read_sidebar_hud_commands_by_project(projects),
+        );
+    }
+}
+
 async fn route_http(
     state: Arc<AppState>,
     request: Request<Body>,
@@ -2212,18 +2240,7 @@ async fn route_http(
                 for per-project command rows in one round trip instead of one
                 readSidebarHud call per project each poll.
                 */
-                if params
-                    .get("includeAllProjectCommands")
-                    .and_then(Value::as_bool)
-                    == Some(true)
-                {
-                    if let Some(hud) = hud.as_object_mut() {
-                        hud.insert(
-                            "commandsByProject".to_string(),
-                            read_sidebar_hud_commands_by_project(&projects),
-                        );
-                    }
-                }
+                apply_commands_by_project_if_requested(&mut hud, &projects, params);
                 Ok(hud)
             },
         ),
@@ -2263,18 +2280,7 @@ async fn route_http(
                 Without it a Settings save would drop the per-project rows until
                 the next full HUD poll.
                 */
-                if params
-                    .get("includeAllProjectCommands")
-                    .and_then(Value::as_bool)
-                    == Some(true)
-                {
-                    if let Some(hud) = hud.as_object_mut() {
-                        hud.insert(
-                            "commandsByProject".to_string(),
-                            read_sidebar_hud_commands_by_project(&projects),
-                        );
-                    }
-                }
+                apply_commands_by_project_if_requested(&mut hud, &projects, params);
                 let mut result = Map::new();
                 result.insert("hud".to_string(), hud);
                 if let Some(item_ids) = item_ids {

--- a/gxserver-rs/src/sidebar_hud.rs
+++ b/gxserver-rs/src/sidebar_hud.rs
@@ -42,6 +42,7 @@ struct StoredSidebarCommand {
     is_default: bool,
     name: String,
     play_completion_sound: bool,
+    show_on_project_row: bool,
     url: Option<String>,
 }
 
@@ -615,6 +616,10 @@ fn sidebar_command_save_mutation(
                 .get("playCompletionSound")
                 .and_then(Value::as_bool)
                 .unwrap_or(true),
+        show_on_project_row: params
+            .get("showOnProjectRow")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         url: (action_type == "browser").then_some(url).flatten(),
     };
     reject_duplicate_sidebar_command_title(
@@ -991,6 +996,7 @@ fn default_sidebar_command_button_value(command: &DefaultSidebarCommand) -> Valu
     button.insert("isDefault".to_string(), Value::Bool(true));
     button.insert("name".to_string(), Value::String(command.name.to_string()));
     button.insert("playCompletionSound".to_string(), Value::Bool(true));
+    button.insert("showOnProjectRow".to_string(), Value::Bool(false));
     Value::Object(button)
 }
 
@@ -1019,6 +1025,10 @@ fn sidebar_command_button_value(command: &StoredSidebarCommand) -> Value {
     button.insert(
         "playCompletionSound".to_string(),
         Value::Bool(command.play_completion_sound),
+    );
+    button.insert(
+        "showOnProjectRow".to_string(),
+        Value::Bool(command.show_on_project_row),
     );
     if let Some(url) = command.url.as_ref() {
         button.insert("url".to_string(), Value::String(url.clone()));
@@ -1113,6 +1123,11 @@ fn normalized_stored_sidebar_commands(candidate: Option<&Value>) -> Vec<StoredSi
             .unwrap_or(false)
             || is_default_sidebar_command_id(command_id);
 
+        let show_on_project_row = item
+            .get("showOnProjectRow")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
         if action_type == "browser" {
             let Some(url) = url else {
                 continue;
@@ -1126,6 +1141,7 @@ fn normalized_stored_sidebar_commands(candidate: Option<&Value>) -> Vec<StoredSi
                 is_default,
                 name,
                 play_completion_sound: false,
+                show_on_project_row,
                 url: Some(url),
             });
             seen_command_ids.insert(command_id.to_string());
@@ -1154,6 +1170,7 @@ fn normalized_stored_sidebar_commands(candidate: Option<&Value>) -> Vec<StoredSi
                 .get("playCompletionSound")
                 .and_then(Value::as_bool)
                 .unwrap_or(true),
+            show_on_project_row,
             url: None,
         });
         seen_command_ids.insert(command_id.to_string());
@@ -1312,6 +1329,10 @@ fn stored_sidebar_commands_value(commands: &[StoredSidebarCommand]) -> Value {
                 item.insert(
                     "playCompletionSound".to_string(),
                     Value::Bool(command.play_completion_sound),
+                );
+                item.insert(
+                    "showOnProjectRow".to_string(),
+                    Value::Bool(command.show_on_project_row),
                 );
                 if let Some(url) = command.url.as_ref() {
                     item.insert("url".to_string(), Value::String(url.clone()));

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -47068,6 +47068,7 @@ function saveSidebarCommand(
     isDefault: isDefaultSidebarCommandId(commandId),
     name,
     playCompletionSound: message.actionType === "terminal" ? message.playCompletionSound : false,
+    showOnProjectRow: message.showOnProjectRow,
     /*
      * CDXC:TitlebarActions 2026-06-16-07:48:
      * Settings no longer writes per-action icon colors. Persist only the glyph

--- a/shared/gxserver-protocol.ts
+++ b/shared/gxserver-protocol.ts
@@ -1334,6 +1334,7 @@ the refreshed HUD/project rows returned after persistence.
 */
 export interface GxserverReadSidebarHudParams {
   activeProjectId?: string;
+  includeAllProjectCommands?: boolean;
 }
 
 export interface GxserverSidebarHudAgentButton {
@@ -1354,15 +1355,35 @@ export interface GxserverSidebarHudCommandButton {
   isDefault: boolean;
   name: string;
   playCompletionSound: boolean;
+  showOnProjectRow?: boolean;
   url?: string;
 }
 
 export interface GxserverSidebarHudResponse {
   agents: readonly GxserverSidebarHudAgentButton[];
+  /**
+   * CDXC:ProjectActions 2026-08-01:
+   * Present only when the caller asked for `includeAllProjectCommands`.
+   * Keyed by project id with worktrees already resolved to their parent's
+   * Actions, mirroring the active-project `commands` resolution per project.
+   */
+  commandsByProject?: Readonly<Record<string, readonly GxserverSidebarHudCommandButton[]>>;
   commands: readonly GxserverSidebarHudCommandButton[];
 }
 
-export type GxserverSidebarHudSettingsMutationParams =
+/**
+ * CDXC:ProjectActions 2026-08-01:
+ * Any HUD settings mutation returns a full replacement HUD snapshot, so
+ * clients that render per-project quick actions ask the mutation for the same
+ * opt-in commandsByProject block readSidebarHud serves. The flag rides beside
+ * every mutation variant instead of inside one so agent mutations cannot
+ * silently drop the per-project rows.
+ */
+export type GxserverSidebarHudSettingsMutationParams = {
+  includeAllProjectCommands?: boolean;
+} & GxserverSidebarHudSettingsMutationIntent;
+
+type GxserverSidebarHudSettingsMutationIntent =
   | {
       acceptAllMode?: "inherit" | "enabled" | "disabled";
       activeProjectId?: string;
@@ -1395,6 +1416,7 @@ export type GxserverSidebarHudSettingsMutationParams =
       name: string;
       operation: "save";
       playCompletionSound?: boolean;
+      showOnProjectRow?: boolean;
       target: "command";
       url?: string;
     }

--- a/shared/project-sidebar-commands.test.ts
+++ b/shared/project-sidebar-commands.test.ts
@@ -39,6 +39,7 @@ describe("normalizeProjectSidebarCommandsStore", () => {
             isDefault: false,
             name: "Dev Server",
             playCompletionSound: true,
+            showOnProjectRow: false,
           },
         ],
         deletedDefaultCommandIds: ["setup"],

--- a/shared/session-grid-contract-sidebar.ts
+++ b/shared/session-grid-contract-sidebar.ts
@@ -796,6 +796,15 @@ export type SidebarHudState = {
   appIconPickerUnavailable?: boolean;
   buildStamp?: string;
   commands: SidebarCommandButton[];
+  /**
+   * CDXC:ProjectActions 2026-08-01:
+   * Per-project Action buttons keyed by project id (worktrees already resolved
+   * to their parent's Actions by gxserver). Project rows read their own entry
+   * so showOnProjectRow actions render for every visible project, not just the
+   * active one. Hosts that cannot serve the block omit it and rows fall back
+   * to rendering nothing.
+   */
+  commandsByProject?: Record<string, SidebarCommandButton[]>;
   commandSessionIndicators: SidebarCommandSessionIndicator[];
   completionBellEnabled: boolean;
   completionSound: CompletionSoundSetting;
@@ -2501,9 +2510,17 @@ export type SidebarToExtensionMessage =
       /*
       CDXC:GPUICommandPane 2026-06-26-05:11:
       `runSidebarCommand` is a narrow Action selector: renderer messages may provide only the saved command id and optional run mode. Native and GPUI hosts must resolve command text, URLs, saved close-on-exit metadata, cwd/env, paths, output, and launch behavior from trusted command/HUD state.
+
+      CDXC:ProjectActions 2026-08-01:
+      Project-row Action buttons add an optional group selector like
+      `runSidebarAgent` already carries. The host resolves the group to its
+      project, activates that project through the existing focus flow, and only
+      then dispatches the trusted launch — the message never gains launch
+      metadata or project paths.
       */
       type: "runSidebarCommand";
       commandId: string;
+      groupId?: string;
       runMode?: SidebarCommandRunMode;
     }
   | {
@@ -2612,6 +2629,7 @@ export type SidebarToExtensionMessage =
       icon?: SidebarCommandIcon;
       name: string;
       playCompletionSound: boolean;
+      showOnProjectRow: boolean;
       command?: string;
       url?: string;
     }

--- a/shared/sidebar-commands.test.ts
+++ b/shared/sidebar-commands.test.ts
@@ -19,6 +19,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Dev",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -29,6 +30,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Build",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -39,6 +41,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Test",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -49,6 +52,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Setup",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
     ]);
@@ -65,6 +69,7 @@ describe("createSidebarCommandButtons", () => {
           isDefault: true,
           name: "App",
           playCompletionSound: true,
+          showOnProjectRow: false,
         },
         {
           actionType: "browser",
@@ -73,6 +78,7 @@ describe("createSidebarCommandButtons", () => {
           isDefault: false,
           name: "Docs",
           playCompletionSound: false,
+          showOnProjectRow: false,
           url: "https://example.com/docs",
         },
       ]),
@@ -85,6 +91,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "App",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -95,6 +102,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Build",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -105,6 +113,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Test",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -115,6 +124,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Setup",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -125,6 +135,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: false,
         name: "Docs",
         playCompletionSound: false,
+        showOnProjectRow: false,
         url: "https://example.com/docs",
       },
     ]);
@@ -143,6 +154,7 @@ describe("createSidebarCommandButtons", () => {
           isDefault: false,
           name: "",
           playCompletionSound: true,
+          showOnProjectRow: false,
         },
       ]),
     ).toEqual(
@@ -152,6 +164,7 @@ describe("createSidebarCommandButtons", () => {
           icon: "bug",
           name: "",
           playCompletionSound: true,
+          showOnProjectRow: false,
         }),
       ]),
     );
@@ -168,6 +181,7 @@ describe("createSidebarCommandButtons", () => {
             isDefault: false,
             name: "Docs",
             playCompletionSound: false,
+            showOnProjectRow: false,
             url: "https://example.com/docs",
           },
         ],
@@ -182,6 +196,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Test",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -192,6 +207,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: false,
         name: "Docs",
         playCompletionSound: false,
+        showOnProjectRow: false,
         url: "https://example.com/docs",
       },
       {
@@ -202,6 +218,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Dev",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -212,6 +229,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Build",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -222,6 +240,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Setup",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
     ]);
@@ -237,6 +256,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Dev",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
       {
@@ -247,6 +267,7 @@ describe("createSidebarCommandButtons", () => {
         isDefault: true,
         name: "Setup",
         playCompletionSound: true,
+        showOnProjectRow: false,
         url: undefined,
       },
     ]);
@@ -264,6 +285,7 @@ describe("getFirstBrowserSidebarCommandUrl", () => {
           isDefault: false,
           name: "Docs",
           playCompletionSound: false,
+          showOnProjectRow: false,
           url: "https://example.com/docs",
         },
         {
@@ -273,6 +295,7 @@ describe("getFirstBrowserSidebarCommandUrl", () => {
           isDefault: false,
           name: "App",
           playCompletionSound: false,
+          showOnProjectRow: false,
           url: "https://example.com/app",
         },
       ],
@@ -307,6 +330,65 @@ describe("normalizeStoredSidebarCommands", () => {
         isDefault: true,
         name: "Dev server",
         playCompletionSound: true,
+        showOnProjectRow: false,
+      },
+    ]);
+  });
+
+  test("should keep saved project-row visibility and default legacy records to hidden", () => {
+    expect(
+      normalizeStoredSidebarCommands([
+        {
+          command: "lazygit",
+          commandId: "custom-lazygit",
+          isDefault: false,
+          name: "Lazygit",
+          showOnProjectRow: true,
+        },
+        {
+          commandId: "custom-docs",
+          isDefault: false,
+          name: "Docs",
+          showOnProjectRow: "yes",
+          url: "https://example.com/docs",
+        },
+        {
+          command: "vp test",
+          commandId: "custom-legacy",
+          isDefault: false,
+          name: "Legacy",
+        },
+      ]),
+    ).toEqual([
+      {
+        actionType: "terminal",
+        closeTerminalOnExit: false,
+        command: "lazygit",
+        commandId: "custom-lazygit",
+        isDefault: false,
+        name: "Lazygit",
+        playCompletionSound: true,
+        showOnProjectRow: true,
+      },
+      {
+        actionType: "browser",
+        closeTerminalOnExit: false,
+        commandId: "custom-docs",
+        isDefault: false,
+        name: "Docs",
+        playCompletionSound: false,
+        showOnProjectRow: false,
+        url: "https://example.com/docs",
+      },
+      {
+        actionType: "terminal",
+        closeTerminalOnExit: false,
+        command: "vp test",
+        commandId: "custom-legacy",
+        isDefault: false,
+        name: "Legacy",
+        playCompletionSound: true,
+        showOnProjectRow: false,
       },
     ]);
   });
@@ -319,6 +401,7 @@ describe("normalizeStoredSidebarCommands", () => {
           isDefault: false,
           name: " Docs ",
           playCompletionSound: true,
+          showOnProjectRow: false,
           url: " https://example.com/docs ",
         },
         {
@@ -327,6 +410,7 @@ describe("normalizeStoredSidebarCommands", () => {
           isDefault: false,
           name: "Broken",
           playCompletionSound: true,
+          showOnProjectRow: false,
         },
       ]),
     ).toEqual([
@@ -337,6 +421,7 @@ describe("normalizeStoredSidebarCommands", () => {
         isDefault: false,
         name: "Docs",
         playCompletionSound: false,
+        showOnProjectRow: false,
         url: "https://example.com/docs",
       },
     ]);
@@ -360,6 +445,7 @@ describe("normalizeStoredSidebarCommands", () => {
           isDefault: false,
           name: "",
           playCompletionSound: true,
+          showOnProjectRow: false,
         },
       ]),
     ).toEqual([
@@ -372,6 +458,7 @@ describe("normalizeStoredSidebarCommands", () => {
         isDefault: false,
         name: "",
         playCompletionSound: true,
+        showOnProjectRow: false,
       },
     ]);
   });
@@ -395,6 +482,7 @@ describe("normalizeStoredSidebarCommands", () => {
         isDefault: false,
         name: "",
         playCompletionSound: true,
+        showOnProjectRow: false,
       },
     ]);
   });
@@ -411,6 +499,7 @@ describe("getSidebarCommandPreviewLabel", () => {
         isDefault: true,
         name: "Dev",
         playCompletionSound: true,
+        showOnProjectRow: false,
       }),
     ).toBe(SIDEBAR_UNCONFIGURED_TERMINAL_COMMAND_LABEL);
   });

--- a/shared/sidebar-commands.ts
+++ b/shared/sidebar-commands.ts
@@ -58,6 +58,7 @@ export type SidebarCommandButton = {
   isDefault: boolean;
   name: string;
   playCompletionSound: boolean;
+  showOnProjectRow: boolean;
   url?: string;
 };
 
@@ -76,6 +77,14 @@ export type StoredSidebarCommand = {
   isDefault: boolean;
   name: string;
   playCompletionSound: boolean;
+  /**
+   * CDXC:ProjectActions 2026-08-01:
+   * Actions flagged showOnProjectRow render as inline icon buttons on their
+   * project's sidebar row beside the built-in header actions. Older saved
+   * records lack the field; normalization defaults it to false so existing
+   * Actions keep their titlebar-only behavior.
+   */
+  showOnProjectRow: boolean;
   command?: string;
   url?: string;
 };
@@ -99,6 +108,7 @@ export function createDefaultSidebarCommandButtons(): SidebarCommandButton[] {
     isDefault: true,
     name: command.name,
     playCompletionSound: true,
+    showOnProjectRow: false,
     url: undefined,
   }));
 }
@@ -190,6 +200,7 @@ export function normalizeStoredSidebarCommands(candidate: unknown): StoredSideba
         isDefault,
         name,
         playCompletionSound: false,
+        showOnProjectRow: partialItem.showOnProjectRow === true,
         ...(icon ? { icon } : {}),
         url,
       });
@@ -216,6 +227,7 @@ export function normalizeStoredSidebarCommands(candidate: unknown): StoredSideba
         typeof partialItem.playCompletionSound === "boolean"
           ? partialItem.playCompletionSound
           : true,
+      showOnProjectRow: partialItem.showOnProjectRow === true,
       ...(icon ? { icon } : {}),
     });
     seenCommandIds.add(commandId);
@@ -258,6 +270,7 @@ function defaultAction(command: (typeof DEFAULT_SIDEBAR_COMMANDS)[number]): Side
     isDefault: true,
     name: command.name,
     playCompletionSound: true,
+    showOnProjectRow: false,
     url: undefined,
   };
 }
@@ -272,6 +285,7 @@ function normalizeStoredCommandButton(command: StoredSidebarCommand): SidebarCom
         isDefault: command.isDefault,
         name: command.name,
         playCompletionSound: false,
+        showOnProjectRow: command.showOnProjectRow === true,
         ...(command.icon ? { icon: command.icon } : {}),
         url: command.url,
       }
@@ -283,6 +297,7 @@ function normalizeStoredCommandButton(command: StoredSidebarCommand): SidebarCom
         isDefault: command.isDefault,
         name: command.name,
         playCompletionSound: command.playCompletionSound,
+        showOnProjectRow: command.showOnProjectRow === true,
         ...(command.icon ? { icon: command.icon } : {}),
         url: undefined,
       };

--- a/sidebar/session-group-section.tsx
+++ b/sidebar/session-group-section.tsx
@@ -33,6 +33,7 @@ import {
   useLayoutEffect,
   useEffect,
   useEffectEvent,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -48,6 +49,9 @@ import {
 } from "../shared/session-grid-contract";
 import type { SidebarProjectDiffStats } from "../shared/project-diff-stats";
 import type { SidebarAgentButton } from "../shared/sidebar-agents";
+import type { SidebarCommandButton } from "../shared/sidebar-commands";
+import { DEFAULT_SIDEBAR_COMMAND_ICON } from "../shared/sidebar-command-icons";
+import { SidebarCommandIconGlyph } from "./sidebar-command-icon";
 import {
   DEFAULT_ghostex_SETTINGS,
   clampProjectSessionListCollapsedCount,
@@ -695,6 +699,25 @@ export function SessionGroupSection({
       (candidate) => candidate?.projectContext?.worktree?.parentProjectId === projectId,
     ).length;
   });
+  /*
+   * CDXC:ProjectActions 2026-08-01:
+   * Project rows render only the Actions the user flagged showOnProjectRow,
+   * read from the HUD's per-project block so every row shows its own project's
+   * Actions instead of the active project's. Hosts that do not serve
+   * commandsByProject (legacy macOS) leave the map empty and rows render no
+   * extra buttons.
+   */
+  const projectCommands = useSidebarStore((state) => {
+    const projectId = state.groupsById[groupId]?.projectContext?.editor.projectId;
+    if (!projectId) {
+      return undefined;
+    }
+    return state.hud.commandsByProject?.[projectId];
+  });
+  const projectRowCommands = useMemo(
+    () => (projectCommands ?? []).filter((command) => command.showOnProjectRow),
+    [projectCommands],
+  );
   const orderedSessionIds = orderedSessionIdsProp ?? storedSessionIds;
   const [contextMenuPosition, setContextMenuPosition] = useState<GroupContextMenuPosition>();
   const [customThemeColor, setCustomThemeColor] = useState(DEFAULT_WORKSPACE_THEME_COLOR);
@@ -1537,6 +1560,23 @@ export function SessionGroupSection({
     });
   };
 
+  const requestRunProjectRowCommand = (command: SidebarCommandButton) => {
+    if (!projectContext) {
+      return;
+    }
+    /*
+     * CDXC:ProjectActions 2026-08-01:
+     * Row Action clicks stay selector-shaped like the Command Palette: command
+     * id plus the row's group id. The host resolves launch metadata from its
+     * trusted per-project HUD state and activates the project before running.
+     */
+    vscode.postMessage({
+      commandId: command.commandId,
+      groupId: group.groupId,
+      type: "runSidebarCommand",
+    });
+  };
+
   const requestCloseGroup = () => {
     if (!canClose) {
       return;
@@ -2284,6 +2324,32 @@ export function SessionGroupSection({
                             stroke={2}
                           />
                         </ProjectHeaderActionButton>
+                        {projectHeaderActions === "all"
+                          ? projectRowCommands.map((command) => {
+                              const commandLabel = command.name.trim() || "Run Action";
+                              return (
+                                <ProjectHeaderActionButton
+                                  aria-label={`Run ${commandLabel} in ${group.title}`}
+                                  className="group-add-button group-project-row-command-button"
+                                  key={command.commandId}
+                                  onClick={(event) => {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    requestRunProjectRowCommand(command);
+                                  }}
+                                  tooltip={commandLabel}
+                                  type="button"
+                                >
+                                  <SidebarCommandIconGlyph
+                                    className="group-add-icon"
+                                    icon={command.icon ?? DEFAULT_SIDEBAR_COMMAND_ICON}
+                                    size={14}
+                                    stroke={2}
+                                  />
+                                </ProjectHeaderActionButton>
+                              );
+                            })
+                          : null}
                         {projectHeaderActions === "all" ? (
                           <div className="group-control-anchor">
                             <div

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -5541,6 +5541,7 @@ type SettingsCommandDraft = {
   icon?: SidebarCommandIcon;
   name: string;
   playCompletionSound: boolean;
+  showOnProjectRow: boolean;
   url?: string;
 };
 
@@ -8894,6 +8895,7 @@ function ActionsSettingsTab({
       icon: draft.icon,
       name: draft.name,
       playCompletionSound: draft.playCompletionSound,
+      showOnProjectRow: draft.showOnProjectRow,
       type: "saveSidebarCommand",
       url: draft.url,
     });
@@ -9152,6 +9154,7 @@ function ActionSettingsEditor({
   );
   const [name, setName] = useState(draft.name);
   const [playCompletionSound, setPlayCompletionSound] = useState(draft.playCompletionSound);
+  const [showOnProjectRow, setShowOnProjectRow] = useState(draft.showOnProjectRow);
   const [url, setUrl] = useState(
     draft.url ??
       ((lockedActionType ?? draft.actionType) === "browser" ? DEFAULT_BROWSER_ACTION_URL : ""),
@@ -9160,6 +9163,7 @@ function ActionSettingsEditor({
   const closeTerminalOnExitId = useId();
   const commandId = useId();
   const nameId = useId();
+  const showOnProjectRowId = useId();
   const soundId = useId();
   const urlId = useId();
   const isActionTypeLocked = lockedActionType !== undefined;
@@ -9188,6 +9192,7 @@ function ActionSettingsEditor({
     icon,
     name: trimmedName,
     playCompletionSound: actionType === "terminal" ? playCompletionSound : false,
+    showOnProjectRow,
     url: actionType === "browser" ? url.trim() : undefined,
   });
 
@@ -9304,6 +9309,23 @@ function ActionSettingsEditor({
           </Field>
         </>
       )}
+      {/*
+       * CDXC:ProjectActions 2026-08-01:
+       * Both terminal and browser actions can opt into the project's sidebar
+       * row, so this toggle lives outside the action-type branch above.
+       */}
+      <Field className="items-center justify-between" orientation="horizontal">
+        <FieldContent>
+          <FieldLabel className="text-sm" htmlFor={showOnProjectRowId}>
+            Show on the project&apos;s sidebar row
+          </FieldLabel>
+        </FieldContent>
+        <Switch
+          checked={showOnProjectRow}
+          id={showOnProjectRowId}
+          onCheckedChange={setShowOnProjectRow}
+        />
+      </Field>
       {/*
        * CDXC:ActionsSettings 2026-06-18-10:11:
        * Settings > Actions must let users delete any selected action from the edit surface itself, including default Build/Test actions whose deletion is represented by deletedDefaultCommandIds. Keep this wired to the same deleteSidebarCommand path as the row trash button so default and custom actions share one behavior.
@@ -9661,6 +9683,7 @@ function createSettingsCommandDraft(actionType: SidebarActionType): SettingsComm
     icon: DEFAULT_SIDEBAR_COMMAND_ICON,
     name: "",
     playCompletionSound: actionType === "terminal",
+    showOnProjectRow: false,
     url: actionType === "browser" ? DEFAULT_BROWSER_ACTION_URL : undefined,
   };
 }
@@ -9674,6 +9697,7 @@ function createSettingsCommandDraftFromButton(command: SidebarCommandButton): Se
     icon: command.icon ?? DEFAULT_SIDEBAR_COMMAND_ICON,
     name: command.name,
     playCompletionSound: command.playCompletionSound,
+    showOnProjectRow: command.showOnProjectRow,
     url: command.url,
   };
 }

--- a/sidebar/sidebar-store.ts
+++ b/sidebar/sidebar-store.ts
@@ -548,6 +548,7 @@ function preserveSidebarHudReferences(
 
   preserveIfEqual("agents");
   preserveIfEqual("commands");
+  preserveIfEqual("commandsByProject");
   preserveIfEqual("commandSessionIndicators");
   preserveIfEqual("git");
   preserveIfEqual("pendingAgentIds");

--- a/sidebar/sidebar-story-workspace.ts
+++ b/sidebar/sidebar-story-workspace.ts
@@ -518,6 +518,7 @@ export function reduceSidebarStoryWorkspace(
         name: message.name,
         playCompletionSound:
           message.actionType === "terminal" ? message.playCompletionSound : false,
+        showOnProjectRow: message.showOnProjectRow,
         url: message.actionType === "browser" ? message.url : undefined,
       };
 

--- a/sidebar/sidebar-story-workspace.ts
+++ b/sidebar/sidebar-story-workspace.ts
@@ -318,6 +318,20 @@ export function createSidebarStoryMessage(
       ...(workspace.options.autoSettleAfterDaysByMachineId
         ? { autoSettleAfterDaysByMachineId: workspace.options.autoSettleAfterDaysByMachineId }
         : {}),
+      /*
+       * CDXC:ProjectActions 2026-08-01:
+       * Project rows read their Actions from `commandsByProject`, not the flat
+       * active-project list, so the story harness has to publish the same block
+       * the daemon does or a flagged Action can never render on a story row.
+       * Every story project context sees the same command set because the
+       * harness models one Actions store.
+       */
+      commandsByProject: Object.fromEntries(
+        groups
+          .map((group) => group.projectContext?.editor.projectId)
+          .filter((projectId): projectId is string => Boolean(projectId))
+          .map((projectId) => [projectId, workspace.options.commands]),
+      ),
       recentProjects: workspace.options.recentProjects,
       settings: workspace.options.settings,
     },


### PR DESCRIPTION
From the Discord thread **"Quick actions on sidebar projects"** — the checkbox you asked for.

## What

- Settings ▸ Actions create/edit gains a **"Show on the project's sidebar row"** switch (both terminal and browser actions, so it sits outside the terminal-only branch next to the two existing switches).
- Flagged Actions render as icon buttons on their project's sidebar row (V1 sidebar) beside the built-in header actions, using `SidebarCommandIconGlyph` + the existing `group-add-button` styling, gated on `projectHeaderActions === "all"`.
- Clicking one on a non-active project activates that project first (focusProjectId + focus-state + active-project-context posts, i.e. the same ordering as clicking the row and then the titlebar action by hand), then dispatches through the existing trusted launch path. **The Rust launch-bridge payload is unchanged.**

## How

- `showOnProjectRow: boolean` added to all three `StoredSidebarCommand` copies (shared TS, `gxserver-rs/sidebar_hud.rs`, `gpui/main.rs`), both save paths, and the CLI `save-command` (declarative `--showOnProjectRow` flag matching `closeTerminalOnExit` semantics). Legacy records normalize to `false`; CDXC notes added at each decision point.
- Per-project rows reuse the `commandsByProject` block you built for Android: the GPUI runtime requests `includeAllProjectCommands: true` on `readSidebarHud` **and on every HUD settings mutation** — the mutation handler now mirrors the block into its response, since clients replace the whole HUD snapshot from it (otherwise a Settings save blanks the rows until the next poll).
- `runSidebarCommand` selector gains an optional `groupId`, mirroring `runSidebarAgent`; the host resolves the Action from that project's own command list (`resolveSidebarCommandForProject`), so two projects with different Actions cannot cross-launch. Launch metadata still never comes from the renderer.
- `preserveSidebarHudReferences` learned the new key so unchanged per-project maps keep stable references.

## Verified

- `bun run typecheck` clean; vitest `shared/` + `sidebar/`: 1300 pass (includes a new normalization test: flag round-trips, non-boolean rejected, legacy defaults hidden); `cargo test` gxserver-rs: 621 pass; gpui crate `cargo check` clean.
- Live daemon round-trip on an isolated HOME + dev port: save with the flag → mutation-result hud and `commandsByProject` both carry it → read-back true/false/defaults correct → confirmed in `state.db` `customCommandsJson`.
- **Not verified live:** the in-app click path — this machine has no full Xcode, so GhosttyKit (Metal toolchain) blocks a local app build. The cross-project ordering (activate → dispatch over the CEF bridge) is the part most worth a minute of hands-on testing on your side.

## Out of scope

The "global on all projects" checkbox — actions are stored per project row and the storage question is on Discord. Happy to follow up once you pick a home for globals. Same for a "workarea view" action type (one-click Kanban button on a row) if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable actions to project rows in the sidebar.
  - Users can choose whether terminal and browser actions appear on project rows.
  - Project-row actions run in the context of the selected project.

- **Bug Fixes**
  - Preserved project-row visibility settings when actions are edited or saved.
  - Legacy actions safely default to hidden project-row display.
  - Sidebar data now stays synchronized across project-specific actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->