### PR TITLE
feat(projects): add Global Defaults for the three project settings fields

### DIFF
--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -12940,8 +12940,17 @@ class GpuiSidebarRuntime {
     worktreeProject: GxserverProjectDomainState,
     setupCommandProject: GxserverProjectDomainState,
   ): Promise<void> {
-    const setupCommand = stringFromRecord(setupCommandProject.gitConfig, "worktreeCommand");
-    if (!setupCommand || !this.client) {
+    /*
+     * CDXC:GlobalProjectDefaults 2026-08-02:
+     * This gate decides whether to call the setup endpoint at all, so it has to
+     * see the Global Default the same way gxserver does. Without that, a project
+     * inheriting its worktree command would return here and the configured
+     * command would never run. gxserver still resolves the command it executes.
+     */
+    const setupCommand =
+      stringFromRecord(setupCommandProject.gitConfig, "worktreeCommand") ??
+      normalizeghostexSettings(this.runtimeSettings?.settings).globalWorktreeCommand;
+    if (!setupCommand.trim() || !this.client) {
       return;
     }
     const result = await this.client.rpc<GxserverTypedOperationResult>(

--- a/gxserver-rs/src/global_project_defaults.rs
+++ b/gxserver-rs/src/global_project_defaults.rs
@@ -1,0 +1,135 @@
+/*
+CDXC:GlobalProjectDefaults 2026-08-02:
+Global Defaults back the three per-project fields on the Projects settings page.
+A project keeps winning whenever its own stored value is non-empty; only an empty
+project value consults the global. Every global therefore defaults to empty, which
+reproduces the exact pre-feature resolution for every project.
+
+The read and the decision are split the same way `session_lifecycle` splits its
+settings gate: `read_global_project_defaults` owns the one filesystem read, and
+`resolve_with_global_default` is a pure function so the cascade is testable
+without a settings file on disk.
+*/
+
+use serde_json::Value;
+
+/// Global Defaults as stored in the shared sidebar settings file. Empty strings
+/// mean "not configured", never "configured as blank".
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GlobalProjectDefaults {
+    pub beads_directory: String,
+    pub beads_display_key: String,
+    pub worktree_command: String,
+}
+
+impl GlobalProjectDefaults {
+    fn from_settings(settings: Option<&Value>) -> Self {
+        let read = |key: &str| -> String {
+            settings
+                .and_then(|settings| settings.get(key))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        };
+        Self {
+            beads_directory: read("globalBeadsDirectory"),
+            beads_display_key: read("globalBeadsDisplayKey"),
+            worktree_command: read("globalWorktreeCommand"),
+        }
+    }
+}
+
+/// Resolve one project field against its Global Default. Returns `None` when
+/// neither side is configured, which every caller must keep treating exactly as
+/// it treated an unset project field before this feature existed.
+pub fn resolve_with_global_default(
+    project_value: Option<&str>,
+    global_value: &str,
+) -> Option<String> {
+    let project_value = project_value.unwrap_or_default().trim();
+    if !project_value.is_empty() {
+        return Some(project_value.to_string());
+    }
+    let global_value = global_value.trim();
+    if global_value.is_empty() {
+        return None;
+    }
+    Some(global_value.to_string())
+}
+
+/// The single read of Global Defaults out of the shared sidebar settings file.
+/// A missing or unparseable file yields all-empty defaults, so a broken settings
+/// file can never silently redirect a project at some other global value.
+pub fn read_global_project_defaults() -> GlobalProjectDefaults {
+    let paths = crate::paths::get_gxserver_paths(None);
+    let settings_path = paths
+        .home_dir
+        .join(".ghostex")
+        .join("state")
+        .join("native-sidebar-settings.json");
+    let settings = std::fs::read_to_string(settings_path)
+        .ok()
+        .and_then(|text| serde_json::from_str::<Value>(&text).ok());
+    GlobalProjectDefaults::from_settings(settings.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn project_value_always_wins_over_the_global_default() {
+        assert_eq!(
+            resolve_with_global_default(Some("/project/board"), "/global/board"),
+            Some("/project/board".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_project_value_falls_back_to_the_global_default() {
+        assert_eq!(
+            resolve_with_global_default(Some("   "), "/global/board"),
+            Some("/global/board".to_string())
+        );
+        assert_eq!(
+            resolve_with_global_default(None, "/global/board"),
+            Some("/global/board".to_string())
+        );
+    }
+
+    #[test]
+    fn unset_global_default_preserves_the_pre_feature_none() {
+        assert_eq!(resolve_with_global_default(None, ""), None);
+        assert_eq!(resolve_with_global_default(Some(""), "   "), None);
+    }
+
+    #[test]
+    fn missing_settings_file_reads_as_nothing_configured() {
+        assert_eq!(
+            GlobalProjectDefaults::from_settings(None),
+            GlobalProjectDefaults::default()
+        );
+    }
+
+    #[test]
+    fn settings_values_are_trimmed_and_read_by_key() {
+        let settings = json!({
+            "globalBeadsDirectory": " /global/board ",
+            "globalBeadsDisplayKey": "AGE",
+            "globalWorktreeCommand": "bun install",
+        });
+        let defaults = GlobalProjectDefaults::from_settings(Some(&settings));
+        assert_eq!(defaults.beads_directory, "/global/board");
+        assert_eq!(defaults.beads_display_key, "AGE");
+        assert_eq!(defaults.worktree_command, "bun install");
+    }
+
+    #[test]
+    fn non_string_settings_values_read_as_nothing_configured() {
+        let settings = json!({ "globalBeadsDirectory": 12, "globalWorktreeCommand": null });
+        let defaults = GlobalProjectDefaults::from_settings(Some(&settings));
+        assert_eq!(defaults, GlobalProjectDefaults::default());
+    }
+}

--- a/gxserver-rs/src/lib.rs
+++ b/gxserver-rs/src/lib.rs
@@ -10,6 +10,7 @@ pub mod constants;
 pub mod domain;
 pub mod events;
 pub mod ghostex_cli;
+pub mod global_project_defaults;
 pub mod http_client;
 pub mod identity;
 pub mod ids;

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -6802,15 +6802,22 @@ async fn prepare_registered_worktree_project(
             candidate.get("projectId").and_then(Value::as_str) == Some(setup_project_id)
         })
         .cloned();
-    if setup_project
-        .as_ref()
-        .and_then(|project| project.get("gitConfig"))
-        .and_then(Value::as_object)
-        .and_then(|config| config.get("worktreeCommand"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|command| !command.is_empty())
-        .is_none()
+    /*
+    CDXC:GlobalProjectDefaults 2026-08-02:
+    This gate skips the setup call entirely when nothing is configured, so it has
+    to consult the Global Default too. Otherwise a project relying on the global
+    would return here and never reach the executor that would have run it.
+    */
+    if crate::global_project_defaults::resolve_with_global_default(
+        setup_project
+            .as_ref()
+            .and_then(|project| project.get("gitConfig"))
+            .and_then(Value::as_object)
+            .and_then(|config| config.get("worktreeCommand"))
+            .and_then(Value::as_str),
+        &crate::global_project_defaults::read_global_project_defaults().worktree_command,
+    )
+    .is_none()
     {
         return Ok(());
     }

--- a/gxserver-rs/src/typed_operations.rs
+++ b/gxserver-rs/src/typed_operations.rs
@@ -300,19 +300,28 @@ fn resolve_project_operation_context(
     let beads_cwd = if endpoint_path == "/api/runBeadsAction"
         && params.get("projectBoardScope").and_then(Value::as_bool) == Some(true)
     {
-        project
+        /*
+        CDXC:GlobalProjectDefaults 2026-08-02:
+        The project's own Beads directory still wins. Only an unset one consults
+        the Global Default, and an unset global still yields None so the board
+        keeps launching from the project root exactly as it did before.
+        */
+        let project_directory = project
             .get("projectBoardConfig")
             .and_then(Value::as_object)
             .and_then(|config| config.get("beadsDirectory"))
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .map(|path| {
-                normalize_existing_directory_path_value(
-                    Some(&Value::String(path.to_string())),
-                    "beadsDirectory",
-                )
-            })
-            .transpose()?
+            .and_then(Value::as_str);
+        crate::global_project_defaults::resolve_with_global_default(
+            project_directory,
+            &crate::global_project_defaults::read_global_project_defaults().beads_directory,
+        )
+        .map(|path| {
+            normalize_existing_directory_path_value(
+                Some(&Value::String(path)),
+                "beadsDirectory",
+            )
+        })
+        .transpose()?
     } else {
         None
     };
@@ -494,11 +503,22 @@ async fn run_project_setup_command(
     }
     let action = action.expect("validated setup action");
     let setup_project = resolve_project_setup_command_project(params, context)?;
-    let command_text = normalize_project_setup_command(
+    /*
+    CDXC:GlobalProjectDefaults 2026-08-02:
+    A project without its own worktree command now runs the Global Default. With
+    no global configured this resolves to None and the operation still no-ops
+    below, which is the pre-feature behavior.
+    */
+    let resolved_setup_command = crate::global_project_defaults::resolve_with_global_default(
         setup_project
             .get("gitConfig")
             .and_then(Value::as_object)
-            .and_then(|config| config.get("worktreeCommand")),
+            .and_then(|config| config.get("worktreeCommand"))
+            .and_then(Value::as_str),
+        &crate::global_project_defaults::read_global_project_defaults().worktree_command,
+    );
+    let command_text = normalize_project_setup_command(
+        resolved_setup_command.map(Value::String).as_ref(),
     )?;
     if command_text.is_empty() {
         return Ok(json!({

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -46378,11 +46378,20 @@ function resolveProjectBoardDisplayMetadata(project: NativeProject): {
   const gxserverProject = findGxserverProject(project.projectId);
   const name = textValue(gxserverProject?.name) ?? project.name;
   const path = textValue(gxserverProject?.path) ?? project.path;
+  /*
+  CDXC:GlobalProjectDefaults 2026-08-02:
+  The Global Default sits between the project's own key and the project-name
+  fallback, so a project that never set a key shows the global ticket prefix
+  while any project with its own key keeps it. An unset global leaves the
+  previous project-name fallback untouched.
+  */
+  const globalBeadsDisplayKey = textValue(settings.globalBeadsDisplayKey);
   const beadsDisplayKey = gxserverProject
     ? (textValue(gxserverProject.projectBoardConfig.beadsDisplayKey) ??
       textValue(gxserverProject.gitConfig.beadsDisplayKey) ??
+      globalBeadsDisplayKey ??
       name)
-    : (project.beadsDisplayKey ?? name);
+    : (project.beadsDisplayKey ?? globalBeadsDisplayKey ?? name);
   return {
     beadsDisplayKey,
     name,

--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -855,6 +855,17 @@ export type ghostexSettings = {
    * The Docs sidebar scans ./docs recursively and root artifacts by default, and users can add comma-separated project-relative folder roots from global Projects settings. Trim spaces around each folder name while preserving spaces inside names such as "my documents".
    */
   manageAdditionalDocsFolders: string;
+  /**
+   * CDXC:GlobalProjectDefaults 2026-08-02:
+   * Global Defaults for the three per-project fields on the Projects settings
+   * page. A project keeps overriding the default whenever its own value is
+   * non-empty; an empty project value now falls back here before falling back
+   * to the previous built-in behavior. Empty globals therefore preserve the
+   * exact pre-existing resolution for every project.
+   */
+  globalWorktreeCommand: string;
+  globalBeadsDisplayKey: string;
+  globalBeadsDirectory: string;
   showProjectEditorDiffFileCount: boolean;
   showUntrackedProjectDiffWhenNoTrackedChanges: boolean;
   completionBellEnabled: boolean;
@@ -1430,6 +1441,14 @@ export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
    * Additional Docs scan folders are opt-in so existing projects continue to expose only ./docs plus root Markdown, HTML, and Excalidraw artifacts until the user lists more project-relative folders.
    */
   manageAdditionalDocsFolders: "",
+  /**
+   * CDXC:GlobalProjectDefaults 2026-08-02:
+   * New installs ship every Global Default empty so project resolution stays
+   * byte-for-byte identical to the pre-feature behavior until a user fills one in.
+   */
+  globalWorktreeCommand: "",
+  globalBeadsDisplayKey: "",
+  globalBeadsDirectory: "",
   /**
    * CDXC:ProjectDiffStats 2026-05-15-14:33:
    * Project-header git stats should hide the changed-file count by default and
@@ -2400,6 +2419,16 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
         DEFAULT_ghostex_SETTINGS.manageAdditionalDocsFolders,
       ),
     ),
+    // CDXC:GlobalProjectDefaults 2026-08-02: Global Defaults for the Projects page fields.
+    globalWorktreeCommand: normalizeGlobalWorktreeCommand(
+      readString(source, "globalWorktreeCommand", DEFAULT_ghostex_SETTINGS.globalWorktreeCommand),
+    ),
+    globalBeadsDisplayKey: normalizeGlobalBeadsDisplayKey(
+      readString(source, "globalBeadsDisplayKey", DEFAULT_ghostex_SETTINGS.globalBeadsDisplayKey),
+    ),
+    globalBeadsDirectory: normalizeGlobalBeadsDirectory(
+      readString(source, "globalBeadsDirectory", DEFAULT_ghostex_SETTINGS.globalBeadsDirectory),
+    ),
     /**
      * CDXC:ProjectDiffStats 2026-05-15-14:33:
      * Missing or invalid older settings must keep project-header git stats in
@@ -3214,6 +3243,26 @@ export function normalizeManageAdditionalDocsFolders(value: string | undefined):
    * The Projects setting is typed as comma-separated text because folder names may contain spaces. Settings normalizes on every keystroke, so preserve the user's draft text here and let native trim comma boundaries and reject unsafe path shapes when scanning.
    */
   return (value ?? "").replace(/\0/gu, "").replace(/\r?\n/gu, ", ").slice(0, 1_000);
+}
+
+/*
+ * CDXC:GlobalProjectDefaults 2026-08-02:
+ * Each Global Default normalizes exactly like the per-project field it backs, so
+ * a value that is valid globally is also valid when a project stores it. The
+ * worktree cap matches the 16384-byte limit gxserver enforces on the project
+ * field, and the ticket key matches the three-character A-Z0-9 shape the
+ * Projects page already forces while typing.
+ */
+export function normalizeGlobalWorktreeCommand(value: string | undefined): string {
+  return (value ?? "").replace(/\0/gu, "").slice(0, 16_384);
+}
+
+export function normalizeGlobalBeadsDisplayKey(value: string | undefined): string {
+  return (value ?? "").toUpperCase().replace(/[^A-Z0-9]/gu, "").slice(0, 3);
+}
+
+export function normalizeGlobalBeadsDirectory(value: string | undefined): string {
+  return (value ?? "").replace(/\0/gu, "").trim().slice(0, 1_000);
 }
 
 function normalizeTerminalCursorStyle(value: string | undefined): TerminalCursorStyle {

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -5262,6 +5262,13 @@ export function SettingsModal({
           {!isFirstLaunchSetup ? (
           <TabsContent className="mt-0 min-h-0 flex-1 overflow-hidden" value="projects">
             <ProjectsSettingsPanel
+              onGlobalBeadsDirectoryChange={(value) => updateDraft("globalBeadsDirectory", value)}
+              onGlobalBeadsDisplayKeyChange={(value) =>
+                updateDraft("globalBeadsDisplayKey", value)
+              }
+              onGlobalWorktreeCommandChange={(value) =>
+                updateDraft("globalWorktreeCommand", value)
+              }
               onManageAdditionalDocsFoldersChange={(value) =>
                 updateDraft("manageAdditionalDocsFolders", value)
               }
@@ -6312,7 +6319,31 @@ function formatRemoteMachineSshTarget(machine: RemoteMachineSettings): string {
   return machine.sshPort ? `${host}:${machine.sshPort}` : host;
 }
 
+/*
+ * CDXC:GlobalProjectDefaults 2026-08-02:
+ * A project field is "inherited" only while the project's own value is empty and
+ * a Global Default exists to take its place. The badge marks that state next to
+ * the field name, and the caller shows the inherited value as the input's
+ * placeholder so the effective value is visible without leaving the page.
+ */
+function InheritedSettingBadge() {
+  return (
+    <span className="settings-inherited-badge" title="Using the Global Default set above">
+      Inherited
+    </span>
+  );
+}
+
+function inheritedPlaceholder(projectValue: string, globalValue: string, fallback: string): string {
+  return projectValue.trim().length === 0 && globalValue.trim().length > 0
+    ? globalValue
+    : fallback;
+}
+
 function ProjectsSettingsPanel({
+  onGlobalBeadsDirectoryChange,
+  onGlobalBeadsDisplayKeyChange,
+  onGlobalWorktreeCommandChange,
   onManageAdditionalDocsFoldersChange,
   onPortlessEnabledChange,
   onPortlessProtocolChange,
@@ -6323,6 +6354,9 @@ function ProjectsSettingsPanel({
   settings,
   vscode,
 }: {
+  onGlobalBeadsDirectoryChange: (value: string) => void;
+  onGlobalBeadsDisplayKeyChange: (value: string) => void;
+  onGlobalWorktreeCommandChange: (value: string) => void;
   onManageAdditionalDocsFoldersChange: (value: string) => void;
   onPortlessEnabledChange: (checked: boolean) => void;
   onPortlessProtocolChange: (protocol: PortlessProtocol) => void;
@@ -6343,6 +6377,18 @@ function ProjectsSettingsPanel({
   const [command, setCommand] = useState(selectedProject?.worktreeCommand ?? "");
   const [beadsDisplayKey, setBeadsDisplayKey] = useState(selectedProject?.beadsDisplayKey ?? "");
   const [beadsDirectory, setBeadsDirectory] = useState(selectedProject?.beadsDirectory ?? "");
+  /*
+   * CDXC:GlobalProjectDefaults 2026-08-02:
+   * Track inheritance against the live draft text rather than the saved project
+   * value so the badge disappears the moment the user starts typing an override
+   * and returns when they clear the field again.
+   */
+  const isWorktreeCommandInherited =
+    command.trim().length === 0 && settings.globalWorktreeCommand.trim().length > 0;
+  const isBeadsDisplayKeyInherited =
+    beadsDisplayKey.trim().length === 0 && settings.globalBeadsDisplayKey.trim().length > 0;
+  const isBeadsDirectoryInherited =
+    beadsDirectory.trim().length === 0 && settings.globalBeadsDirectory.trim().length > 0;
 
   useEffect(() => {
     if (!projects.some((project) => project.projectId === selectedProjectId)) {
@@ -6487,6 +6533,70 @@ function ProjectsSettingsPanel({
           </CardContent>
         </Card>
         ) : null}
+        {shouldShowSettingsSection(search.sections.globalDefaults) ? (
+        <Card className="settings-project-command-card">
+          <CardContent className="flex flex-col gap-4 p-4">
+            {/*
+              CDXC:GlobalProjectDefaults 2026-08-02:
+              Global Defaults sits above the project selector because it configures every project at once. Each field mirrors the per-project field of the same name below; a project keeps winning whenever its own value is non-empty, so filling nothing in here leaves every project resolving exactly as it did before.
+            */}
+            <div className="settings-management-header-text">
+              <h3 className="settings-management-heading">Global Defaults</h3>
+              <p className="settings-management-description">
+                Applied to every project that does not set its own value below.
+              </p>
+            </div>
+            <FieldGroup>
+              <Field>
+                <FieldLabel>Worktree command</FieldLabel>
+                <SettingsTextarea
+                  aria-label="Global worktree command"
+                  className="settings-project-command-textarea"
+                  onChange={(event) => onGlobalWorktreeCommandChange(event.currentTarget.value)}
+                  placeholder="bun install"
+                  value={settings.globalWorktreeCommand}
+                />
+                <FieldDescription>
+                  Runs in every new worktree folder unless the project sets its own command.
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+            <FieldGroup>
+              <Field>
+                <FieldLabel>Ticket key</FieldLabel>
+                <SettingsInput
+                  aria-label="Global ticket key"
+                  maxLength={3}
+                  onChange={(event) =>
+                    onGlobalBeadsDisplayKeyChange(
+                      event.currentTarget.value.toUpperCase().replace(/[^A-Z0-9]/gu, ""),
+                    )
+                  }
+                  placeholder="ZMX"
+                  value={settings.globalBeadsDisplayKey}
+                />
+                <FieldDescription>
+                  Ticket prefix for every project board unless the project sets its own key.
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+            <FieldGroup>
+              <Field>
+                <FieldLabel>Beads directory</FieldLabel>
+                <SettingsInput
+                  aria-label="Global Beads directory"
+                  onChange={(event) => onGlobalBeadsDirectoryChange(event.currentTarget.value)}
+                  placeholder="/Users/you/code/my-repo"
+                  value={settings.globalBeadsDirectory}
+                />
+                <FieldDescription>
+                  Absolute path every Project board reads its Beads workspace (.beads) from unless the project sets its own directory. Leave blank to keep using each project root.
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+          </CardContent>
+        </Card>
+        ) : null}
         {!shouldShowSettingsSection(search.sections.projectSettings) ? null : projects.length ===
           0 ? (
         <Empty>
@@ -6594,12 +6704,19 @@ function ProjectsSettingsPanel({
             */}
             <FieldGroup>
               <Field>
-                <FieldLabel>Worktree command</FieldLabel>
+                <FieldLabel>
+                  Worktree command
+                  {isWorktreeCommandInherited ? <InheritedSettingBadge /> : null}
+                </FieldLabel>
                 <SettingsTextarea
                   aria-label="Worktree command"
                   className="settings-project-command-textarea"
                   onChange={(event) => setCommand(event.currentTarget.value)}
-                  placeholder="bun install"
+                  placeholder={inheritedPlaceholder(
+                    command,
+                    settings.globalWorktreeCommand,
+                    "bun install",
+                  )}
                   value={command}
                 />
                 <FieldDescription>
@@ -6621,14 +6738,21 @@ function ProjectsSettingsPanel({
             */}
             <FieldGroup>
               <Field>
-                <FieldLabel>Ticket key</FieldLabel>
+                <FieldLabel>
+                  Ticket key
+                  {isBeadsDisplayKeyInherited ? <InheritedSettingBadge /> : null}
+                </FieldLabel>
                 <SettingsInput
                   aria-label="Ticket key"
                   maxLength={3}
                   onChange={(event) =>
                     setBeadsDisplayKey(event.currentTarget.value.toUpperCase().replace(/[^A-Z0-9]/gu, ""))
                   }
-                  placeholder="ZMX"
+                  placeholder={inheritedPlaceholder(
+                    beadsDisplayKey,
+                    settings.globalBeadsDisplayKey,
+                    "ZMX",
+                  )}
                   value={beadsDisplayKey}
                 />
                 <FieldDescription>
@@ -6650,15 +6774,22 @@ function ProjectsSettingsPanel({
             */}
             <FieldGroup>
               <Field>
-                <FieldLabel>Beads directory</FieldLabel>
+                <FieldLabel>
+                  Beads directory
+                  {isBeadsDirectoryInherited ? <InheritedSettingBadge /> : null}
+                </FieldLabel>
                 <SettingsInput
                   aria-label="Beads directory"
                   onChange={(event) => setBeadsDirectory(event.currentTarget.value)}
-                  placeholder="/Users/you/code/my-repo"
+                  placeholder={inheritedPlaceholder(
+                    beadsDirectory,
+                    settings.globalBeadsDirectory,
+                    "/Users/you/code/my-repo",
+                  )}
                   value={beadsDirectory}
                 />
                 <FieldDescription>
-                  Absolute path the Project board reads its Beads workspace (.beads) from. Leave blank to use the project root.
+                  Absolute path the Project board reads its Beads workspace (.beads) from. Leave blank to use the Global Default, or the project root when that is empty too.
                 </FieldDescription>
               </Field>
             </FieldGroup>
@@ -10709,6 +10840,27 @@ const EXTRA_SETTINGS_TAB_SEARCH_SECTIONS: Record<
           },
         ],
         title: "Docs",
+      },
+      {
+        id: "globalDefaults",
+        settings: [
+          {
+            key: "globalWorktreeCommand",
+            subtitle: "Worktree command every project uses unless it sets its own.",
+            title: "Global worktree command",
+          },
+          {
+            key: "globalTicketKey",
+            subtitle: "Ticket key every project uses unless it sets its own.",
+            title: "Global ticket key",
+          },
+          {
+            key: "globalBeadsDirectory",
+            subtitle: "Beads directory every project uses unless it sets its own.",
+            title: "Global Beads directory",
+          },
+        ],
+        title: "Global Defaults",
       },
       {
         id: "projectSettings",

--- a/sidebar/styles/modals.css
+++ b/sidebar/styles/modals.css
@@ -4050,6 +4050,27 @@ html:has(body.app-modal-host-native-window-body) {
 }
 
 /*
+ * CDXC:GlobalProjectDefaults 2026-08-02:
+ * The Inherited badge sits inline after a project field name to mark that the
+ * field is currently taking its value from Global Defaults. Keep it quiet: it
+ * reports state, it is not an action, so it must not compete with the field
+ * label it annotates.
+ */
+.settings-inherited-badge {
+  align-self: center;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  opacity: 0.65;
+  padding: 0 6px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/*
  * CDXC:RemoteMachines 2026-06-08-19:12:
  * Saved remote machine cards need a quiet summary header, compact SSH fields, and hover-revealed delete controls so the Remote tab matches Agents/Actions management styling in the settings modal.
  *


### PR DESCRIPTION
Adds a **Global Defaults** section at the top of the Projects settings page, per the discussion in feedback-and-ideas. It holds the same three fields the per-project card already owns — worktree command, ticket key, and Beads directory — and each applies to every project that does not set its own value.

## Why this is safe to land

**Empty already meant "fall back" for all three fields** ("Leave blank to use the project root"). So this adds a link to an existing chain rather than changing what any stored value means. Every global ships empty, which reproduces the exact previous resolution for every project. Nobody's setup moves unless they fill something in.

## Inherited indicator

A project field taking its value from a global shows a small **Inherited** badge next to the field name, and renders the global value as its input placeholder so the effective value is visible without leaving the page.

The badge tracks the live draft text, not the saved value — it clears the moment an override is typed and returns when the field is emptied again.

## Where the cascade lands

Resolution goes only into **behavioral** consumers. The settings projections deliberately keep exposing each project's own stored value, otherwise the badge could not tell "set to X" from "inheriting X".

| Field | Behavioral site |
|---|---|
| Beads directory | `typed_operations.rs` — Beads cwd |
| Worktree command | `typed_operations.rs` executor, plus the `server.rs` and `gxserver-runtime.ts` gates |
| Ticket key | `native-sidebar.tsx` — between the legacy `gitConfig` key and the project-name fallback |

Both worktree gates matter: each early-returns when nothing is configured, so either one would otherwise skip the executor for a project that inherits its command.

`global_project_defaults.rs` splits the one filesystem read from the decision, the way `session_lifecycle.rs` splits its settings gate, so the cascade is unit-testable without a settings file on disk.

## Validation

- `tsc --noEmit` — clean
- `cargo test` — 662 existing pass, plus 6 new covering project-wins / empty-falls-back / empty-global-preserves-old-behavior
- `vitest run --config vitest.release.config.ts` — 1279 pass. The 2 failures in `shared/sidebar-commands.test.ts` (`showOnProjectRow`) reproduce identically on a clean checkout of `main` at f0575281 and are unrelated to this change.
- Verified in Storybook (`sidebar-settings-modal--projects`): setting a global ticket key and clearing the project's own key shows the Inherited badge with the global as placeholder, while a sibling field that has its own value shows no badge; typing an override dismisses it.

## One thing worth flagging separately

GPUI's Kanban currently passes the project *display name* as `beadsDisplayKey` regardless of the configured key (`gpui/src/main.rs`), so the per-project ticket key only takes effect in the native sidebar today. That is pre-existing on `main` and untouched here, but it means the ticket-key half of this feature inherits that same limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)