### PR TITLE
feat(kanban): show bead assignee and creator on cards

### DIFF
--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -15,6 +15,7 @@ import {
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
+  ticketCreatorName,
   type BoardTicket,
 } from "./project-board-shared";
 
@@ -88,6 +89,16 @@ describe("project board priority labels", () => {
   test("normalizes legacy P4 values into the visible Low tier", () => {
     expect(priorityLabel(4)).toBe("Low");
     expect(prioritySelectValue(4)).toBe("3");
+  });
+});
+
+describe("project board creator", () => {
+  test("shows the creator only when it differs from the assignee", () => {
+    expect(ticketCreatorName("harry", "dobby")).toBe("harry");
+    expect(ticketCreatorName("harry", "harry")).toBeUndefined();
+    expect(ticketCreatorName("harry", undefined)).toBe("harry");
+    expect(ticketCreatorName(undefined, "dobby")).toBeUndefined();
+    expect(ticketCreatorName("", "dobby")).toBeUndefined();
   });
 });
 

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -37,6 +37,7 @@ export type BeadsIssue = {
   comment_count?: number;
   comments?: BeadsComment[];
   created_at?: string;
+  created_by?: string;
   dependencies?: BeadsDependency[];
   dependency_count?: number;
   dependent_count?: number;
@@ -274,6 +275,19 @@ export function toBoardTickets(
       boardStatus: beadsStatusToBoardStatus(issue.status),
       displayId: formatTicketDisplayId(issue, displayKey, serialByIssueId),
     }));
+}
+
+/*
+  CDXC:ProjectBoardCreator 2026-08-07-07:52:
+  Cards and Edit ticket show who created a bead next to who is assigned to it. The creator is
+  redundant noise when it is the same person as the assignee, so display surfaces resolve the
+  creator through here instead of each deciding when to hide it.
+*/
+export function ticketCreatorName(
+  createdBy: string | undefined,
+  assignee: string | undefined,
+): string | undefined {
+  return createdBy && createdBy !== assignee ? createdBy : undefined;
 }
 
 export function estimateToTshirt(estimate: number | null | undefined): TshirtSize | undefined {

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -152,6 +152,34 @@ describe("Project Board form event handling", () => {
     expect(contextMenuSource).toContain('"Delete"');
   });
 
+  test("shows the Beads assignee on Kanban cards and in Edit ticket", () => {
+    /*
+     * CDXC:ProjectBoardAssignee 2026-08-07-06:07:
+     * Kanban cards and Edit ticket should surface the Beads assignee so it is not confused with the
+     * agent dropdown, which is now titled Start work with. Unassigned tickets must render as before,
+     * so both the card chip and the Edit ticket field stay conditional on an assignee value.
+     */
+    const ticketCardSource = sourceBetween("function TicketCard(", "function ProjectBoardTicketContextMenu(");
+    const metaFieldsSource = sourceBetween("function TicketMetaFields(", "function DependencyPicker(");
+    const conversationSectionSource = sourceBetween("function ConversationSection(", "function conversationLinkLabel(");
+    const assigneeStyleSource = sourceBetween(".project-board-card-assignee {", ".project-board-comments {");
+
+    expect(ticketCardSource).toContain("{ticket.assignee ? (");
+    expect(ticketCardSource).toContain('className="project-board-card-assignee"');
+    expect(ticketCardSource).toContain("{ticket.assignee}</span>");
+    expect(metaFieldsSource).toContain("{assignee ? (");
+    expect(metaFieldsSource).toContain("<span>Assignee</span>");
+    expect(metaFieldsSource).toContain('className="project-ticket-assignee-value"');
+    expect(conversationSectionSource).toContain(
+      '<div className="project-ticket-section-title">Start work with</div>',
+    );
+    expect(conversationSectionSource).not.toContain(
+      '<div className="project-ticket-section-title">Conversation</div>',
+    );
+    expect(assigneeStyleSource).toContain("text-overflow: ellipsis;");
+    expect(tasksPlaceholderSource).toContain("assignee={detail.ticket?.assignee}");
+  });
+
   test("reports sanitized focus-owner events for native Kanban focus arbitration", () => {
     /*
      * CDXC:ProjectBoardFocus 2026-06-12-08:44:

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -180,6 +180,33 @@ describe("Project Board form event handling", () => {
     expect(tasksPlaceholderSource).toContain("assignee={detail.ticket?.assignee}");
   });
 
+  test("shows the Beads creator distinctly from the assignee", () => {
+    /*
+     * CDXC:ProjectBoardCreator 2026-08-07-07:52:
+     * Cards and Edit ticket show who created a bead next to who works it, so the two must read
+     * differently: the creator is muted "by <name>" text with no person icon, the assignee keeps its
+     * icon chip. Both resolve the creator through ticketCreatorName so it disappears when it is unset
+     * or the same person as the assignee, and the assignee chip spells its role out in the tooltip.
+     */
+    const ticketCardSource = sourceBetween("function TicketCard(", "function ProjectBoardTicketContextMenu(");
+    const metaFieldsSource = sourceBetween("function TicketMetaFields(", "function DependencyPicker(");
+    const creatorStyleSource = sourceBetween(
+      ".project-board-card-creator {",
+      ".project-board-card-assignee {",
+    );
+
+    expect(ticketCardSource).toContain("ticketCreatorName(ticket.created_by, ticket.assignee)");
+    expect(ticketCardSource).toContain('className="project-board-card-creator"');
+    expect(ticketCardSource).toContain("by {creator}");
+    expect(ticketCardSource).toContain("title={`Assigned to ${ticket.assignee}`}");
+    expect(metaFieldsSource).toContain("ticketCreatorName(createdBy, assignee)");
+    expect(metaFieldsSource).toContain("{creator ? (");
+    expect(metaFieldsSource).toContain("<span>Created by</span>");
+    expect(metaFieldsSource).toContain('className="project-ticket-creator-value"');
+    expect(creatorStyleSource).toContain("text-overflow: ellipsis;");
+    expect(tasksPlaceholderSource).toContain("createdBy={detail.ticket?.created_by}");
+  });
+
   test("reports sanitized focus-owner events for native Kanban focus arbitration", () => {
     /*
      * CDXC:ProjectBoardFocus 2026-06-12-08:44:

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -15,6 +15,7 @@ import {
   IconSearch,
   IconTrash,
   IconUnlink,
+  IconUser,
   IconX,
 } from "@tabler/icons-react";
 import { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/react";
@@ -3046,6 +3047,7 @@ function ProjectBoardApp() {
             onKeyDown={(event) => handleCmdEnter(event, () => void saveTicketDetail())}
           >
             <TicketMetaFields
+              assignee={detail.ticket?.assignee}
               blockedByIds={detail.blockedByIds}
               blockingIds={detail.blockingIds}
               knownLabels={knownLabels}
@@ -3433,6 +3435,7 @@ function ProjectBoardApp() {
 }
 
 function TicketMetaFields({
+  assignee,
   blockedByIds,
   blockingIds,
   knownLabels,
@@ -3449,6 +3452,7 @@ function TicketMetaFields({
   ticketOptions,
   tshirt,
 }: {
+  assignee?: string;
   blockedByIds: string[];
   blockingIds: string[];
   knownLabels: string[];
@@ -3602,6 +3606,15 @@ function TicketMetaFields({
         selectedIds={blockedByIds}
         ticketOptions={ticketOptions}
       />
+      {assignee ? (
+        <div className="project-ticket-field project-ticket-field-inline">
+          <span>Assignee</span>
+          <div className="project-ticket-assignee-value" title={assignee}>
+            <IconUser aria-hidden="true" />
+            <span className="project-ticket-assignee-name">{assignee}</span>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -3824,7 +3837,7 @@ function ConversationSection({
   );
   return (
     <section className="project-ticket-conversations" aria-label="Linked conversations">
-      <div className="project-ticket-section-title">Conversation</div>
+      <div className="project-ticket-section-title">Start work with</div>
       <div className="project-ticket-conversation-controls">
         <Select
           disabled={agents.length === 0}
@@ -4251,6 +4264,12 @@ function TicketCard({
           ) : null}
           {blockedByCount > 0 ? <span>{blockedByCount} blocked</span> : null}
           {blockingCount > 0 ? <span>{blockingCount} blocking</span> : null}
+          {ticket.assignee ? (
+            <span className="project-board-card-assignee" title={ticket.assignee}>
+              <IconUser />
+              <span className="project-board-card-assignee-name">{ticket.assignee}</span>
+            </span>
+          ) : null}
           <span className="project-board-comments">
             <IconMessageCircle />
             {ticket.comment_count ?? ticket.comments?.length ?? 0}
@@ -7190,6 +7209,27 @@ styleElement.textContent = `
     font-weight: 680;
   }
 
+  .project-board-card-assignee {
+    align-items: center;
+    color: rgba(244, 244, 245, 0.72);
+    display: inline-flex;
+    gap: 4px;
+    max-width: 50%;
+    min-width: 0;
+  }
+
+  .project-board-card-assignee svg {
+    flex: none;
+    height: 13px;
+    width: 13px;
+  }
+
+  .project-board-card-assignee-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .project-board-comments {
     align-items: center;
     display: inline-flex;
@@ -7495,6 +7535,27 @@ styleElement.textContent = `
 
   .project-ticket-field-inline {
     gap: 6px;
+  }
+
+  .project-ticket-assignee-value {
+    align-items: center;
+    color: rgba(250, 250, 250, 0.92);
+    display: flex;
+    font-weight: 500;
+    gap: 5px;
+    min-width: 0;
+  }
+
+  .project-ticket-assignee-value svg {
+    flex: none;
+    height: 14px;
+    width: 14px;
+  }
+
+  .project-ticket-assignee-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .project-ticket-field textarea,

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -101,6 +101,7 @@ import {
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
   isDescriptionImageSource,
+  ticketCreatorName,
   tshirtToEstimate,
   toBoardTickets,
   estimateToTshirt,
@@ -3050,6 +3051,7 @@ function ProjectBoardApp() {
               assignee={detail.ticket?.assignee}
               blockedByIds={detail.blockedByIds}
               blockingIds={detail.blockingIds}
+              createdBy={detail.ticket?.created_by}
               knownLabels={knownLabels}
               labels={detail.labels}
               onBlockedByChange={(blockedByIds) =>
@@ -3438,6 +3440,7 @@ function TicketMetaFields({
   assignee,
   blockedByIds,
   blockingIds,
+  createdBy,
   knownLabels,
   labels,
   onBlockedByChange,
@@ -3455,6 +3458,7 @@ function TicketMetaFields({
   assignee?: string;
   blockedByIds: string[];
   blockingIds: string[];
+  createdBy?: string;
   knownLabels: string[];
   labels: string[];
   onBlockedByChange: (ids: string[]) => void;
@@ -3471,6 +3475,7 @@ function TicketMetaFields({
 }) {
   const [labelDraft, setLabelDraft] = useState("");
   const labelSuggestions = knownLabels.filter((label) => !labels.includes(label));
+  const creator = ticketCreatorName(createdBy, assignee);
 
   return (
     <div className="project-ticket-meta-grid">
@@ -3606,6 +3611,14 @@ function TicketMetaFields({
         selectedIds={blockedByIds}
         ticketOptions={ticketOptions}
       />
+      {creator ? (
+        <div className="project-ticket-field project-ticket-field-inline">
+          <span>Created by</span>
+          <div className="project-ticket-creator-value" title={creator}>
+            {creator}
+          </div>
+        </div>
+      ) : null}
       {assignee ? (
         <div className="project-ticket-field project-ticket-field-inline">
           <span>Assignee</span>
@@ -4208,6 +4221,7 @@ function TicketCard({
   });
   const blockedByCount = ticket.dependency_count ?? getBlockedByIds(ticket).length;
   const blockingCount = ticket.dependent_count ?? 0;
+  const creator = ticketCreatorName(ticket.created_by, ticket.assignee);
   const primaryLink = getPrimaryUsableConversationLink(links) ?? links[0];
   const additionalLinkCount = primaryLink ? links.length - 1 : 0;
   const primaryLinkLabel = primaryLink ? conversationLinkLabel(primaryLink) : "";
@@ -4264,8 +4278,13 @@ function TicketCard({
           ) : null}
           {blockedByCount > 0 ? <span>{blockedByCount} blocked</span> : null}
           {blockingCount > 0 ? <span>{blockingCount} blocking</span> : null}
+          {creator ? (
+            <span className="project-board-card-creator" title={`Created by ${creator}`}>
+              by {creator}
+            </span>
+          ) : null}
           {ticket.assignee ? (
-            <span className="project-board-card-assignee" title={ticket.assignee}>
+            <span className="project-board-card-assignee" title={`Assigned to ${ticket.assignee}`}>
               <IconUser />
               <span className="project-board-card-assignee-name">{ticket.assignee}</span>
             </span>
@@ -7209,6 +7228,14 @@ styleElement.textContent = `
     font-weight: 680;
   }
 
+  .project-board-card-creator {
+    max-width: 45%;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .project-board-card-assignee {
     align-items: center;
     color: rgba(244, 244, 245, 0.72);
@@ -7535,6 +7562,15 @@ styleElement.textContent = `
 
   .project-ticket-field-inline {
     gap: 6px;
+  }
+
+  .project-ticket-creator-value {
+    color: rgba(250, 250, 250, 0.68);
+    font-weight: 500;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .project-ticket-assignee-value {


### PR DESCRIPTION
Follow-up from our Discord thread (BANOZZ) about the Project Board: cards never showed *who* a bead belongs to, and the agent dropdown kept being mistaken for the assignee.

## What changes

- **Kanban card**: a person-icon chip with the Beads `assignee` (hidden when unset — unassigned cards render exactly as before), plus muted `by <creator>` text for `created_by` so the orchestrator and the worker read as two different people. Creator hides when identical to the assignee.
- **Edit ticket**: read-only "Created by" and "Assignee" rows (each hidden when unset).
- **Rename**: the "Conversation" section title becomes **"Start work with"** — the Select under it already had `aria-label="Agent for Start work"`, so the title now says what the control does instead of looking like the assignee.
- No write paths and no new bridge actions — display only. `assignee`/`created_by` already arrive via `bd list --all --json`; they were typed-but-unrendered.

## Verification

- `bun run typecheck` → exit 0
- `bunx vitest run native/sidebar/ shared/` → all tests pass (the only failing *suite* is the pre-existing `native-agent-prompt-text.test.ts` bun:test import, untouched)
- New source-text tests follow the existing anchored pattern; the hide-when-identical rule lives in one pure helper (`ticketCreatorName`) so card and dialog can't drift.

## To test

Open a board where beads carry assignees/creators (`bd update <id> --assignee <name>`): chip + "by" text on cards, both rows in Edit ticket, and the renamed section.

## Merge notes

Touches `tasks-placeholder.tsx` and its source-text test like #links and #toolbar PRs — whichever lands later needs a trivial anchor rebase; happy to rebase this stack after any of them merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creator information to ticket cards and edit dialogs.
  * Assignee details now include user icons and improved text truncation.
  * Creator information is hidden when unavailable or identical to the assignee.
  * Updated the conversation section label to “Start work with.”

* **Tests**
  * Added coverage for creator and assignee display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->