### PR TITLE
feat(actions): store Global Actions in gxserver

### DIFF
--- a/gxserver-rs/src/constants.rs
+++ b/gxserver-rs/src/constants.rs
@@ -68,4 +68,5 @@ pub const GXSERVER_MIGRATION_IDS: &[&str] = &[
     "0015_project_visibility",
     "0016_session_settle_snooze_lifecycle",
     "0017_stashed_prompts",
+    "0018_global_sidebar_commands",
 ];

--- a/gxserver-rs/src/domain.rs
+++ b/gxserver-rs/src/domain.rs
@@ -511,6 +511,136 @@ impl<'a> DomainRepository<'a> {
         Ok(json!({ "deleted": deleted > 0 }))
     }
 
+    /*
+    CDXC:GlobalActions 2026-08-01-16:00:
+    Global Actions are daemon-owned rather than project-owned, so every client
+    reads one list instead of a per-project column. Rows come back in sortOrder
+    with commandId as the tiebreak, so two actions saved in the same tick still
+    order deterministically across reads.
+    */
+    pub fn list_global_sidebar_commands(&self) -> DomainResult<Vec<Value>> {
+        let mut statement = self
+            .db
+            .prepare(
+                r#"
+                SELECT definitionJson FROM global_sidebar_commands
+                ORDER BY sortOrder ASC, commandId ASC
+                "#,
+            )
+            .map_err(sql_error)?;
+        let stored_definitions = statement
+            .query_map([], |row| row.get::<_, String>("definitionJson"))
+            .map_err(sql_error)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(sql_error)?;
+        Ok(stored_definitions
+            .into_iter()
+            .filter_map(|definition| serde_json::from_str::<Value>(&definition).ok())
+            .collect())
+    }
+
+    pub fn save_global_sidebar_command(
+        &self,
+        command_id: &str,
+        definition: &Value,
+    ) -> DomainResult<()> {
+        let timestamp = now_iso();
+        let definition_json = serde_json::to_string(definition).map_err(|error| {
+            DomainStateError::corrupt_state(format!(
+                "Global action definition could not be serialized: {error}"
+            ))
+        })?;
+        /*
+        A new action lands after everything currently stored; an edit keeps the
+        position it already had. COALESCE over MAX gives the first row
+        sortOrder 1 without a separate empty-table branch.
+        */
+        self.db
+            .execute(
+                r#"
+                INSERT INTO global_sidebar_commands (
+                  commandId, definitionJson, sortOrder, createdAt, updatedAt
+                )
+                VALUES (
+                  ?1,
+                  ?2,
+                  COALESCE(
+                    (SELECT sortOrder FROM global_sidebar_commands WHERE commandId = ?1),
+                    (SELECT COALESCE(MAX(sortOrder), 0) + 1 FROM global_sidebar_commands)
+                  ),
+                  ?3,
+                  ?3
+                )
+                ON CONFLICT(commandId) DO UPDATE SET
+                  definitionJson = excluded.definitionJson,
+                  updatedAt = excluded.updatedAt
+                "#,
+                params![command_id, definition_json, timestamp],
+            )
+            .map_err(sql_error)?;
+        Ok(())
+    }
+
+    pub fn delete_global_sidebar_command(&self, command_id: &str) -> DomainResult<()> {
+        self.db
+            .execute(
+                "DELETE FROM global_sidebar_commands WHERE commandId = ?1",
+                [command_id],
+            )
+            .map_err(sql_error)?;
+        Ok(())
+    }
+
+    /*
+    Reorder assigns positions from the ids the client sent, in order. Ids the
+    client did not mention keep their relative order after the listed ones
+    rather than being dropped, so a client on an older list cannot silently
+    delete an action it had not loaded yet.
+    */
+    pub fn order_global_sidebar_commands(&self, command_ids: &[String]) -> DomainResult<()> {
+        let timestamp = now_iso();
+        let stored_ids = {
+            let mut statement = self
+                .db
+                .prepare(
+                    r#"
+                    SELECT commandId FROM global_sidebar_commands
+                    ORDER BY sortOrder ASC, commandId ASC
+                    "#,
+                )
+                .map_err(sql_error)?;
+            let stored_ids = statement
+                .query_map([], |row| row.get::<_, String>("commandId"))
+                .map_err(sql_error)?
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(sql_error)?;
+            stored_ids
+        };
+        let mut next_order = command_ids
+            .iter()
+            .filter(|command_id| stored_ids.contains(command_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        for command_id in stored_ids {
+            if !next_order.contains(&command_id) {
+                next_order.push(command_id);
+            }
+        }
+        for (index, command_id) in next_order.iter().enumerate() {
+            self.db
+                .execute(
+                    r#"
+                    UPDATE global_sidebar_commands
+                    SET sortOrder = ?2, updatedAt = ?3
+                    WHERE commandId = ?1
+                    "#,
+                    params![command_id, (index + 1) as f64, timestamp],
+                )
+                .map_err(sql_error)?;
+        }
+        Ok(())
+    }
+
     pub fn get_project(&self, project_id: &str) -> DomainResult<Option<Value>> {
         let row = self
             .db

--- a/gxserver-rs/src/domain.rs
+++ b/gxserver-rs/src/domain.rs
@@ -599,46 +599,80 @@ impl<'a> DomainRepository<'a> {
     */
     pub fn order_global_sidebar_commands(&self, command_ids: &[String]) -> DomainResult<()> {
         let timestamp = now_iso();
-        let stored_ids = {
-            let mut statement = self
-                .db
-                .prepare(
-                    r#"
-                    SELECT commandId FROM global_sidebar_commands
-                    ORDER BY sortOrder ASC, commandId ASC
-                    "#,
-                )
-                .map_err(sql_error)?;
-            let stored_ids = statement
-                .query_map([], |row| row.get::<_, String>("commandId"))
-                .map_err(sql_error)?
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(sql_error)?;
-            stored_ids
-        };
-        let mut next_order = command_ids
-            .iter()
-            .filter(|command_id| stored_ids.contains(command_id))
-            .cloned()
-            .collect::<Vec<_>>();
-        for command_id in stored_ids {
-            if !next_order.contains(&command_id) {
-                next_order.push(command_id);
+        /*
+        One reorder is many row writes, so it takes the writer reservation before
+        reading the stored ids and commits or rolls back as a unit, mirroring
+        `update_session_order`. Without the transaction a failure partway leaves
+        some rows on the new sortOrder and some on the old — an interleaved list
+        that the server would then echo back as the confirmed order. Taking
+        BEGIN IMMEDIATE before the SELECT also closes the read-then-write race
+        against a concurrent save or delete, which would otherwise keep a stale
+        sortOrder that this reorder never accounted for.
+        */
+        self.db
+            .execute_batch("BEGIN IMMEDIATE TRANSACTION")
+            .map_err(sql_error)?;
+        let result = (|| -> DomainResult<()> {
+            let stored_ids = {
+                let mut statement = self
+                    .db
+                    .prepare(
+                        r#"
+                        SELECT commandId FROM global_sidebar_commands
+                        ORDER BY sortOrder ASC, commandId ASC
+                        "#,
+                    )
+                    .map_err(sql_error)?;
+                let stored_ids = statement
+                    .query_map([], |row| row.get::<_, String>("commandId"))
+                    .map_err(sql_error)?
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .map_err(sql_error)?;
+                stored_ids
+            };
+            /*
+            A repeated id would otherwise consume two index positions — the
+            append guard below skips the duplicate, but the write loop would
+            still assign it twice — so requested ids are deduplicated first.
+            */
+            let mut next_order: Vec<String> = Vec::with_capacity(stored_ids.len());
+            for command_id in command_ids {
+                if stored_ids.contains(command_id) && !next_order.contains(command_id) {
+                    next_order.push(command_id.clone());
+                }
+            }
+            for command_id in stored_ids {
+                if !next_order.contains(&command_id) {
+                    next_order.push(command_id);
+                }
+            }
+            for (index, command_id) in next_order.iter().enumerate() {
+                self.db
+                    .execute(
+                        r#"
+                        UPDATE global_sidebar_commands
+                        SET sortOrder = ?2, updatedAt = ?3
+                        WHERE commandId = ?1
+                        "#,
+                        params![command_id, (index + 1) as f64, timestamp],
+                    )
+                    .map_err(sql_error)?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                if let Err(error) = self.db.execute_batch("COMMIT") {
+                    let _ = self.db.execute_batch("ROLLBACK");
+                    return Err(sql_error(error));
+                }
+                Ok(())
+            }
+            Err(error) => {
+                let _ = self.db.execute_batch("ROLLBACK");
+                Err(error)
             }
         }
-        for (index, command_id) in next_order.iter().enumerate() {
-            self.db
-                .execute(
-                    r#"
-                    UPDATE global_sidebar_commands
-                    SET sortOrder = ?2, updatedAt = ?3
-                    WHERE commandId = ?1
-                    "#,
-                    params![command_id, (index + 1) as f64, timestamp],
-                )
-                .map_err(sql_error)?;
-        }
-        Ok(())
     }
 
     pub fn get_project(&self, project_id: &str) -> DomainResult<Option<Value>> {

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -100,7 +100,8 @@ use crate::{
     session_status::agent_activity_presentation_refresh_delay_ms,
     sidebar_hud::{
         create_sidebar_hud_settings_mutation, read_sidebar_hud,
-        read_sidebar_hud_commands_by_project,
+        read_sidebar_hud_commands_by_project, read_sidebar_hud_global_commands,
+        GlobalSidebarCommandUpdate,
     },
     sidebar_project_collections::{
         read_sidebar_project_collections, update_sidebar_project_collections,
@@ -2248,6 +2249,23 @@ async fn route_http(
                         );
                     }
                 }
+                /*
+                CDXC:GlobalActions 2026-08-01-16:00:
+                Global Actions live in their own daemon table rather than in
+                project metadata, so they are attached here instead of inside
+                read_sidebar_hud, which stays a pure projection of project rows.
+                Served unconditionally rather than behind an opt-in flag: the
+                list is one small array with no per-project fan-out, and every
+                surface that renders the tab strip needs it on first paint.
+                */
+                if let Some(hud) = hud.as_object_mut() {
+                    hud.insert(
+                        "globalCommands".to_string(),
+                        read_sidebar_hud_global_commands(
+                            &repository.list_global_sidebar_commands()?,
+                        ),
+                    );
+                }
                 Ok(hud)
             },
         ),
@@ -2264,7 +2282,19 @@ async fn route_http(
                 let projects = repository.list_projects()?;
                 let mutation = create_sidebar_hud_settings_mutation(&projects, params)?;
                 let hud_active_project_id = mutation.hud_active_project_id;
-                let item_ids = mutation.item_ids;
+                let mut item_ids = mutation.item_ids;
+                /*
+                CDXC:GlobalActions 2026-08-01-16:00:
+                A reorder response must echo the order the daemon actually
+                stored — the sidebar treats itemIds as the confirmation for its
+                optimistic reorder and falls back to an empty list without it.
+                The stored order can differ from the ids the client sent, since
+                the repository keeps unlisted actions instead of dropping them.
+                */
+                let global_command_order_requested = matches!(
+                    mutation.global_command_update,
+                    Some(GlobalSidebarCommandUpdate::Order { .. })
+                );
                 let mut updated_projects = Vec::new();
                 for update in mutation.updates {
                     let project = repository.update_project(&update.params)?;
@@ -2277,8 +2307,46 @@ async fn route_http(
                     )?;
                     updated_projects.push(project);
                 }
+                /*
+                CDXC:GlobalActions 2026-08-01-16:00:
+                A Global Action write touches no project row, so it schedules no
+                projectUpdated presentation delta. Clients pick the new list up
+                from the refreshed HUD this call returns and from their next HUD
+                poll, the same way they already do for action edits.
+                */
+                match mutation.global_command_update {
+                    Some(GlobalSidebarCommandUpdate::Save {
+                        command_id,
+                        definition,
+                    }) => repository.save_global_sidebar_command(&command_id, &definition)?,
+                    Some(GlobalSidebarCommandUpdate::Delete { command_id }) => {
+                        repository.delete_global_sidebar_command(&command_id)?
+                    }
+                    Some(GlobalSidebarCommandUpdate::Order { command_ids }) => {
+                        repository.order_global_sidebar_commands(&command_ids)?
+                    }
+                    None => {}
+                }
                 let projects = repository.list_projects()?;
-                let hud = read_sidebar_hud(&projects, hud_active_project_id.as_deref());
+                let mut hud = read_sidebar_hud(&projects, hud_active_project_id.as_deref());
+                let global_commands =
+                    read_sidebar_hud_global_commands(&repository.list_global_sidebar_commands()?);
+                if global_command_order_requested {
+                    item_ids = Some(
+                        global_commands
+                            .as_array()
+                            .into_iter()
+                            .flatten()
+                            .filter_map(Value::as_object)
+                            .filter_map(|command| command.get("commandId"))
+                            .filter_map(Value::as_str)
+                            .map(str::to_string)
+                            .collect(),
+                    );
+                }
+                if let Some(hud) = hud.as_object_mut() {
+                    hud.insert("globalCommands".to_string(), global_commands);
+                }
                 let mut result = Map::new();
                 result.insert("hud".to_string(), hud);
                 if let Some(item_ids) = item_ids {

--- a/gxserver-rs/src/sidebar_hud.rs
+++ b/gxserver-rs/src/sidebar_hud.rs
@@ -787,12 +787,21 @@ fn global_sidebar_command_save_mutation(
 ) -> Result<SidebarHudSettingsMutation, DomainStateError> {
     let command_id = optional_trimmed_param(params, "commandId")
         .unwrap_or_else(create_custom_sidebar_command_id);
-    let mut next_command = stored_sidebar_command_from_save_params(params, command_id.clone())?;
     /*
-    The four default actions (dev/build/test/setup) are project-scoped. A Global
-    Action is always user-created, so it can never be a default no matter what id
-    the client sends, and nothing here resurrects a deleted default.
+    The four default actions (dev/build/test/setup) are project-scoped, so their
+    ids are reserved and a Global Action may never claim one. Rejecting at save
+    is what makes that hold on BOTH paths: the read projection recomputes
+    is_default from the id itself, so a stored Global Action called "dev" would
+    come back marked as a default however it was written. Rejecting here also
+    keeps global and project ids from colliding on the reserved names, which a
+    run-by-id selector could not otherwise tell apart.
     */
+    if is_default_sidebar_command_id(&command_id) {
+        return Err(DomainStateError::bad_request(
+            "Global actions cannot use a built-in action id.",
+        ));
+    }
+    let mut next_command = stored_sidebar_command_from_save_params(params, command_id.clone())?;
     next_command.is_default = false;
     Ok(SidebarHudSettingsMutation {
         global_command_update: Some(GlobalSidebarCommandUpdate::Save {
@@ -2088,5 +2097,53 @@ mod tests {
         .unwrap()
         .clone();
         assert!(create_sidebar_hud_settings_mutation(&projects, &params).is_err());
+    }
+
+    /*
+    CDXC:GlobalActions 2026-08-01-19:00:
+    A Global Action may not claim a reserved built-in id. The read projection
+    recomputes isDefault from the id, so a stored global "dev" would come back
+    marked as a default however it was written, and a run-by-id selector could
+    not tell it apart from the project action of the same name.
+    */
+    #[test]
+    fn global_command_save_rejects_reserved_default_ids() {
+        let projects = Vec::new();
+        for command_id in ["dev", "build", "test", "setup"] {
+            let params = json!({
+                "actionType": "terminal",
+                "command": "echo hi",
+                "commandId": command_id,
+                "name": "Reserved",
+                "operation": "save",
+                "target": "globalCommand"
+            })
+            .as_object()
+            .unwrap()
+            .clone();
+            assert!(
+                create_sidebar_hud_settings_mutation(&projects, &params).is_err(),
+                "expected reserved global command id {command_id} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn global_command_save_needs_no_project() {
+        let projects = Vec::new();
+        let params = json!({
+            "actionType": "terminal",
+            "command": "gh pr list",
+            "name": "PRs",
+            "operation": "save",
+            "target": "globalCommand"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let mutation = create_sidebar_hud_settings_mutation(&projects, &params)
+            .expect("global saves must not require an active project");
+        assert!(mutation.updates.is_empty());
+        assert!(mutation.global_command_update.is_some());
     }
 }

--- a/gxserver-rs/src/sidebar_hud.rs
+++ b/gxserver-rs/src/sidebar_hud.rs
@@ -62,9 +62,34 @@ pub struct SidebarHudProjectMutation {
 
 #[derive(Clone, Debug)]
 pub struct SidebarHudSettingsMutation {
+    /*
+    CDXC:GlobalActions 2026-08-01-16:00:
+    Global Actions belong to the daemon, not to a project row, so a settings
+    mutation is no longer always a project write. A global mutation carries this
+    field and leaves `updates` empty; a project mutation is unchanged and leaves
+    this None. The two never both apply in one request because the Settings UI
+    edits one list at a time.
+    */
+    pub global_command_update: Option<GlobalSidebarCommandUpdate>,
     pub hud_active_project_id: Option<String>,
     pub item_ids: Option<Vec<String>>,
     pub updates: Vec<SidebarHudProjectMutation>,
+}
+
+/// A single write against the daemon-owned Global Actions list. The repository
+/// owns ordering and timestamps; this only describes the intent.
+#[derive(Clone, Debug)]
+pub enum GlobalSidebarCommandUpdate {
+    Delete {
+        command_id: String,
+    },
+    Order {
+        command_ids: Vec<String>,
+    },
+    Save {
+        command_id: String,
+        definition: Value,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -347,6 +372,9 @@ pub fn create_sidebar_hud_settings_mutation(
         ("command", "save") => sidebar_command_save_mutation(projects, params),
         ("command", "delete") => sidebar_command_delete_mutation(projects, params),
         ("command", "order") => sidebar_command_order_mutation(projects, params),
+        ("globalCommand", "save") => global_sidebar_command_save_mutation(params),
+        ("globalCommand", "delete") => global_sidebar_command_delete_mutation(params),
+        ("globalCommand", "order") => global_sidebar_command_order_mutation(params),
         _ => Err(DomainStateError::bad_request(
             "Unsupported sidebar Settings mutation.",
         )),
@@ -546,6 +574,7 @@ fn sidebar_agent_projects_mutation(
         ));
     }
     Ok(SidebarHudSettingsMutation {
+        global_command_update: None,
         hud_active_project_id: optional_trimmed_param(params, "activeProjectId"),
         item_ids: None,
         updates,
@@ -558,43 +587,6 @@ fn sidebar_command_save_mutation(
 ) -> Result<SidebarHudSettingsMutation, DomainStateError> {
     let command_scope = sidebar_command_scope(projects, params)?;
     let mut state = sidebar_command_state(command_scope.owner_project);
-    let name = params
-        .get("name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .unwrap_or_default()
-        .to_string();
-    let icon = params
-        .get("icon")
-        .and_then(Value::as_str)
-        .and_then(sidebar_command_icon)
-        .map(str::to_string);
-    if name.is_empty() && icon.is_none() {
-        return Err(DomainStateError::bad_request(
-            "Sidebar action mutations require a name or icon.",
-        ));
-    }
-    let action_type = match params.get("actionType").and_then(Value::as_str) {
-        Some("browser") => "browser",
-        Some("terminal") => "terminal",
-        _ => {
-            return Err(DomainStateError::bad_request(
-                "Unsupported sidebar action type.",
-            ));
-        }
-    };
-    let command_text = optional_trimmed_param(params, "command");
-    let url = optional_trimmed_param(params, "url");
-    if action_type == "browser" && url.is_none() {
-        return Err(DomainStateError::bad_request(
-            "Browser sidebar actions require a URL.",
-        ));
-    }
-    if action_type == "terminal" && command_text.is_none() {
-        return Err(DomainStateError::bad_request(
-            "Terminal sidebar actions require a command.",
-        ));
-    }
     let current_command_ids = sidebar_button_ids(
         &sidebar_command_buttons_from_state(
             &state.commands,
@@ -605,32 +597,7 @@ fn sidebar_command_save_mutation(
     );
     let command_id = optional_trimmed_param(params, "commandId")
         .unwrap_or_else(create_custom_sidebar_command_id);
-    let next_command = StoredSidebarCommand {
-        action_type,
-        close_terminal_on_exit: action_type == "terminal"
-            && params
-                .get("closeTerminalOnExit")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-        command: (action_type == "terminal")
-            .then_some(command_text)
-            .flatten(),
-        command_id: command_id.clone(),
-        icon,
-        is_default: is_default_sidebar_command_id(&command_id),
-        links: if action_type == "terminal" {
-            normalized_sidebar_command_links(params.get("links"))
-        } else {
-            Vec::new()
-        },
-        name,
-        play_completion_sound: action_type == "terminal"
-            && params
-                .get("playCompletionSound")
-                .and_then(Value::as_bool)
-                .unwrap_or(true),
-        url: (action_type == "browser").then_some(url).flatten(),
-    };
+    let next_command = stored_sidebar_command_from_save_params(params, command_id.clone())?;
     reject_duplicate_sidebar_command_title(
         &next_command,
         &state.commands,
@@ -730,6 +697,156 @@ fn sidebar_command_order_mutation(
     let mut mutation = sidebar_command_project_mutation(command_scope, state)?;
     mutation.item_ids = Some(item_ids);
     Ok(mutation)
+}
+
+/*
+CDXC:GlobalActions 2026-08-01-16:00:
+Project and Global Actions accept the exact same action definition from
+Settings — only ownership differs — so both saves validate through one path.
+Splitting the validation would let the two lists drift into accepting different
+action shapes, which is how a Global Action that mobile cannot run gets saved.
+*/
+fn stored_sidebar_command_from_save_params(
+    params: &Map<String, Value>,
+    command_id: String,
+) -> Result<StoredSidebarCommand, DomainStateError> {
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string();
+    let icon = params
+        .get("icon")
+        .and_then(Value::as_str)
+        .and_then(sidebar_command_icon)
+        .map(str::to_string);
+    if name.is_empty() && icon.is_none() {
+        return Err(DomainStateError::bad_request(
+            "Sidebar action mutations require a name or icon.",
+        ));
+    }
+    let action_type = match params.get("actionType").and_then(Value::as_str) {
+        Some("browser") => "browser",
+        Some("terminal") => "terminal",
+        _ => {
+            return Err(DomainStateError::bad_request(
+                "Unsupported sidebar action type.",
+            ));
+        }
+    };
+    let command_text = optional_trimmed_param(params, "command");
+    let url = optional_trimmed_param(params, "url");
+    if action_type == "browser" && url.is_none() {
+        return Err(DomainStateError::bad_request(
+            "Browser sidebar actions require a URL.",
+        ));
+    }
+    if action_type == "terminal" && command_text.is_none() {
+        return Err(DomainStateError::bad_request(
+            "Terminal sidebar actions require a command.",
+        ));
+    }
+    Ok(StoredSidebarCommand {
+        action_type,
+        close_terminal_on_exit: action_type == "terminal"
+            && params
+                .get("closeTerminalOnExit")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        command: (action_type == "terminal")
+            .then_some(command_text)
+            .flatten(),
+        is_default: is_default_sidebar_command_id(&command_id),
+        command_id,
+        icon,
+        links: if action_type == "terminal" {
+            normalized_sidebar_command_links(params.get("links"))
+        } else {
+            Vec::new()
+        },
+        name,
+        play_completion_sound: action_type == "terminal"
+            && params
+                .get("playCompletionSound")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+        url: (action_type == "browser").then_some(url).flatten(),
+    })
+}
+
+/*
+CDXC:GlobalActions 2026-08-01-16:00:
+Global Action mutations never read or write project rows, so they do not resolve
+a command scope, an owner project, or a worktree parent the way Project Action
+mutations must. The repository owns ordering and the stored list; these arms only
+validate the intent and hand it over.
+*/
+fn global_sidebar_command_save_mutation(
+    params: &Map<String, Value>,
+) -> Result<SidebarHudSettingsMutation, DomainStateError> {
+    let command_id = optional_trimmed_param(params, "commandId")
+        .unwrap_or_else(create_custom_sidebar_command_id);
+    let mut next_command = stored_sidebar_command_from_save_params(params, command_id.clone())?;
+    /*
+    The four default actions (dev/build/test/setup) are project-scoped. A Global
+    Action is always user-created, so it can never be a default no matter what id
+    the client sends, and nothing here resurrects a deleted default.
+    */
+    next_command.is_default = false;
+    Ok(SidebarHudSettingsMutation {
+        global_command_update: Some(GlobalSidebarCommandUpdate::Save {
+            command_id,
+            definition: sidebar_command_button_value(&next_command),
+        }),
+        hud_active_project_id: optional_trimmed_param(params, "activeProjectId"),
+        item_ids: None,
+        updates: Vec::new(),
+    })
+}
+
+fn global_sidebar_command_delete_mutation(
+    params: &Map<String, Value>,
+) -> Result<SidebarHudSettingsMutation, DomainStateError> {
+    Ok(SidebarHudSettingsMutation {
+        global_command_update: Some(GlobalSidebarCommandUpdate::Delete {
+            command_id: required_trimmed_param(params, "commandId")?,
+        }),
+        hud_active_project_id: optional_trimmed_param(params, "activeProjectId"),
+        item_ids: None,
+        updates: Vec::new(),
+    })
+}
+
+fn global_sidebar_command_order_mutation(
+    params: &Map<String, Value>,
+) -> Result<SidebarHudSettingsMutation, DomainStateError> {
+    Ok(SidebarHudSettingsMutation {
+        global_command_update: Some(GlobalSidebarCommandUpdate::Order {
+            command_ids: normalized_string_order(params.get("commandIds")),
+        }),
+        hud_active_project_id: optional_trimmed_param(params, "activeProjectId"),
+        item_ids: None,
+        updates: Vec::new(),
+    })
+}
+
+/*
+CDXC:GlobalActions 2026-08-01-16:00:
+Global Actions are normalized through the same stored-command projection as
+Project Actions, minus the defaults branch: there are no built-in global actions
+to resurrect or tombstone, so the stored rows are the whole list. Rows arrive
+from the repository already in sortOrder.
+*/
+pub fn read_sidebar_hud_global_commands(stored_definitions: &[Value]) -> Value {
+    let stored_commands =
+        normalized_stored_sidebar_commands(Some(&Value::Array(stored_definitions.to_vec())));
+    Value::Array(
+        stored_commands
+            .iter()
+            .map(sidebar_command_button_value)
+            .collect(),
+    )
 }
 
 fn sidebar_agent_buttons_from_projects(projects: &[Value]) -> Value {
@@ -982,6 +1099,7 @@ fn sidebar_command_project_mutation(
         string_array_value(&state.deleted_default_command_ids),
     );
     Ok(SidebarHudSettingsMutation {
+        global_command_update: None,
         hud_active_project_id: command_scope.hud_active_project_id,
         item_ids: None,
         updates: vec![SidebarHudProjectMutation {

--- a/gxserver-rs/src/storage.rs
+++ b/gxserver-rs/src/storage.rs
@@ -1067,6 +1067,34 @@ pub const GXSERVER_STORAGE_MIGRATIONS: &[Migration] = &[
       PRAGMA user_version = 17;
     "#,
     },
+    Migration {
+        id: "0018_global_sidebar_commands",
+        /*
+        CDXC:GlobalActions 2026-08-01-16:00:
+        Global Actions show the same action on every project, so they cannot
+        live in projects.customCommandsJson the way Project Actions do. Store
+        them daemon-side in their own table so mobile, web, and every desktop
+        build read one list instead of mirroring a per-project column. The
+        definition body is the same normalized stored-command shape Project
+        Actions use; only ownership and ordering differ. Defaults
+        (dev/build/test/setup) stay project-scoped, so there is no
+        deletedDefaultCommandIds equivalent here and every row is user-created.
+        */
+        sql: r#"
+      CREATE TABLE IF NOT EXISTS global_sidebar_commands (
+        commandId TEXT PRIMARY KEY,
+        definitionJson TEXT NOT NULL,
+        sortOrder REAL NOT NULL,
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_global_sidebar_commands_order
+        ON global_sidebar_commands(sortOrder, commandId);
+
+      PRAGMA user_version = 18;
+    "#,
+    },
 ];
 
 #[cfg(unix)]
@@ -1115,10 +1143,10 @@ mod tests {
         let journal_mode: String = db
             .query_row("PRAGMA journal_mode", [], |row| row.get(0))
             .expect("journal_mode");
-        assert_eq!(user_version, 17);
+        assert_eq!(user_version, 18);
         assert_eq!(foreign_keys, 1);
         assert_eq!(journal_mode, "wal");
-        assert_eq!(schema_migration_count(&db), 17);
+        assert_eq!(schema_migration_count(&db), 18);
         assert_eq!(
             explicit_index_names(&db),
             vec![
@@ -1127,6 +1155,7 @@ mod tests {
                 "idx_automation_runs_project_created".to_string(),
                 "idx_automations_due".to_string(),
                 "idx_automations_project_updated".to_string(),
+                "idx_global_sidebar_commands_order".to_string(),
                 "idx_id_allocations_kind_parent".to_string(),
                 "idx_portless_domain_project_identity".to_string(),
                 "idx_portless_domain_project_slug".to_string(),

--- a/shared/gxserver-protocol.ts
+++ b/shared/gxserver-protocol.ts
@@ -1398,6 +1398,14 @@ export interface GxserverSidebarHudCommandLink {
 export interface GxserverSidebarHudResponse {
   agents: readonly GxserverSidebarHudAgentButton[];
   commands: readonly GxserverSidebarHudCommandButton[];
+  /**
+   * CDXC:GlobalActions 2026-08-01:
+   * Global Actions apply to every project and are stored daemon-side rather
+   * than in project metadata, so they arrive as their own list instead of
+   * inside `commands`. Optional because a gxserver older than the app drops
+   * fields it does not know; surfaces normalize the gap to an empty list.
+   */
+  globalCommands?: readonly GxserverSidebarHudCommandButton[];
 }
 
 export type GxserverSidebarHudSettingsMutationParams =
@@ -1434,20 +1442,27 @@ export type GxserverSidebarHudSettingsMutationParams =
       name: string;
       operation: "save";
       playCompletionSound?: boolean;
-      target: "command";
+      /**
+       * CDXC:GlobalActions 2026-08-01:
+       * Global and Project Actions accept the identical action definition and
+       * differ only in ownership, so the target selects the list rather than
+       * the payload shape. gxserver validates both through one path, which is
+       * what keeps the two lists from drifting into different action shapes.
+       */
+      target: "command" | "globalCommand";
       url?: string;
     }
   | {
       activeProjectId?: string;
       commandId: string;
       operation: "delete";
-      target: "command";
+      target: "command" | "globalCommand";
     }
   | {
       activeProjectId?: string;
       commandIds: readonly string[];
       operation: "order";
-      target: "command";
+      target: "command" | "globalCommand";
     };
 
 export interface GxserverSidebarHudSettingsMutationResult {

--- a/shared/sidebar-commands.test.ts
+++ b/shared/sidebar-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vite-plus/test";
 import {
+  createGlobalSidebarCommandButtons,
   createSidebarCommandButtons,
   getFirstBrowserSidebarCommandUrl,
   getSidebarCommandPreviewLabel,
@@ -504,5 +505,64 @@ describe("normalizeStoredSidebarCommandOrder", () => {
       "test",
       "dev",
     ]);
+  });
+});
+
+describe("createGlobalSidebarCommandButtons", () => {
+  test("should render nothing when no global actions are stored", () => {
+    expect(createGlobalSidebarCommandButtons([])).toEqual([]);
+  });
+
+  test("should not resurrect the project default actions", () => {
+    expect(
+      createGlobalSidebarCommandButtons([
+        {
+          actionType: "terminal",
+          closeTerminalOnExit: false,
+          command: "gh pr list",
+          commandId: "custom-prs",
+          isDefault: false,
+          name: "PRs",
+          playCompletionSound: true,
+        },
+      ]).map((command) => command.commandId),
+    ).toEqual(["custom-prs"]);
+  });
+
+  test("should apply the stored order and append unlisted actions", () => {
+    const storedCommands = [
+      {
+        actionType: "terminal" as const,
+        closeTerminalOnExit: false,
+        command: "gh pr list",
+        commandId: "custom-prs",
+        isDefault: false,
+        name: "PRs",
+        playCompletionSound: true,
+      },
+      {
+        actionType: "browser" as const,
+        closeTerminalOnExit: false,
+        commandId: "custom-docs",
+        isDefault: false,
+        name: "Docs",
+        playCompletionSound: false,
+        url: "https://example.com",
+      },
+      {
+        actionType: "terminal" as const,
+        closeTerminalOnExit: false,
+        command: "git status",
+        commandId: "custom-status",
+        isDefault: false,
+        name: "Status",
+        playCompletionSound: true,
+      },
+    ];
+    expect(
+      createGlobalSidebarCommandButtons(storedCommands, ["custom-docs", "custom-prs"]).map(
+        (command) => command.commandId,
+      ),
+    ).toEqual(["custom-docs", "custom-prs", "custom-status"]);
   });
 });

--- a/shared/sidebar-commands.ts
+++ b/shared/sidebar-commands.ts
@@ -171,6 +171,24 @@ export function createSidebarCommandButtons(
   return orderSidebarCommandButtons([...defaultButtons, ...customButtons], storedOrder);
 }
 
+/**
+ * CDXC:GlobalActions 2026-08-01:
+ * Global Actions have no built-in members — dev/build/test/setup are
+ * project-scoped — so the stored rows are the entire list. That removes the
+ * whole default-resurrection and tombstone branch that project actions need,
+ * and it means an empty store renders an empty section rather than four
+ * unconfigured placeholder buttons.
+ */
+export function createGlobalSidebarCommandButtons(
+  storedCommands: readonly StoredSidebarCommand[],
+  storedOrder: readonly string[] = [],
+): SidebarCommandButton[] {
+  return orderSidebarCommandButtons(
+    storedCommands.map((command) => normalizeStoredCommandButton(command)),
+    storedOrder,
+  );
+}
+
 export function isDefaultSidebarCommandId(commandId: string): commandId is DefaultSidebarCommandId {
   return DEFAULT_SIDEBAR_COMMANDS.some((command) => command.commandId === commandId);
 }


### PR DESCRIPTION
First of two PRs for the Global Actions feature you specced. This one is the daemon and contract layer only — **nothing is user-visible until the follow-up adds the tab strip.** Splitting it so the storage shape gets reviewed before the GPUI work depends on it.

## Why a new table

Global Actions apply to every project, so they can't live in `projects.customCommandsJson` the way Project Actions do. This adds a daemon-owned `global_sidebar_commands` table (migration `0018`), matching your `app_user_data` / `automations` / `stashed_prompts` precedent — so mobile, web and every desktop build read one list instead of mirroring a per-project column.

Per your note: *"global actions should be stored in gxserver so they're available for mobile/web/macos/windows/etc."*

## Notable design points

- **No defaults, so no tombstones.** dev/build/test/setup stay project-scoped, so every global action is user-created. That drops the whole default-resurrection and `deletedDefaultCommandIds` branch — the stored rows are the entire list.
- **`read_sidebar_hud` stays pure.** `globalCommands` is attached by the server afterwards, the same pattern already used for `commandsByProject`, so the projection over project rows is untouched.
- **`sidebar_command_scope` assumed exactly one owner project.** That's the assumption that had to give: `SidebarHudSettingsMutation` grows one optional field, and a global write schedules no `projectUpdated` delta because it touches no project row.
- **One validator for both lists.** Global and Project saves take identical payloads and differ only in ownership, so they share a parser. Splitting it would let the two lists drift into accepting different action shapes.
- **Reorder keeps unlisted actions.** A client reordering a stale list can't silently drop an action it hadn't loaded yet.

## Verification

- `cargo check` clean; `cargo test --lib` 655 passed
- `bun run typecheck` clean; `bun test` 1279 passed
- Driven end to end against a real daemon on an isolated `HOME`: create with zero projects open, reorder (full and partial), edit-keeps-position, delete, and persistence across restart

This commit is verified to build and test green on its own, so it's mergeable independently of the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for global sidebar commands alongside project-specific commands.
  * Global commands can be saved, deleted, and reordered.
  * Sidebar HUD responses now include global commands in their stored order.
  * Global commands remain separate from project default actions.
  * Added validation and normalization for global command definitions.

* **Tests**
  * Added coverage for empty global actions, ordering, normalization, and exclusion of project defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->