### PR TITLE
feat(kanban): lane sorting with directions and persistent view preferences

### DIFF
--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -15,6 +15,7 @@ import {
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
+  sortBoardTickets,
   type BoardTicket,
 } from "./project-board-shared";
 
@@ -131,6 +132,184 @@ describe("project board filters", () => {
     ]);
     expect(filterBoardTickets(tickets, "", "0", "XS").map((ticket) => ticket.id)).toEqual([
       "urgent-xs",
+    ]);
+  });
+});
+
+describe("project board sorting", () => {
+  const doneTickets: BoardTicket[] = [
+    {
+      boardStatus: "done",
+      closed_at: "2026-06-01T10:00:00.000Z",
+      created_at: "2026-01-01T10:00:00.000Z",
+      displayId: "ZMX-1",
+      id: "closed-june",
+      priority: 3,
+      status: "closed",
+      title: "Closed in June",
+      updated_at: "2026-06-01T10:00:00.000Z",
+    },
+    {
+      boardStatus: "done",
+      closed_at: "2026-08-05T10:00:00.000Z",
+      created_at: "2026-07-01T10:00:00.000Z",
+      displayId: "ZMX-2",
+      id: "closed-august",
+      priority: 2,
+      status: "closed",
+      title: "Closed in August",
+      updated_at: "2026-08-05T10:00:00.000Z",
+    },
+    {
+      boardStatus: "done",
+      created_at: "2026-02-01T10:00:00.000Z",
+      displayId: "ZMX-3",
+      id: "closed-without-timestamp",
+      priority: 0,
+      status: "closed",
+      title: "Closed before bd recorded closed_at",
+      updated_at: "2026-07-04T10:00:00.000Z",
+    },
+  ];
+
+  test("puts the newest closed beads first in Done without a selected sort", () => {
+    expect(sortBoardTickets(doneTickets, "default", "done").map((ticket) => ticket.id)).toEqual([
+      "closed-august",
+      "closed-without-timestamp",
+      "closed-june",
+    ]);
+  });
+
+  test("keeps the newest closed beads visible under the lane limit", () => {
+    /*
+     * CDXC:ProjectBoardSort 2026-08-07:
+     * Lanes slice their ticket list before rendering, so Done ordering only helps if it happens
+     * ahead of that cap.
+     */
+    expect(
+      sortBoardTickets(doneTickets, "default", "done")
+        .slice(0, 1)
+        .map((ticket) => ticket.id),
+    ).toEqual(["closed-august"]);
+  });
+
+  test("leaves other lanes in Beads order without a selected sort", () => {
+    const todoTickets: BoardTicket[] = [
+      {
+        boardStatus: "todo",
+        created_at: "2026-01-01T10:00:00.000Z",
+        displayId: "ZMX-4",
+        id: "older",
+        priority: 2,
+        status: "open",
+        title: "Older",
+        updated_at: "2026-01-02T10:00:00.000Z",
+      },
+      {
+        boardStatus: "todo",
+        created_at: "2026-05-01T10:00:00.000Z",
+        displayId: "ZMX-5",
+        id: "newer",
+        priority: 2,
+        status: "open",
+        title: "Newer",
+        updated_at: "2026-05-02T10:00:00.000Z",
+      },
+    ];
+
+    expect(sortBoardTickets(todoTickets, "default", "todo")).toBe(todoTickets);
+  });
+
+  test("applies a selected sort to every lane", () => {
+    expect(sortBoardTickets(doneTickets, "updated", "done").map((ticket) => ticket.id)).toEqual([
+      "closed-august",
+      "closed-without-timestamp",
+      "closed-june",
+    ]);
+    expect(sortBoardTickets(doneTickets, "created", "done").map((ticket) => ticket.id)).toEqual([
+      "closed-august",
+      "closed-without-timestamp",
+      "closed-june",
+    ]);
+    expect(sortBoardTickets(doneTickets, "priority", "backlog").map((ticket) => ticket.id)).toEqual([
+      "closed-without-timestamp",
+      "closed-august",
+      "closed-june",
+    ]);
+  });
+
+  test("sorts legacy P4 beads with the visible Low tier", () => {
+    const tickets: BoardTicket[] = [
+      {
+        boardStatus: "todo",
+        displayId: "ZMX-6",
+        id: "legacy-low",
+        priority: 4,
+        status: "open",
+        title: "Legacy low",
+        updated_at: "2026-05-02T10:00:00.000Z",
+      },
+      {
+        boardStatus: "todo",
+        displayId: "ZMX-7",
+        id: "low",
+        priority: 3,
+        status: "open",
+        title: "Low",
+        updated_at: "2026-05-01T10:00:00.000Z",
+      },
+      {
+        boardStatus: "todo",
+        displayId: "ZMX-8",
+        id: "high",
+        priority: 1,
+        status: "open",
+        title: "High",
+        updated_at: "2026-04-01T10:00:00.000Z",
+      },
+    ];
+
+    expect(sortBoardTickets(tickets, "priority", "todo").map((ticket) => ticket.id)).toEqual([
+      "high",
+      "legacy-low",
+      "low",
+    ]);
+  });
+
+  test("sinks beads with no usable timestamps to the bottom", () => {
+    const tickets: BoardTicket[] = [
+      {
+        boardStatus: "done",
+        displayId: "ZMX-9",
+        id: "undated-first",
+        priority: 2,
+        status: "closed",
+        title: "Undated",
+      },
+      {
+        boardStatus: "done",
+        closed_at: "not-a-date",
+        displayId: "ZMX-10",
+        id: "undated-second",
+        priority: 2,
+        status: "closed",
+        title: "Unparseable",
+      },
+      {
+        boardStatus: "done",
+        closed_at: "2026-03-01T10:00:00.000Z",
+        displayId: "ZMX-11",
+        id: "dated",
+        priority: 2,
+        status: "closed",
+        title: "Dated",
+      },
+    ];
+
+    expect(sortBoardTickets(tickets, "default", "done").map((ticket) => ticket.id)).toEqual([
+      "dated",
+      "undated-first",
+      "undated-second",
     ]);
   });
 });

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   appendImageMarkdownToDescription,
   BOARD_COLUMNS,
+  BOARD_SORT_OPTIONS,
   beadsStatusToBoardStatus,
   boardStatusBeadsValue,
   buildAgentWorkPrompt,
@@ -172,6 +173,27 @@ describe("project board sorting", () => {
     },
   ];
 
+  test("offers both directions for every sort key", () => {
+    expect(BOARD_SORT_OPTIONS.map((option) => option.value)).toEqual([
+      "default",
+      "updated-desc",
+      "updated-asc",
+      "created-desc",
+      "created-asc",
+      "priority-asc",
+      "priority-desc",
+    ]);
+    expect(BOARD_SORT_OPTIONS.map((option) => option.label)).toEqual([
+      "Default order",
+      "Last updated (newest first)",
+      "Last updated (oldest first)",
+      "Created (newest first)",
+      "Created (oldest first)",
+      "Priority (urgent first)",
+      "Priority (low first)",
+    ]);
+  });
+
   test("puts the newest closed beads first in Done without a selected sort", () => {
     expect(sortBoardTickets(doneTickets, "default", "done").map((ticket) => ticket.id)).toEqual([
       "closed-august",
@@ -220,25 +242,30 @@ describe("project board sorting", () => {
     expect(sortBoardTickets(todoTickets, "default", "todo")).toBe(todoTickets);
   });
 
-  test("applies a selected sort to every lane", () => {
-    expect(sortBoardTickets(doneTickets, "updated", "done").map((ticket) => ticket.id)).toEqual([
+  test("applies a selected sort to every lane in both directions", () => {
+    expect(sortBoardTickets(doneTickets, "updated-desc", "done").map((ticket) => ticket.id)).toEqual([
       "closed-august",
       "closed-without-timestamp",
       "closed-june",
     ]);
-    expect(sortBoardTickets(doneTickets, "created", "done").map((ticket) => ticket.id)).toEqual([
+    expect(sortBoardTickets(doneTickets, "updated-asc", "done").map((ticket) => ticket.id)).toEqual([
+      "closed-june",
+      "closed-without-timestamp",
+      "closed-august",
+    ]);
+    expect(sortBoardTickets(doneTickets, "created-desc", "backlog").map((ticket) => ticket.id)).toEqual([
       "closed-august",
       "closed-without-timestamp",
       "closed-june",
     ]);
-    expect(sortBoardTickets(doneTickets, "priority", "backlog").map((ticket) => ticket.id)).toEqual([
+    expect(sortBoardTickets(doneTickets, "created-asc", "backlog").map((ticket) => ticket.id)).toEqual([
+      "closed-june",
       "closed-without-timestamp",
       "closed-august",
-      "closed-june",
     ]);
   });
 
-  test("sorts legacy P4 beads with the visible Low tier", () => {
+  test("reverses the priority view, tie-break included, and keeps legacy P4 in the Low tier", () => {
     const tickets: BoardTicket[] = [
       {
         boardStatus: "todo",
@@ -269,14 +296,19 @@ describe("project board sorting", () => {
       },
     ];
 
-    expect(sortBoardTickets(tickets, "priority", "todo").map((ticket) => ticket.id)).toEqual([
+    expect(sortBoardTickets(tickets, "priority-asc", "todo").map((ticket) => ticket.id)).toEqual([
       "high",
+      "low",
+      "legacy-low",
+    ]);
+    expect(sortBoardTickets(tickets, "priority-desc", "todo").map((ticket) => ticket.id)).toEqual([
       "legacy-low",
       "low",
+      "high",
     ]);
   });
 
-  test("sinks beads with no usable timestamps to the bottom", () => {
+  test("sinks beads with no usable timestamps to the bottom in both directions", () => {
     const tickets: BoardTicket[] = [
       {
         boardStatus: "done",
@@ -303,10 +335,16 @@ describe("project board sorting", () => {
         priority: 2,
         status: "closed",
         title: "Dated",
+        updated_at: "2026-03-01T10:00:00.000Z",
       },
     ];
 
     expect(sortBoardTickets(tickets, "default", "done").map((ticket) => ticket.id)).toEqual([
+      "dated",
+      "undated-first",
+      "undated-second",
+    ]);
+    expect(sortBoardTickets(tickets, "updated-asc", "done").map((ticket) => ticket.id)).toEqual([
       "dated",
       "undated-first",
       "undated-second",

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -6,15 +6,18 @@ import {
   beadsStatusToBoardStatus,
   boardStatusBeadsValue,
   buildAgentWorkPrompt,
+  DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   extractDescriptionImagePreviews,
   extractDescriptionImageReferences,
   ensureIssuePrefix,
   filterBoardTickets,
   formatProjectBoardCommentText,
+  normalizeProjectBoardViewPreferences,
   parseProjectBoardCommentText,
   priorityLabel,
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
+  projectBoardViewPreferencesStorageKey,
   removeDescriptionImageReference,
   sortBoardTickets,
   type BoardTicket,
@@ -424,6 +427,59 @@ describe("project board statuses", () => {
     ]);
     expect(beadsStatusToBoardStatus("backlog")).toBe("backlog");
     expect(boardStatusBeadsValue("backlog")).toBe("backlog");
+  });
+});
+
+describe("project board view preferences", () => {
+  test("keys stored toolbar selections by project", () => {
+    expect(projectBoardViewPreferencesStorageKey("P3lv0")).toBe("ghostex-project-board-view:P3lv0");
+    expect(projectBoardViewPreferencesStorageKey("remote:machine:P9")).toBe(
+      "ghostex-project-board-view:remote:machine:P9",
+    );
+  });
+
+  test("restores stored priority, estimate, and sort selections", () => {
+    expect(
+      normalizeProjectBoardViewPreferences({
+        estimateFilter: "M",
+        priorityFilter: "1",
+        sortOption: "created-asc",
+      }),
+    ).toEqual({
+      estimateFilter: "M",
+      priorityFilter: "1",
+      sortOption: "created-asc",
+    });
+    expect(normalizeProjectBoardViewPreferences({ estimateFilter: "none" }).estimateFilter).toBe(
+      "none",
+    );
+  });
+
+  test("falls back to defaults for missing or unusable stored values", () => {
+    /*
+     * CDXC:ProjectBoardViewPreferences 2026-08-07:
+     * Stored preferences outlive the option lists that produced them, and localStorage is editable
+     * from outside the board, so anything that is not a current option must land on its default
+     * instead of leaving the toolbar on a value the board cannot filter or sort by.
+     */
+    expect(normalizeProjectBoardViewPreferences(null)).toEqual(DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES);
+    expect(normalizeProjectBoardViewPreferences("all")).toEqual(DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES);
+    expect(normalizeProjectBoardViewPreferences({})).toEqual(DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES);
+    expect(
+      normalizeProjectBoardViewPreferences({
+        estimateFilter: "XXL",
+        priorityFilter: 1,
+        sortOption: "closed-desc",
+      }),
+    ).toEqual(DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES);
+  });
+
+  test("keeps every offered toolbar option restorable", () => {
+    for (const option of BOARD_SORT_OPTIONS) {
+      expect(normalizeProjectBoardViewPreferences({ sortOption: option.value }).sortOption).toBe(
+        option.value,
+      );
+    }
   });
 });
 

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -17,7 +17,7 @@ import {
   priorityLabel,
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
-  projectBoardViewPreferencesStorageKey,
+  PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,
   removeDescriptionImageReference,
   sortBoardTickets,
   type BoardTicket,
@@ -431,11 +431,13 @@ describe("project board statuses", () => {
 });
 
 describe("project board view preferences", () => {
-  test("keys stored toolbar selections by project", () => {
-    expect(projectBoardViewPreferencesStorageKey("P3lv0")).toBe("ghostex-project-board-view:P3lv0");
-    expect(projectBoardViewPreferencesStorageKey("remote:machine:P9")).toBe(
-      "ghostex-project-board-view:remote:machine:P9",
-    );
+  test("stores toolbar selections under one app-wide key", () => {
+    /*
+     * CDXC:ProjectBoardViewPreferences 2026-08-07:
+     * Priority, estimate, and sort describe how the user reads a board rather than anything about
+     * a project, so the key carries no project id and every board restores the same selections.
+     */
+    expect(PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY).toBe("ghostex-project-board-view");
   });
 
   test("restores stored priority, estimate, and sort selections", () => {

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -190,7 +190,8 @@ export type ProjectBoardViewPreferences = {
 
 /*
   CDXC:ProjectBoardViewPreferences 2026-08-07:
-  The Kanban is its own web surface, so leaving the board tears it down and every toolbar selection dies with it. Priority, estimate, and sort are durable per-project view settings and are restored on the next mount; ticket search stays ephemeral because a restored query would hide most of the board without an obvious cause.
+  The Kanban is its own web surface, so leaving the board tears it down and every toolbar selection dies with it. Priority, estimate, and sort are durable view settings and are restored on the next mount; ticket search stays ephemeral because a restored query would hide most of the board without an obvious cause.
+  The three selections describe how the user wants to read a board rather than anything about a particular project, so one app-wide set follows them into every project instead of each board keeping its own.
   Stored values outlive the option lists that produced them, so a preference that no longer matches a current option falls back to its default instead of leaving the toolbar showing a value the board cannot filter or sort by.
 */
 export const DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES: ProjectBoardViewPreferences = {
@@ -199,7 +200,7 @@ export const DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES: ProjectBoardViewPreferences
   sortOption: "default",
 };
 
-const PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY_PREFIX = "ghostex-project-board-view:";
+export const PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY = "ghostex-project-board-view";
 const BOARD_PRIORITY_FILTER_VALUES: ReadonlyArray<BoardPriorityFilter> = [
   "all",
   ...PRIORITY_OPTIONS.map((option) => option.value),
@@ -415,10 +416,6 @@ export function projectBoardRawProjectIdFromUrlParam(projectId: string): string 
   } catch {
     return projectId;
   }
-}
-
-export function projectBoardViewPreferencesStorageKey(projectId: string): string {
-  return `${PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY_PREFIX}${projectId}`;
 }
 
 export function normalizeProjectBoardViewPreferences(

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -160,17 +160,27 @@ export const TSHIRT_OPTIONS = [
   { label: "XL", minutes: 240 },
 ] as const;
 
-export const BOARD_SORT_OPTIONS = [
-  { label: "Default order", value: "default" },
-  { label: "Last updated", value: "updated" },
-  { label: "Created", value: "created" },
-  { label: "Priority", value: "priority" },
-] as const;
-
 export type TshirtSize = (typeof TSHIRT_OPTIONS)[number]["label"];
 export type BoardPriorityFilter = "all" | (typeof PRIORITY_OPTIONS)[number]["value"];
 export type BoardEstimateFilter = "all" | "none" | TshirtSize;
-export type BoardSortOption = (typeof BOARD_SORT_OPTIONS)[number]["value"];
+export type BoardSortDirection = "asc" | "desc";
+export type BoardSortKey = "created" | "priority" | "updated";
+export type BoardSortOption = "default" | `${BoardSortKey}-${BoardSortDirection}`;
+
+/*
+  CDXC:ProjectBoardSort 2026-08-07:
+  Each sort key is offered in both directions as its own option instead of a separate direction toggle, because the toolbar's other controls are single dropdowns and a direction control would have nothing to act on while Default order is selected.
+  Direction values describe the underlying field, so `asc` means oldest first for timestamps and urgent first for priority; the visible labels carry that meaning for users.
+*/
+export const BOARD_SORT_OPTIONS: ReadonlyArray<{ label: string; value: BoardSortOption }> = [
+  { label: "Default order", value: "default" },
+  { label: "Last updated (newest first)", value: "updated-desc" },
+  { label: "Last updated (oldest first)", value: "updated-asc" },
+  { label: "Created (newest first)", value: "created-desc" },
+  { label: "Created (oldest first)", value: "created-asc" },
+  { label: "Priority (urgent first)", value: "priority-asc" },
+  { label: "Priority (low first)", value: "priority-desc" },
+];
 
 const REQUIRED_CUSTOM_STATUS_CONFIG = "backlog,test,review";
 const PROJECT_BOARD_COMMENT_METADATA_SEPARATOR = "---";
@@ -441,7 +451,8 @@ export function filterBoardTickets(
   CDXC:ProjectBoardSort 2026-08-07:
   Lanes only render their first PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN cards, so ticket order is a board-level concern rather than a lane-render detail.
   Beads returns no meaningful order for `list --all`, which leaves a Done lane of hundreds of closed beads hiding the work that just finished behind that cap.
-  Done therefore defaults to newest-closed-first while the other lanes keep the Beads order they have always shown, and an explicit sort selection applies to every lane.
+  Done therefore defaults to newest-closed-first while the other lanes keep the Beads order they have always shown, and an explicit sort selection applies to every lane in its chosen direction.
+  Direction also drives the priority tie-break so the two priority views are exact reverses of each other rather than differing only in their tiers.
 */
 export function sortBoardTickets(
   tickets: BoardTicket[],
@@ -451,21 +462,28 @@ export function sortBoardTickets(
   if (sort === "default") {
     return column === "done"
       ? [...tickets].sort((left, right) =>
-          compareNewestFirst(boardTicketClosedTime(left), boardTicketClosedTime(right)),
+          compareBoardTicketTimes(boardTicketClosedTime(left), boardTicketClosedTime(right), "desc"),
         )
       : tickets;
   }
-  if (sort === "priority") {
+  const [sortKey, sortDirection] = sort.split("-") as [BoardSortKey, BoardSortDirection];
+  if (sortKey === "priority") {
     return [...tickets].sort((left, right) => {
       const priorityDelta =
         Number(prioritySelectValue(left.priority)) - Number(prioritySelectValue(right.priority));
       return priorityDelta !== 0
-        ? priorityDelta
-        : compareNewestFirst(boardTicketUpdatedTime(left), boardTicketUpdatedTime(right));
+        ? applyBoardSortDirection(priorityDelta, sortDirection)
+        : compareBoardTicketTimes(
+            boardTicketUpdatedTime(left),
+            boardTicketUpdatedTime(right),
+            sortDirection,
+          );
     });
   }
-  const ticketTime = sort === "created" ? boardTicketCreatedTime : boardTicketUpdatedTime;
-  return [...tickets].sort((left, right) => compareNewestFirst(ticketTime(left), ticketTime(right)));
+  const ticketTime = sortKey === "created" ? boardTicketCreatedTime : boardTicketUpdatedTime;
+  return [...tickets].sort((left, right) =>
+    compareBoardTicketTimes(ticketTime(left), ticketTime(right), sortDirection),
+  );
 }
 
 function boardTicketClosedTime(ticket: BoardTicket): number {
@@ -485,11 +503,29 @@ function parseBoardTicketTime(value: string | undefined): number {
   return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
 }
 
-function compareNewestFirst(left: number, right: number): number {
+function compareBoardTicketTimes(
+  left: number,
+  right: number,
+  direction: BoardSortDirection,
+): number {
   if (left === right) {
     return 0;
   }
-  return left > right ? -1 : 1;
+  /*
+    CDXC:ProjectBoardSort 2026-08-07:
+    A bead whose timestamp is missing or unparseable is unknown rather than oldest, so it stays at the bottom of the lane in both directions instead of leading the oldest-first views.
+  */
+  if (left === Number.NEGATIVE_INFINITY) {
+    return 1;
+  }
+  if (right === Number.NEGATIVE_INFINITY) {
+    return -1;
+  }
+  return applyBoardSortDirection(left > right ? 1 : -1, direction);
+}
+
+function applyBoardSortDirection(ascendingComparison: number, direction: BoardSortDirection): number {
+  return direction === "asc" ? ascendingComparison : -ascendingComparison;
 }
 
 export function appendImageMarkdownToDescription(

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -34,6 +34,7 @@ export type BeadsIssue = {
   assignee?: string;
   blocked_by?: string[];
   blocks?: string[];
+  closed_at?: string;
   comment_count?: number;
   comments?: BeadsComment[];
   created_at?: string;
@@ -159,9 +160,17 @@ export const TSHIRT_OPTIONS = [
   { label: "XL", minutes: 240 },
 ] as const;
 
+export const BOARD_SORT_OPTIONS = [
+  { label: "Default order", value: "default" },
+  { label: "Last updated", value: "updated" },
+  { label: "Created", value: "created" },
+  { label: "Priority", value: "priority" },
+] as const;
+
 export type TshirtSize = (typeof TSHIRT_OPTIONS)[number]["label"];
 export type BoardPriorityFilter = "all" | (typeof PRIORITY_OPTIONS)[number]["value"];
 export type BoardEstimateFilter = "all" | "none" | TshirtSize;
+export type BoardSortOption = (typeof BOARD_SORT_OPTIONS)[number]["value"];
 
 const REQUIRED_CUSTOM_STATUS_CONFIG = "backlog,test,review";
 const PROJECT_BOARD_COMMENT_METADATA_SEPARATOR = "---";
@@ -426,6 +435,61 @@ export function filterBoardTickets(
     threshold: 0.38,
   });
   return fuse.search(normalizedQuery).map((result) => result.item);
+}
+
+/*
+  CDXC:ProjectBoardSort 2026-08-07:
+  Lanes only render their first PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN cards, so ticket order is a board-level concern rather than a lane-render detail.
+  Beads returns no meaningful order for `list --all`, which leaves a Done lane of hundreds of closed beads hiding the work that just finished behind that cap.
+  Done therefore defaults to newest-closed-first while the other lanes keep the Beads order they have always shown, and an explicit sort selection applies to every lane.
+*/
+export function sortBoardTickets(
+  tickets: BoardTicket[],
+  sort: BoardSortOption,
+  column: BoardStatusKey,
+): BoardTicket[] {
+  if (sort === "default") {
+    return column === "done"
+      ? [...tickets].sort((left, right) =>
+          compareNewestFirst(boardTicketClosedTime(left), boardTicketClosedTime(right)),
+        )
+      : tickets;
+  }
+  if (sort === "priority") {
+    return [...tickets].sort((left, right) => {
+      const priorityDelta =
+        Number(prioritySelectValue(left.priority)) - Number(prioritySelectValue(right.priority));
+      return priorityDelta !== 0
+        ? priorityDelta
+        : compareNewestFirst(boardTicketUpdatedTime(left), boardTicketUpdatedTime(right));
+    });
+  }
+  const ticketTime = sort === "created" ? boardTicketCreatedTime : boardTicketUpdatedTime;
+  return [...tickets].sort((left, right) => compareNewestFirst(ticketTime(left), ticketTime(right)));
+}
+
+function boardTicketClosedTime(ticket: BoardTicket): number {
+  return parseBoardTicketTime(ticket.closed_at ?? ticket.updated_at ?? ticket.created_at);
+}
+
+function boardTicketUpdatedTime(ticket: BoardTicket): number {
+  return parseBoardTicketTime(ticket.updated_at ?? ticket.created_at);
+}
+
+function boardTicketCreatedTime(ticket: BoardTicket): number {
+  return parseBoardTicketTime(ticket.created_at);
+}
+
+function parseBoardTicketTime(value: string | undefined): number {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function compareNewestFirst(left: number, right: number): number {
+  if (left === right) {
+    return 0;
+  }
+  return left > right ? -1 : 1;
 }
 
 export function appendImageMarkdownToDescription(

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -182,6 +182,37 @@ export const BOARD_SORT_OPTIONS: ReadonlyArray<{ label: string; value: BoardSort
   { label: "Priority (low first)", value: "priority-desc" },
 ];
 
+export type ProjectBoardViewPreferences = {
+  estimateFilter: BoardEstimateFilter;
+  priorityFilter: BoardPriorityFilter;
+  sortOption: BoardSortOption;
+};
+
+/*
+  CDXC:ProjectBoardViewPreferences 2026-08-07:
+  The Kanban is its own web surface, so leaving the board tears it down and every toolbar selection dies with it. Priority, estimate, and sort are durable per-project view settings and are restored on the next mount; ticket search stays ephemeral because a restored query would hide most of the board without an obvious cause.
+  Stored values outlive the option lists that produced them, so a preference that no longer matches a current option falls back to its default instead of leaving the toolbar showing a value the board cannot filter or sort by.
+*/
+export const DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES: ProjectBoardViewPreferences = {
+  estimateFilter: "all",
+  priorityFilter: "all",
+  sortOption: "default",
+};
+
+const PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY_PREFIX = "ghostex-project-board-view:";
+const BOARD_PRIORITY_FILTER_VALUES: ReadonlyArray<BoardPriorityFilter> = [
+  "all",
+  ...PRIORITY_OPTIONS.map((option) => option.value),
+];
+const BOARD_ESTIMATE_FILTER_VALUES: ReadonlyArray<BoardEstimateFilter> = [
+  "all",
+  "none",
+  ...TSHIRT_OPTIONS.map((option) => option.label),
+];
+const BOARD_SORT_OPTION_VALUES: ReadonlyArray<BoardSortOption> = BOARD_SORT_OPTIONS.map(
+  (option) => option.value,
+);
+
 const REQUIRED_CUSTOM_STATUS_CONFIG = "backlog,test,review";
 const PROJECT_BOARD_COMMENT_METADATA_SEPARATOR = "---";
 const PROJECT_BOARD_COMMENT_AGENT_PREFIX = "Agent:";
@@ -384,6 +415,44 @@ export function projectBoardRawProjectIdFromUrlParam(projectId: string): string 
   } catch {
     return projectId;
   }
+}
+
+export function projectBoardViewPreferencesStorageKey(projectId: string): string {
+  return `${PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY_PREFIX}${projectId}`;
+}
+
+export function normalizeProjectBoardViewPreferences(
+  candidate: unknown,
+): ProjectBoardViewPreferences {
+  const stored =
+    typeof candidate === "object" && candidate !== null
+      ? (candidate as Record<string, unknown>)
+      : {};
+  return {
+    estimateFilter: normalizeBoardViewPreference(
+      stored.estimateFilter,
+      BOARD_ESTIMATE_FILTER_VALUES,
+      DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES.estimateFilter,
+    ),
+    priorityFilter: normalizeBoardViewPreference(
+      stored.priorityFilter,
+      BOARD_PRIORITY_FILTER_VALUES,
+      DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES.priorityFilter,
+    ),
+    sortOption: normalizeBoardViewPreference(
+      stored.sortOption,
+      BOARD_SORT_OPTION_VALUES,
+      DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES.sortOption,
+    ),
+  };
+}
+
+function normalizeBoardViewPreference<TValue extends string>(
+  candidate: unknown,
+  allowedValues: ReadonlyArray<TValue>,
+  fallback: TValue,
+): TValue {
+  return allowedValues.includes(candidate as TValue) ? (candidate as TValue) : fallback;
 }
 
 export async function ensureWorkflowStatuses(

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -263,6 +263,33 @@ describe("Project Board form event handling", () => {
     expect(saveSource).not.toContain('await loadTickets({ mode: "mutation" })');
   });
 
+  test("sorts lanes in the board toolbar before the visible ticket limit", () => {
+    /*
+     * CDXC:ProjectBoardSort 2026-08-07:
+     * The Kanban toolbar owns ticket order alongside the existing filters, and lane grouping must
+     * sort before BoardLane slices to PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN so the newest
+     * closed beads stay visible in Done.
+     */
+    const projectBoardSource = sourceBetween("function ProjectBoardApp()", "function TicketMetaFields(");
+    const filtersSource = sourceBetween(
+      '<section className="project-board-filters"',
+      '{activeSurfaceTab === "triage" ? (',
+    );
+    const laneSource = sourceBetween("function BoardLane({", "function TicketCard(");
+
+    expect(projectBoardSource).toContain(
+      'const [sortOption, setSortOption] = useState<BoardSortOption>("default");',
+    );
+    expect(projectBoardSource).toContain("result[column.key] = sortBoardTickets(");
+    expect(projectBoardSource).toContain("sortOption,\n          column.key,");
+    expect(filtersSource).toContain('aria-label="Sort tickets"');
+    expect(filtersSource).toContain("PROJECT_BOARD_SORT_SELECT_ITEMS");
+    expect(filtersSource).toContain("setSortOption(value as BoardSortOption)");
+    expect(laneSource).toContain(
+      "const visibleTickets = tickets.slice(0, PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN);",
+    );
+  });
+
   test("snapshots form values before functional state updaters", () => {
     /*
      * CDXC:ProjectBoardForms 2026-06-09-15:36:

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -290,24 +290,25 @@ describe("Project Board form event handling", () => {
     );
   });
 
-  test("restores and stores the board toolbar selections per project", () => {
+  test("restores and stores the board toolbar selections across projects", () => {
     /*
      * CDXC:ProjectBoardViewPreferences 2026-08-07:
      * Switching away from the Kanban tab unmounts the board surface, so the toolbar must seed its
-     * priority, estimate, and sort state from the project's stored preferences and write every
-     * later selection back under the same project-scoped key. Search stays out of that payload.
+     * priority, estimate, and sort state from the stored preferences and write every later
+     * selection back. The key and the write are project-independent so the selections follow the
+     * user into every board. Search stays out of that payload.
      */
     const projectBoardSource = sourceBetween("function ProjectBoardApp()", "function TicketMetaFields(");
 
     expect(tasksPlaceholderSource).toContain(
-      "function readProjectBoardViewPreferences(projectId: string): ProjectBoardViewPreferences {",
+      "function readProjectBoardViewPreferences(): ProjectBoardViewPreferences {",
     );
     expect(tasksPlaceholderSource).toContain(
-      "window.localStorage.getItem(projectBoardViewPreferencesStorageKey(projectId)) || \"null\",",
+      'JSON.parse(window.localStorage.getItem(PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY) || "null"),',
     );
     expect(tasksPlaceholderSource).toContain("return DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES;");
     expect(projectBoardSource).toContain(
-      "const storedViewPreferences = useMemo(\n    () => readProjectBoardViewPreferences(projectId),\n    [projectId],\n  );",
+      "const storedViewPreferences = useMemo(() => readProjectBoardViewPreferences(), []);",
     );
     expect(projectBoardSource).toContain(
       "useState<BoardPriorityFilter>(\n    storedViewPreferences.priorityFilter,\n  );",
@@ -317,9 +318,9 @@ describe("Project Board form event handling", () => {
     );
     expect(projectBoardSource).toContain("useState<BoardSortOption>(storedViewPreferences.sortOption);");
     expect(projectBoardSource).toContain(
-      "window.localStorage.setItem(\n      projectBoardViewPreferencesStorageKey(projectId),\n      JSON.stringify({ estimateFilter, priorityFilter, sortOption }),\n    );",
+      "window.localStorage.setItem(\n      PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,\n      JSON.stringify({ estimateFilter, priorityFilter, sortOption }),\n    );",
     );
-    expect(projectBoardSource).toContain("}, [estimateFilter, priorityFilter, projectId, sortOption]);");
+    expect(projectBoardSource).toContain("}, [estimateFilter, priorityFilter, sortOption]);");
     expect(projectBoardSource).not.toContain("JSON.stringify({ estimateFilter, priorityFilter, searchQuery");
     expect(projectBoardSource).toContain('const [searchQuery, setSearchQuery] = useState("");');
   });

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -278,7 +278,7 @@ describe("Project Board form event handling", () => {
     const laneSource = sourceBetween("function BoardLane({", "function TicketCard(");
 
     expect(projectBoardSource).toContain(
-      'const [sortOption, setSortOption] = useState<BoardSortOption>("default");',
+      "const [sortOption, setSortOption] = useState<BoardSortOption>(storedViewPreferences.sortOption);",
     );
     expect(projectBoardSource).toContain("result[column.key] = sortBoardTickets(");
     expect(projectBoardSource).toContain("sortOption,\n          column.key,");
@@ -288,6 +288,40 @@ describe("Project Board form event handling", () => {
     expect(laneSource).toContain(
       "const visibleTickets = tickets.slice(0, PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN);",
     );
+  });
+
+  test("restores and stores the board toolbar selections per project", () => {
+    /*
+     * CDXC:ProjectBoardViewPreferences 2026-08-07:
+     * Switching away from the Kanban tab unmounts the board surface, so the toolbar must seed its
+     * priority, estimate, and sort state from the project's stored preferences and write every
+     * later selection back under the same project-scoped key. Search stays out of that payload.
+     */
+    const projectBoardSource = sourceBetween("function ProjectBoardApp()", "function TicketMetaFields(");
+
+    expect(tasksPlaceholderSource).toContain(
+      "function readProjectBoardViewPreferences(projectId: string): ProjectBoardViewPreferences {",
+    );
+    expect(tasksPlaceholderSource).toContain(
+      "window.localStorage.getItem(projectBoardViewPreferencesStorageKey(projectId)) || \"null\",",
+    );
+    expect(tasksPlaceholderSource).toContain("return DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES;");
+    expect(projectBoardSource).toContain(
+      "const storedViewPreferences = useMemo(\n    () => readProjectBoardViewPreferences(projectId),\n    [projectId],\n  );",
+    );
+    expect(projectBoardSource).toContain(
+      "useState<BoardPriorityFilter>(\n    storedViewPreferences.priorityFilter,\n  );",
+    );
+    expect(projectBoardSource).toContain(
+      "useState<BoardEstimateFilter>(\n    storedViewPreferences.estimateFilter,\n  );",
+    );
+    expect(projectBoardSource).toContain("useState<BoardSortOption>(storedViewPreferences.sortOption);");
+    expect(projectBoardSource).toContain(
+      "window.localStorage.setItem(\n      projectBoardViewPreferencesStorageKey(projectId),\n      JSON.stringify({ estimateFilter, priorityFilter, sortOption }),\n    );",
+    );
+    expect(projectBoardSource).toContain("}, [estimateFilter, priorityFilter, projectId, sortOption]);");
+    expect(projectBoardSource).not.toContain("JSON.stringify({ estimateFilter, priorityFilter, searchQuery");
+    expect(projectBoardSource).toContain('const [searchQuery, setSearchQuery] = useState("");');
   });
 
   test("snapshots form values before functional state updaters", () => {

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -74,6 +74,7 @@ import {
 import {
   BOARD_COLUMNS,
   BOARD_SORT_OPTIONS,
+  DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   PRIORITY_OPTIONS,
   TSHIRT_OPTIONS,
   appendImageMarkdownToDescription,
@@ -94,11 +95,13 @@ import {
   normalizeBeadsPayload,
   normalizeDisplayIssueKey,
   normalizeIssuePrefix,
+  normalizeProjectBoardViewPreferences,
   parseProjectBoardCommentText,
   parseBeadsJson,
   priorityLabel,
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
+  projectBoardViewPreferencesStorageKey,
   removeDescriptionImageReference,
   isDescriptionImageSource,
   sortBoardTickets,
@@ -111,6 +114,7 @@ import {
   type BoardPriorityFilter,
   type BoardSortOption,
   type ProjectBoardCommentMetadata,
+  type ProjectBoardViewPreferences,
   type BeadsIssue,
   type BoardStatusKey,
   type BoardTicket,
@@ -259,6 +263,18 @@ function readExperimentalFeaturesEnabled(searchParams: URLSearchParams): boolean
     return false;
   }
   return DEFAULT_ghostex_SETTINGS.showBetaFeatures;
+}
+
+function readProjectBoardViewPreferences(projectId: string): ProjectBoardViewPreferences {
+  try {
+    return normalizeProjectBoardViewPreferences(
+      JSON.parse(
+        window.localStorage.getItem(projectBoardViewPreferencesStorageKey(projectId)) || "null",
+      ),
+    );
+  } catch {
+    return DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES;
+  }
 }
 
 const PROJECT_BOARD_START_LOCATION_SELECT_ITEMS: ReadonlyArray<{
@@ -571,9 +587,17 @@ function ProjectBoardApp() {
   const [errorMessage, setErrorMessage] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const [priorityFilter, setPriorityFilter] = useState<BoardPriorityFilter>("all");
-  const [estimateFilter, setEstimateFilter] = useState<BoardEstimateFilter>("all");
-  const [sortOption, setSortOption] = useState<BoardSortOption>("default");
+  const storedViewPreferences = useMemo(
+    () => readProjectBoardViewPreferences(projectId),
+    [projectId],
+  );
+  const [priorityFilter, setPriorityFilter] = useState<BoardPriorityFilter>(
+    storedViewPreferences.priorityFilter,
+  );
+  const [estimateFilter, setEstimateFilter] = useState<BoardEstimateFilter>(
+    storedViewPreferences.estimateFilter,
+  );
+  const [sortOption, setSortOption] = useState<BoardSortOption>(storedViewPreferences.sortOption);
   const [detail, setDetail] = useState<DetailDraft>(createEmptyDetailDraft);
   const [newTicketOpen, setNewTicketOpen] = useState(false);
   const [newTicket, setNewTicket] = useState<TicketFormDraft>(createEmptyTicketFormDraft);
@@ -819,6 +843,13 @@ function ProjectBoardApp() {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      projectBoardViewPreferencesStorageKey(projectId),
+      JSON.stringify({ estimateFilter, priorityFilter, sortOption }),
+    );
+  }, [estimateFilter, priorityFilter, projectId, sortOption]);
 
   const openNewTicket = useCallback((status: BoardStatusKey = "todo") => {
     setNewTicket((current) => ({ ...current, status }));

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -76,6 +76,7 @@ import {
   BOARD_SORT_OPTIONS,
   DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   PRIORITY_OPTIONS,
+  PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,
   TSHIRT_OPTIONS,
   appendImageMarkdownToDescription,
   beadsErrorMessage,
@@ -101,7 +102,6 @@ import {
   priorityLabel,
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
-  projectBoardViewPreferencesStorageKey,
   removeDescriptionImageReference,
   isDescriptionImageSource,
   sortBoardTickets,
@@ -265,12 +265,10 @@ function readExperimentalFeaturesEnabled(searchParams: URLSearchParams): boolean
   return DEFAULT_ghostex_SETTINGS.showBetaFeatures;
 }
 
-function readProjectBoardViewPreferences(projectId: string): ProjectBoardViewPreferences {
+function readProjectBoardViewPreferences(): ProjectBoardViewPreferences {
   try {
     return normalizeProjectBoardViewPreferences(
-      JSON.parse(
-        window.localStorage.getItem(projectBoardViewPreferencesStorageKey(projectId)) || "null",
-      ),
+      JSON.parse(window.localStorage.getItem(PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY) || "null"),
     );
   } catch {
     return DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES;
@@ -587,10 +585,7 @@ function ProjectBoardApp() {
   const [errorMessage, setErrorMessage] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const storedViewPreferences = useMemo(
-    () => readProjectBoardViewPreferences(projectId),
-    [projectId],
-  );
+  const storedViewPreferences = useMemo(() => readProjectBoardViewPreferences(), []);
   const [priorityFilter, setPriorityFilter] = useState<BoardPriorityFilter>(
     storedViewPreferences.priorityFilter,
   );
@@ -846,10 +841,10 @@ function ProjectBoardApp() {
 
   useEffect(() => {
     window.localStorage.setItem(
-      projectBoardViewPreferencesStorageKey(projectId),
+      PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,
       JSON.stringify({ estimateFilter, priorityFilter, sortOption }),
     );
-  }, [estimateFilter, priorityFilter, projectId, sortOption]);
+  }, [estimateFilter, priorityFilter, sortOption]);
 
   const openNewTicket = useCallback((status: BoardStatusKey = "todo") => {
     setNewTicket((current) => ({ ...current, status }));

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/components/ui/tooltip";
 import {
   BOARD_COLUMNS,
+  BOARD_SORT_OPTIONS,
   PRIORITY_OPTIONS,
   TSHIRT_OPTIONS,
   appendImageMarkdownToDescription,
@@ -100,6 +101,7 @@ import {
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
   isDescriptionImageSource,
+  sortBoardTickets,
   tshirtToEstimate,
   toBoardTickets,
   estimateToTshirt,
@@ -107,6 +109,7 @@ import {
   type BeadsBridgeResponse,
   type BoardEstimateFilter,
   type BoardPriorityFilter,
+  type BoardSortOption,
   type ProjectBoardCommentMetadata,
   type BeadsIssue,
   type BoardStatusKey,
@@ -285,6 +288,8 @@ const PROJECT_BOARD_ESTIMATE_FILTER_SELECT_ITEMS: Array<{ label: string; value: 
   { label: "All estimates", value: "all" },
   ...PROJECT_BOARD_TSHIRT_SELECT_ITEMS,
 ];
+const PROJECT_BOARD_SORT_SELECT_ITEMS: Array<{ label: string; value: BoardSortOption }> =
+  BOARD_SORT_OPTIONS.map((option) => ({ label: option.label, value: option.value }));
 const PROJECT_AUTOMATION_TRIAGE_RECENT_COMPLETED_LIMIT = 5;
 
 type BoardRefreshMode = "background" | "initial" | "manual" | "mutation";
@@ -568,6 +573,7 @@ function ProjectBoardApp() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [priorityFilter, setPriorityFilter] = useState<BoardPriorityFilter>("all");
   const [estimateFilter, setEstimateFilter] = useState<BoardEstimateFilter>("all");
+  const [sortOption, setSortOption] = useState<BoardSortOption>("default");
   const [detail, setDetail] = useState<DetailDraft>(createEmptyDetailDraft);
   const [newTicketOpen, setNewTicketOpen] = useState(false);
   const [newTicket, setNewTicket] = useState<TicketFormDraft>(createEmptyTicketFormDraft);
@@ -1236,12 +1242,16 @@ function ProjectBoardApp() {
   const ticketsByColumn = useMemo(() => {
     return BOARD_COLUMNS.reduce<Record<BoardStatusKey, BoardTicket[]>>(
       (result, column) => {
-        result[column.key] = filteredTickets.filter((ticket) => ticket.boardStatus === column.key);
+        result[column.key] = sortBoardTickets(
+          filteredTickets.filter((ticket) => ticket.boardStatus === column.key),
+          sortOption,
+          column.key,
+        );
         return result;
       },
       { backlog: [], done: [], in_progress: [], review: [], test: [], todo: [] },
     );
-  }, [filteredTickets]);
+  }, [filteredTickets, sortOption]);
   const showInitialBoardLoadingOverlay =
     activeSurfaceTab === "board" && loadState === "loading" && !hasCompletedInitialBoardLoad;
 
@@ -2485,6 +2495,22 @@ function ProjectBoardApp() {
             </SelectTrigger>
             <SelectContent>
               {PROJECT_BOARD_ESTIMATE_FILTER_SELECT_ITEMS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            items={PROJECT_BOARD_SORT_SELECT_ITEMS}
+            onValueChange={(value) => setSortOption(value as BoardSortOption)}
+            value={sortOption}
+          >
+            <SelectTrigger aria-label="Sort tickets" className="project-board-filter-select" size="sm">
+              <SelectValue placeholder="Default order" />
+            </SelectTrigger>
+            <SelectContent>
+              {PROJECT_BOARD_SORT_SELECT_ITEMS.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}
                 </SelectItem>


### PR DESCRIPTION
From the Discord thread (BANOZZ): with 223 closed beads, the Done column was unusable — and it turned out to be worse than a sorting gap.

## The bug

Columns render beads in whatever order `bd list --all --json` returns, and each lane slices to the first 120 (`PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN`). With no ordering, "Showing 120 of 223" meant *an arbitrary* 120 — recently finished work was often invisible entirely.

## What changes

- **`sortBoardTickets`** — a pure comparator helper applied inside the `ticketsByColumn` memo, i.e. **before** the lane cap slices, so the cap keeps the newest.
- **Done defaults to newest-closed-first** (fallback chain `closed_at → updated_at → created_at`; older beads predate bd recording `closed_at`). Other lanes keep their Beads order until a sort is chosen.
- **Toolbar sort Select** next to the existing priority/estimate filters, 7 options: Default order, Last updated / Created / Priority — each in both directions. Beads with unparseable timestamps sink to the bottom in *both* directions (unknown ≠ oldest).
- **View preferences persist app-wide**: priority filter, estimate filter, and sort survive leaving the board (the kanban is its own CEF surface, so tab switches tore state down). One `localStorage` key — the selections describe how the user reads a board, not project data. Stored values are validated against the live option lists and fall back to defaults; search stays ephemeral so a forgotten query can't hide the board.

## Verification

- `bun run typecheck` → exit 0; `bunx vitest run native/sidebar/ shared/` → all pass (same pre-existing bun:test suite failure only)
- Comparator unit tests cover both directions per key, the legacy-P4 tier, undated beads, and cap-keeps-newest; persistence tests were mutation-checked (six mutations, all caught, file restored byte-identical).

## To test

Open a board with many closed beads → Done shows newest first. Pick "Created (oldest first)" → every lane reorders. Set filters + sort, switch to another tab and back → selections restored, in any project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added project board sorting by priority, creation date, update date, and completion date, with ascending and descending options.
  - Added a persistent sort selector to the board toolbar.
  - Board view preferences now persist across project switches and restore safely with defaults when invalid.
  - Sorting occurs before lane limits are applied, improving which tickets appear in each column.
- **Tests**
  - Added comprehensive coverage for sorting behavior and preference persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->