### PR TITLE
feat(terminal): optional background image behind terminal panes

### DIFF
--- a/gpui/src/shared_settings.rs
+++ b/gpui/src/shared_settings.rs
@@ -45,6 +45,9 @@ const DEFAULT_TERMINAL_FONT_WEIGHT: f64 = 300.0;
 const NORMAL_TERMINAL_FONT_WEIGHT: f64 = 400.0;
 const DEFAULT_TERMINAL_GHOSTTY_THEME: &str = "GitHub Dark";
 const DEFAULT_TERMINAL_BACKGROUND_COLOR: &str = "#000000";
+const DEFAULT_TERMINAL_BACKGROUND_IMAGE: &str = "";
+const DEFAULT_TERMINAL_BACKGROUND_IMAGE_OPACITY: f64 = 1.0;
+const DEFAULT_TERMINAL_BACKGROUND_IMAGE_FIT: &str = "cover";
 const DEFAULT_TERMINAL_LETTER_SPACING: f64 = 0.0;
 const DEFAULT_TERMINAL_LINE_HEIGHT: f64 = 1.2;
 const DEFAULT_TERMINAL_CURSOR_STYLE_BLINK: bool = true;
@@ -261,6 +264,9 @@ pub struct SharedGpuiTerminalEngineSettings {
     pub font_weight: f32,
     pub ghostty_theme: String,
     pub terminal_background_rgb: Option<[u8; 3]>,
+    pub background_image_path: String,
+    pub background_image_opacity: f32,
+    pub background_image_fit: String,
     pub letter_spacing: f32,
     pub line_height: f32,
     pub mouse_hide_while_typing: bool,
@@ -732,6 +738,24 @@ impl SharedSidebarSettingsSnapshot {
                 &self.object,
                 "workspaceBackgroundColor",
                 DEFAULT_TERMINAL_BACKGROUND_COLOR,
+            )),
+            background_image_path: read_string_field(
+                &self.object,
+                "terminalBackgroundImage",
+                DEFAULT_TERMINAL_BACKGROUND_IMAGE,
+            )
+            .trim()
+            .to_string(),
+            background_image_opacity: read_finite_number_field(
+                &self.object,
+                "terminalBackgroundImageOpacity",
+                DEFAULT_TERMINAL_BACKGROUND_IMAGE_OPACITY,
+            )
+            .clamp(0.0, 1.0) as f32,
+            background_image_fit: normalize_terminal_background_image_fit(read_string_field(
+                &self.object,
+                "terminalBackgroundImageFit",
+                DEFAULT_TERMINAL_BACKGROUND_IMAGE_FIT,
             )),
             letter_spacing: read_finite_number_field(
                 &self.object,
@@ -1991,6 +2015,13 @@ fn normalize_terminal_background_rgb(value: &str) -> Option<[u8; 3]> {
         u8::from_str_radix(&hex[4..6], 16).ok()?,
     ];
     Some(if rgb == [0, 0, 0] { [1, 1, 1] } else { rgb })
+}
+
+fn normalize_terminal_background_image_fit(value: &str) -> String {
+    match value.trim() {
+        "contain" | "stretch" | "natural" => value.trim().to_string(),
+        _ => DEFAULT_TERMINAL_BACKGROUND_IMAGE_FIT.to_string(),
+    }
 }
 
 fn normalize_ghostty_copy_on_select(value: &str) -> String {

--- a/gpui/src/terminal_element.rs
+++ b/gpui/src/terminal_element.rs
@@ -58,21 +58,28 @@ wakeup and only changes are emitted.
 */
 
 use std::any::TypeId;
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::{ops::Range, path::PathBuf, time::Duration};
+use std::{
+    ops::Range,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use futures::StreamExt as _;
+use image::Frame;
 
 use gpui::{
-    AnyElement, App, BorderStyle, Bounds, BoxShadow, ClipboardItem, ContentMask, Context,
-    CursorStyle, DispatchPhase, Element, ElementId, ElementInputHandler, Entity,
+    AnyElement, App, BorderStyle, Bounds, BoxShadow, ClipboardItem, ContentMask, Context, Corners,
+    CursorStyle, DevicePixels, DispatchPhase, Element, ElementId, ElementInputHandler, Entity,
     EntityInputHandler, EventEmitter, ExternalPaths, FocusHandle, Focusable, Font, FontStyle,
-    FontWeight, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement,
-    KeyDownEvent, KeyUpEvent, Keystroke, LayoutId, Modifiers, ModifiersChangedEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Point, Render, Rgba,
-    ScrollDelta, ScrollWheelEvent, ShapedLine, SharedString, Size, StrikethroughStyle, Style,
-    Styled, TextAlign, TextRun, UTF16Selection, UnderlineStyle as GpuiUnderlineStyle, Window,
-    canvas, div, fill, outline, point, prelude::FluentBuilder as _, px, size, svg,
+    FontWeight, Global, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement,
+    IntoElement, KeyDownEvent, KeyUpEvent, Keystroke, LayoutId, Modifiers, ModifiersChangedEvent,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Point,
+    Render, RenderImage, Rgba, ScrollDelta, ScrollWheelEvent, ShapedLine, SharedString, Size,
+    StrikethroughStyle, Style, Styled, TextAlign, TextRun, UTF16Selection,
+    UnderlineStyle as GpuiUnderlineStyle, Window, canvas, div, fill, outline, point,
+    prelude::FluentBuilder as _, px, size, svg,
 };
 use gpui_component::{
     native_menu::NativeMenu,
@@ -194,9 +201,26 @@ pub enum TerminalMouseShiftCapture {
     Never,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TerminalBackgroundImageFit {
+    Contain,
+    #[default]
+    Cover,
+    Stretch,
+    Natural,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TerminalBackgroundImage {
+    pub path: PathBuf,
+    pub opacity: f32,
+    pub fit: TerminalBackgroundImageFit,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct TerminalViewSettings {
     pub cursor_shape: TerminalCursorShape,
+    pub background_image: Option<TerminalBackgroundImage>,
     pub cursor_blink: bool,
     pub cursor_opacity: f32,
     pub cursor_text: Option<TerminalConfiguredColor>,
@@ -219,6 +243,7 @@ impl Default for TerminalViewSettings {
     fn default() -> Self {
         Self {
             cursor_shape: TerminalCursorShape::Block,
+            background_image: None,
             cursor_blink: false,
             cursor_opacity: 1.0,
             cursor_text: None,
@@ -2831,6 +2856,46 @@ impl TerminalElement {
         Self { terminal }
     }
 
+    /// Draws the configured background image over the pane's background fill and
+    /// under the cell backgrounds. Cells only paint a quad when they carry an
+    /// explicit background, so the image stays visible behind default-background
+    /// text while selections and TUI colors still cover it.
+    fn paint_background_image(
+        &self,
+        bounds: Bounds<Pixels>,
+        background: Hsla,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let Some(settings) = self.terminal.read(cx).settings.background_image.clone() else {
+            return;
+        };
+        let Some(image) = background_image_for_path(settings.path.as_path(), cx) else {
+            return;
+        };
+
+        let image_bounds =
+            background_image_bounds(bounds, image.size(0), settings.fit, window.scale_factor());
+        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+            window
+                .paint_image(image_bounds, Corners::default(), image, 0, false)
+                .ok();
+        });
+
+        // gpui's element opacity is crate-private, so dim by laying the pane
+        // background back over the image at the inverse alpha.
+        let opacity = settings.opacity.clamp(0.0, 1.0);
+        if opacity < 1.0 {
+            window.paint_quad(fill(
+                bounds,
+                Hsla {
+                    a: 1.0 - opacity,
+                    ..background
+                },
+            ));
+        }
+    }
+
     /// Register this frame's input surfaces: the IME input handler on the
     /// focus handle, key listeners on this dispatch node (focused path
     /// only), and window mouse listeners scoped by the hitbox.
@@ -3042,6 +3107,7 @@ impl Element for TerminalElement {
         };
 
         window.paint_quad(fill(bounds, layout.background));
+        self.paint_background_image(bounds, layout.background, window, cx);
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             for (row, layout_row) in layout.rows.iter().enumerate() {
                 for span in &layout_row.bg_spans {
@@ -3208,6 +3274,82 @@ fn blend_rgb(a: Rgb, b: Rgb, factor: f32) -> Rgb {
 /// arrives un-applied from the snapshot and is swapped here; `faint` dims the
 /// foreground toward the effective background. Returns `(fg, Option<bg>)`
 /// where `None` bg means the element's default background quad shows through.
+/// Decoded background images, keyed by path. Decoding is synchronous but happens
+/// once per path for the whole app; panes repaint from the cached texture.
+/// A path that fails to decode caches `None` so a bad path is not retried per frame.
+#[derive(Default)]
+struct TerminalBackgroundImageCache {
+    entries: HashMap<PathBuf, Option<Arc<RenderImage>>>,
+}
+
+impl Global for TerminalBackgroundImageCache {}
+
+fn background_image_for_path(path: &Path, cx: &mut App) -> Option<Arc<RenderImage>> {
+    if let Some(cached) = cx
+        .try_global::<TerminalBackgroundImageCache>()
+        .and_then(|cache| cache.entries.get(path))
+    {
+        return cached.clone();
+    }
+
+    let decoded = decode_background_image(path);
+    cx.default_global::<TerminalBackgroundImageCache>()
+        .entries
+        .insert(path.to_path_buf(), decoded.clone());
+    decoded
+}
+
+fn decode_background_image(path: &Path) -> Option<Arc<RenderImage>> {
+    let bytes = std::fs::read(path).ok()?;
+    let mut data = image::load_from_memory(&bytes).ok()?.into_rgba8();
+    // gpui uploads sprite atlas tiles as BGRA.
+    for pixel in data.chunks_exact_mut(4) {
+        pixel.swap(0, 2);
+    }
+    Some(Arc::new(RenderImage::new(vec![Frame::new(data)])))
+}
+
+/// Where to draw the image inside `container`. Oversized results are expected for
+/// `Cover`; the caller clips with a content mask.
+fn background_image_bounds(
+    container: Bounds<Pixels>,
+    image_size: Size<DevicePixels>,
+    fit: TerminalBackgroundImageFit,
+    scale_factor: f32,
+) -> Bounds<Pixels> {
+    let scale = if scale_factor > 0.0 { scale_factor } else { 1.0 };
+    let natural_width = image_size.width.0 as f32 / scale;
+    let natural_height = image_size.height.0 as f32 / scale;
+    if natural_width <= 0.0 || natural_height <= 0.0 {
+        return container;
+    }
+
+    let container_width = f32::from(container.size.width);
+    let container_height = f32::from(container.size.height);
+    let (width, height) = match fit {
+        TerminalBackgroundImageFit::Stretch => (container_width, container_height),
+        TerminalBackgroundImageFit::Natural => (natural_width, natural_height),
+        TerminalBackgroundImageFit::Contain | TerminalBackgroundImageFit::Cover => {
+            let scale_x = container_width / natural_width;
+            let scale_y = container_height / natural_height;
+            let factor = if matches!(fit, TerminalBackgroundImageFit::Contain) {
+                scale_x.min(scale_y)
+            } else {
+                scale_x.max(scale_y)
+            };
+            (natural_width * factor, natural_height * factor)
+        }
+    };
+
+    Bounds::new(
+        point(
+            container.origin.x + px((container_width - width) / 2.0),
+            container.origin.y + px((container_height - height) / 2.0),
+        ),
+        size(px(width), px(height)),
+    )
+}
+
 fn resolve_cell_colors(cell: &SnapshotCell, frame: &TerminalSnapshot) -> (Rgb, Option<Rgb>) {
     let mut fg = cell.fg.unwrap_or(frame.foreground);
     let mut bg = cell.bg;

--- a/gpui/src/terminal_ghostty_surface.rs
+++ b/gpui/src/terminal_ghostty_surface.rs
@@ -886,6 +886,9 @@ fn parse_ghostty_terminal_engine_config(
         font,
         view: TerminalViewSettings {
             cursor_shape,
+            // The GhosttyKit surface path is not selected at runtime; the
+            // composited engine owns background images.
+            background_image: None,
             cursor_blink: parse_config_bool(
                 optional_value("cursor-style-blink").unwrap_or("false"),
             )?,

--- a/gpui/src/terminal_gpui_engine.rs
+++ b/gpui/src/terminal_gpui_engine.rs
@@ -18,8 +18,9 @@ use crate::AgentsTerminalRuntimeSessionId;
 use crate::ghostty_vt::VtOptionAsAlt;
 use crate::shared_settings::{SharedGpuiTerminalEngineSettings, SharedTerminalConfirmCloseSurface};
 use crate::terminal_element::{
-    TerminalConfiguredColor, TerminalCursorShape, TerminalFontConfig, TerminalMetricAdjustment,
-    TerminalView, TerminalViewSettings,
+    TerminalBackgroundImage, TerminalBackgroundImageFit, TerminalConfiguredColor,
+    TerminalCursorShape, TerminalFontConfig, TerminalMetricAdjustment, TerminalView,
+    TerminalViewSettings,
 };
 use crate::terminal_model::{Rgb, TerminalConfirmCloseBehavior, TerminalSpawnConfig};
 
@@ -68,6 +69,7 @@ impl GpuiTerminalEngineConfig {
             font,
             view: TerminalViewSettings {
                 cursor_shape,
+                background_image: terminal_background_image_from_settings(settings),
                 cursor_blink: settings.cursor_style_blink,
                 copy_on_select: settings.copy_on_select,
                 selection_clipboard_enabled: settings.selection_clipboard_enabled,
@@ -123,6 +125,26 @@ impl GpuiTerminalEngineConfig {
             palette: crate::ghostty_vt::default_color_palette(),
         });
     }
+}
+
+/// An empty path leaves the pane on its solid background, which is the default.
+pub(crate) fn terminal_background_image_from_settings(
+    settings: &SharedGpuiTerminalEngineSettings,
+) -> Option<TerminalBackgroundImage> {
+    let path = settings.background_image_path.trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(TerminalBackgroundImage {
+        path: PathBuf::from(path),
+        opacity: settings.background_image_opacity.clamp(0.0, 1.0),
+        fit: match settings.background_image_fit.as_str() {
+            "contain" => TerminalBackgroundImageFit::Contain,
+            "stretch" => TerminalBackgroundImageFit::Stretch,
+            "natural" => TerminalBackgroundImageFit::Natural,
+            _ => TerminalBackgroundImageFit::Cover,
+        },
+    })
 }
 
 struct GpuiTerminalTheme {

--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -44,6 +44,7 @@ export type GhosttyConfirmCloseSurface = "false" | "true" | "always";
 export type GhosttyCopyOnSelect = "false" | "true" | "clipboard";
 export type GhosttyScrollbar = "system" | "never";
 export type TerminalCursorStyle = "bar" | "block" | "underline";
+export type TerminalBackgroundImageFit = "cover" | "contain" | "stretch" | "natural";
 export type WindowsTerminalBackend = "wsl";
 export type BrowserOpenMode = "browser-pane";
 export type BrowserFeedbackTool = "react-grab" | "agentation";
@@ -1086,6 +1087,9 @@ export type ghostexSettings = {
   terminalFontSize: number;
   terminalFontWeight: number;
   terminalGhosttyTheme: string;
+  terminalBackgroundImage: string;
+  terminalBackgroundImageOpacity: number;
+  terminalBackgroundImageFit: TerminalBackgroundImageFit;
   terminalLetterSpacing: number;
   terminalLineHeight: number;
   /**
@@ -1784,6 +1788,9 @@ export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
   terminalFontSize: 13,
   terminalFontWeight: 300,
   terminalGhosttyTheme: "GitHub Dark",
+  terminalBackgroundImage: "",
+  terminalBackgroundImageOpacity: 1,
+  terminalBackgroundImageFit: "cover",
   terminalLetterSpacing: 0,
   terminalLineHeight: 1.2,
   terminalPaneHorizontalPaddingPx: DEFAULT_TERMINAL_PANE_PADDING_PX,
@@ -2851,6 +2858,28 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
     terminalGhosttyTheme: normalizeGhosttyTheme(
       readString(source, "terminalGhosttyTheme", DEFAULT_ghostex_SETTINGS.terminalGhosttyTheme),
     ),
+    terminalBackgroundImage: readString(
+      source,
+      "terminalBackgroundImage",
+      DEFAULT_ghostex_SETTINGS.terminalBackgroundImage,
+    ).trim(),
+    terminalBackgroundImageOpacity: clampNumber(
+      readNumber(
+        source,
+        "terminalBackgroundImageOpacity",
+        DEFAULT_ghostex_SETTINGS.terminalBackgroundImageOpacity,
+      ),
+      0,
+      1,
+      DEFAULT_ghostex_SETTINGS.terminalBackgroundImageOpacity,
+    ),
+    terminalBackgroundImageFit: normalizeTerminalBackgroundImageFit(
+      readString(
+        source,
+        "terminalBackgroundImageFit",
+        DEFAULT_ghostex_SETTINGS.terminalBackgroundImageFit,
+      ),
+    ),
     terminalLetterSpacing: clampNumber(
       readNumber(source, "terminalLetterSpacing", DEFAULT_ghostex_SETTINGS.terminalLetterSpacing),
       -2,
@@ -3602,6 +3631,14 @@ function normalizeGhosttyConfirmCloseSurface(
 
 function normalizeGhosttyScrollbar(value: string | undefined): GhosttyScrollbar {
   return value === "never" ? "never" : "system";
+}
+
+function normalizeTerminalBackgroundImageFit(
+  value: string | undefined,
+): TerminalBackgroundImageFit {
+  return value === "contain" || value === "stretch" || value === "natural"
+    ? value
+    : DEFAULT_ghostex_SETTINGS.terminalBackgroundImageFit;
 }
 
 function normalizePortlessProtocol(value: string | undefined): PortlessProtocol {

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -729,6 +729,9 @@ const MAIN_SETTINGS_SECTION_SETTING_KEYS: Record<
     "ghosttySettingsActions",
     "terminalGhosttyTheme",
     "workspaceBackgroundColor",
+    "terminalBackgroundImage",
+    "terminalBackgroundImageOpacity",
+    "terminalBackgroundImageFit",
     "terminalFontFamily",
     "terminalFontSize",
     "terminalFontWeight",
@@ -975,6 +978,9 @@ const ADVANCED_MAIN_SETTING_KEYS = new Set<string>([
   "showSessionCloseContextMenuAction",
   "workspaceActivePaneBorderColor",
   "workspaceBackgroundColor",
+  "terminalBackgroundImage",
+  "terminalBackgroundImageOpacity",
+  "terminalBackgroundImageFit",
   "clickToWakeSleepingSessions",
   "commandsPanelDefaultHeightPx",
   "ghosttySettingsActions",
@@ -2198,6 +2204,27 @@ export function SettingsModal({
         key: "workspaceBackgroundColor",
         subtitle: "Color shown behind terminal panes.",
         title: "Terminal Background",
+      },
+      {
+        key: "terminalBackgroundImage",
+        subtitle: "Absolute path to an image drawn behind terminal panes.",
+        title: "Background Image",
+      },
+      {
+        key: "terminalBackgroundImageOpacity",
+        subtitle: "Blend the background image toward the terminal background color.",
+        title: "Background Image Opacity",
+      },
+      {
+        key: "terminalBackgroundImageFit",
+        options: [
+          { label: "Cover", value: "cover" },
+          { label: "Contain", value: "contain" },
+          { label: "Stretch", value: "stretch" },
+          { label: "Natural size", value: "natural" },
+        ],
+        subtitle: "How the background image is scaled inside each pane.",
+        title: "Background Image Fit",
       },
       {
         key: "terminalFontFamily",
@@ -3982,6 +4009,48 @@ export function SettingsModal({
                   {...getSettingModificationProps("workspaceBackgroundColor")}
                   onChange={(value) => updateDraft("workspaceBackgroundColor", value)}
                   value={draft.workspaceBackgroundColor}
+                />
+              ) : null}
+              {mainSettingVisible(settingsSearch.terminal, "terminalBackgroundImage") ? (
+                <TextField
+                  description="Absolute path to an image drawn behind terminal panes. Leave blank for none."
+                  label="Background Image"
+                  {...getSettingModificationProps("terminalBackgroundImage")}
+                  onChange={(value) => updateDraft("terminalBackgroundImage", value)}
+                  placeholder="/Users/you/Pictures/background.png"
+                  value={draft.terminalBackgroundImage}
+                />
+              ) : null}
+              {mainSettingVisible(settingsSearch.terminal, "terminalBackgroundImageOpacity") ? (
+                <SliderNumberField
+                  description="Blend the background image toward the terminal background color."
+                  label="Background Image Opacity"
+                  {...getSettingModificationProps("terminalBackgroundImageOpacity")}
+                  max={1}
+                  min={0}
+                  onCommit={(value) => updateDraft("terminalBackgroundImageOpacity", value)}
+                  onChange={(value) =>
+                    updateDraftDebounced("terminalBackgroundImageOpacity", value)
+                  }
+                  step={0.05}
+                  value={draft.terminalBackgroundImageOpacity}
+                />
+              ) : null}
+              {mainSettingVisible(settingsSearch.terminal, "terminalBackgroundImageFit") ? (
+                <SelectField
+                  description="How the background image is scaled inside each pane."
+                  label="Background Image Fit"
+                  {...getSettingModificationProps("terminalBackgroundImageFit")}
+                  onChange={(value) =>
+                    updateDraft("terminalBackgroundImageFit", value as TerminalBackgroundImageFit)
+                  }
+                  options={[
+                    { label: "Cover", value: "cover" },
+                    { label: "Contain", value: "contain" },
+                    { label: "Stretch", value: "stretch" },
+                    { label: "Natural size", value: "natural" },
+                  ]}
+                  value={draft.terminalBackgroundImageFit}
                 />
               ) : null}
               {mainSettingVisible(settingsSearch.terminal, "terminalFontFamily") ? (


### PR DESCRIPTION
Adds an optional background image behind terminal panes, off by default.

Settings → Terminal gains three controls next to Terminal Background: an image
path, an opacity slider, and a fit mode (cover / contain / stretch / natural
size). Leaving the path empty keeps the current solid-colour behaviour, and the
paint path is unchanged when it is empty.

## How it renders

`TerminalElement::paint` already fills the pane with a single background quad.
The image is painted directly after that fill and before the cell background
spans, clipped to the pane with the existing content mask.

This layering works because `resolve_cell_colors` returns `Option<Rgb>` and a
span is only pushed when a cell carries an explicit background:

```rust
if let Some(bg) = bg {
    push_span(&mut bg_spans, col, rgb_to_hsla(bg));
}
```

Default-background cells paint no quad, so the image shows through behind
ordinary text, while selections, ANSI backgrounds and TUI-painted regions still
draw over it — the same ordering Ghostty's own renderer uses.

On macOS the engine config comes from `load_ghostty_terminal_engine_config_from_path`
rather than `GpuiTerminalEngineConfig::from_shared`, so the image is applied onto
the parsed config at both call sites in `main.rs`, next to the existing
`scroll_to_bottom_when_typing` patch. Without that the setting reaches the config
struct on Linux/Windows but never on macOS.

## Notes

- Decoding is cached per path in a gpui global, so it happens once rather than
  per frame. A path that fails to decode caches the failure instead of retrying.
- `Window::with_element_opacity` is `pub(crate)`, so opacity is applied by
  painting the pane background back over the image at the inverse alpha.
- No tests, per AGENTS.md ("Don't write any test for the code in the gpui app").
  The shared settings normaliser is covered by the existing
  `shared/ghostex-settings.test.ts` suite, which still passes.

Verified on a local `bun run build` of this branch: the three controls appear
under Settings → Terminal, persist to `native-sidebar-settings.json`, and the
image renders behind both freshly opened panes and live agent sessions with
text, selections and TUI colours drawing over it correctly.

Happy to change the defaults, the control labels, or move this behind Show Beta
Features if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal background images.
  * Choose an image path, opacity, and display mode: Cover, Contain, Stretch, or Natural size.
  * Background images are disabled when no image path is set.
  * Added settings controls with search, persistence, and reset-to-default support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->