### PR TITLE
fix(kanban): make board and dialog scrollbars mouse-grabbable

### DIFF
--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -70,7 +70,7 @@ describe("Project Board form event handling", () => {
      * pointer-events: none overlay is not a scrollbar and must not come back.
      */
     const boardScrollbarSource = sourceBetween(
-      ".project-board-lanes,\n  .project-board-lane-scroll {",
+      ".project-board-lanes,\n  .project-board-lane-scroll,\n  .project-ticket-dialog-body {",
       ".project-board-toolbar {",
     );
 
@@ -79,6 +79,39 @@ describe("Project Board form event handling", () => {
     expect(boardScrollbarSource).toContain("height: 8px;");
     expect(boardScrollbarSource).toContain("width: 8px;");
     expect(tasksPlaceholderSource).not.toContain("project-board-lane-scrollbar");
+  });
+
+  test("keeps the ticket dialog body scrollbar grabbable with the mouse", () => {
+    /*
+     * CDXC:DialogScrollbar 2026-08-07:
+     * The ticket dialog body shared the comment list's hidden-scrollbar rules,
+     * so Chromium measured a 0px scroll gutter on it and neither a track click
+     * nor a thumb drag anywhere along its right edge moved it — wheel-only. It
+     * must stay on the board's real-scrollbar rules. The comment list must stay
+     * hidden here because its Radix ScrollArea paints its own grabbable bar, and
+     * the dialog thumb's hover reveal must set background-color rather than the
+     * background shorthand, which would reset the content-box clip that keeps
+     * the painted rail at 2px.
+     */
+    const hiddenScrollbarSource = sourceBetween(
+      '.project-ticket-comment-list [data-slot="scroll-area-viewport"] {',
+      ".project-board-lanes,",
+    );
+    const dialogScrollbarSource = sourceBetween(
+      ".project-board-lanes,\n  .project-board-lane-scroll,\n  .project-ticket-dialog-body {",
+      ".project-board-toolbar {",
+    );
+    const dialogThumbHoverSource = sourceBetween(
+      ".project-ticket-dialog-body:focus-within::-webkit-scrollbar-thumb {",
+      '.project-ticket-comment-list [data-slot="scroll-area-scrollbar"] {',
+    );
+
+    expect(hiddenScrollbarSource).not.toContain("project-ticket-dialog-body");
+    expect(hiddenScrollbarSource).toContain("scrollbar-width: none;");
+    expect(hiddenScrollbarSource).toContain("width: 2px;");
+    expect(dialogScrollbarSource).toContain(".project-ticket-dialog-body::-webkit-scrollbar {");
+    expect(dialogScrollbarSource).toContain(".project-ticket-dialog-body::-webkit-scrollbar-thumb {");
+    expect(dialogThumbHoverSource).toContain("background-color: var(--project-board-scrollbar);");
   });
 
   test("shows the first-open Kanban loading overlay until initial load finishes", () => {

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -60,6 +60,27 @@ describe("Project Board form event handling", () => {
     expect(laneLayoutSource).toContain("border-left-width: 0;");
   });
 
+  test("keeps the Kanban board scrollbars grabbable with the mouse", () => {
+    /*
+     * CDXC:BoardScrollbars 2026-08-07:
+     * The board strip and the lane bodies must keep a real scrollbar box, or the
+     * board is wheel-only: Chromium measured a 0px scroll gutter (nothing to
+     * click or drag) whenever the scroller carried scrollbar-width: none, a
+     * scrollbar-color, or a zero-sized ::-webkit-scrollbar. A decorative
+     * pointer-events: none overlay is not a scrollbar and must not come back.
+     */
+    const boardScrollbarSource = sourceBetween(
+      ".project-board-lanes,\n  .project-board-lane-scroll {",
+      ".project-board-toolbar {",
+    );
+
+    expect(boardScrollbarSource).toContain("scrollbar-width: auto;");
+    expect(boardScrollbarSource).not.toContain("scrollbar-color");
+    expect(boardScrollbarSource).toContain("height: 8px;");
+    expect(boardScrollbarSource).toContain("width: 8px;");
+    expect(tasksPlaceholderSource).not.toContain("project-board-lane-scrollbar");
+  });
+
   test("shows the first-open Kanban loading overlay until initial load finishes", () => {
     /*
      * CDXC:ProjectBoardLoading 2026-06-20-18:21:

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -5907,20 +5907,16 @@ styleElement.textContent = `
     outline: none;
   }
 
-  .project-ticket-dialog-body,
   .project-ticket-comment-list [data-slot="scroll-area-viewport"] {
     scrollbar-color: transparent transparent;
     scrollbar-width: none;
   }
 
-  .project-ticket-dialog-body:hover,
-  .project-ticket-dialog-body:focus-within,
   .project-ticket-comment-list:hover [data-slot="scroll-area-viewport"],
   .project-ticket-comment-list:focus-within [data-slot="scroll-area-viewport"] {
     scrollbar-color: var(--project-board-scrollbar) transparent;
   }
 
-  .project-ticket-dialog-body::-webkit-scrollbar,
   .project-ticket-comment-list [data-slot="scroll-area-viewport"]::-webkit-scrollbar {
     height: 2px;
     width: 2px;
@@ -5936,14 +5932,24 @@ styleElement.textContent = `
    * scrollers stay out of the hidden-scrollbar rules above. The 8px box is the
    * mouse target and the thumb's transparent borders keep the painted rail at
    * the board's 2px width.
+   *
+   * CDXC:DialogScrollbar 2026-08-07:
+   * The ticket dialog body sat in the hidden-scrollbar rules above, and
+   * measuring it in Chromium showed the same wheel-only failure the board had:
+   * a 0px gutter, and no scroll from a track click or a thumb drag at any x
+   * offset along its right edge. It joins the real-scrollbar rules here. The
+   * comment list stays hidden above because its Radix ScrollArea paints its own
+   * interactable bar.
    */
   .project-board-lanes,
-  .project-board-lane-scroll {
+  .project-board-lane-scroll,
+  .project-ticket-dialog-body {
     scrollbar-width: auto;
   }
 
   .project-board-lanes::-webkit-scrollbar,
-  .project-board-lane-scroll::-webkit-scrollbar {
+  .project-board-lane-scroll::-webkit-scrollbar,
+  .project-ticket-dialog-body::-webkit-scrollbar {
     background: transparent;
     display: block;
     height: 8px;
@@ -5964,8 +5970,6 @@ styleElement.textContent = `
     background: transparent;
   }
 
-  .project-ticket-dialog-body:hover::-webkit-scrollbar-thumb,
-  .project-ticket-dialog-body:focus-within::-webkit-scrollbar-thumb,
   .project-ticket-comment-list:hover [data-slot="scroll-area-viewport"]::-webkit-scrollbar-thumb,
   .project-ticket-comment-list:focus-within [data-slot="scroll-area-viewport"]::-webkit-scrollbar-thumb {
     background: var(--project-board-scrollbar);
@@ -5977,7 +5981,8 @@ styleElement.textContent = `
     border-top: 3px solid transparent;
   }
 
-  .project-board-lane-scroll::-webkit-scrollbar-thumb {
+  .project-board-lane-scroll::-webkit-scrollbar-thumb,
+  .project-ticket-dialog-body::-webkit-scrollbar-thumb {
     background-clip: content-box;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
@@ -5986,7 +5991,9 @@ styleElement.textContent = `
   .project-board-lanes:hover::-webkit-scrollbar-thumb,
   .project-board-lanes:focus-within::-webkit-scrollbar-thumb,
   .project-board-lane:hover .project-board-lane-scroll::-webkit-scrollbar-thumb,
-  .project-board-lane:focus-within .project-board-lane-scroll::-webkit-scrollbar-thumb {
+  .project-board-lane:focus-within .project-board-lane-scroll::-webkit-scrollbar-thumb,
+  .project-ticket-dialog-body:hover::-webkit-scrollbar-thumb,
+  .project-ticket-dialog-body:focus-within::-webkit-scrollbar-thumb {
     background-color: var(--project-board-scrollbar);
   }
 

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -2663,6 +2663,11 @@ function ProjectBoardApp() {
                 scrollers. Apply the shared Codex-style masks to the scroll
                 containers themselves so lane headers and custom scrollbars stay
                 crisp while overflowing cards fade at the edges.
+
+                CDXC:BoardScrollbars 2026-08-07:
+                Both bars are now the browser's own scrollbars on those same
+                masked scrollers, so their ends fade with the content instead of
+                staying crisp.
               */}
               <section className="project-board-lanes horizontal-scroll-fade-mask" aria-label="Project issue board">
                 {BOARD_COLUMNS.map((column) => (
@@ -4050,62 +4055,6 @@ function BoardLane({
   });
   const visibleTickets = tickets.slice(0, PROJECT_BOARD_MAX_VISIBLE_TICKETS_PER_COLUMN);
   const hiddenTicketCount = tickets.length - visibleTickets.length;
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [scrollThumb, setScrollThumb] = useState({ height: 0, top: 0, visible: false });
-  const updateScrollThumb = useCallback(() => {
-    const element = scrollRef.current;
-    if (!element) {
-      return;
-    }
-    const maxScrollTop = element.scrollHeight - element.clientHeight;
-    if (maxScrollTop <= 1) {
-      setScrollThumb((current) =>
-        current.visible || current.height !== 0 || current.top !== 0
-          ? { height: 0, top: 0, visible: false }
-          : current,
-      );
-      return;
-    }
-    const height = Math.max(24, (element.clientHeight / element.scrollHeight) * element.clientHeight);
-    const top = (element.scrollTop / maxScrollTop) * (element.clientHeight - height);
-    setScrollThumb((current) => {
-      const next = {
-        height: Math.round(height),
-        top: Math.round(top),
-        visible: true,
-      };
-      return current.height === next.height && current.top === next.top && current.visible === next.visible
-        ? current
-        : next;
-    });
-  }, []);
-
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (!element) {
-      return;
-    }
-    updateScrollThumb();
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? undefined
-        : new ResizeObserver(() => updateScrollThumb());
-    if (resizeObserver) {
-      resizeObserver.observe(element);
-      if (element.firstElementChild) {
-        resizeObserver.observe(element.firstElementChild);
-      }
-    } else {
-      window.addEventListener("resize", updateScrollThumb);
-    }
-    return () => {
-      resizeObserver?.disconnect();
-      if (!resizeObserver) {
-        window.removeEventListener("resize", updateScrollThumb);
-      }
-    };
-  }, [hiddenTicketCount, updateScrollThumb, visibleTickets.length]);
-
   return (
     <section
       className="project-board-lane"
@@ -4132,11 +4081,7 @@ function BoardLane({
           </Button>
         </div>
       </header>
-      <div
-        className="project-board-lane-scroll vertical-scroll-fade-mask"
-        onScroll={updateScrollThumb}
-        ref={scrollRef}
-      >
+      <div className="project-board-lane-scroll vertical-scroll-fade-mask">
         <div className="project-board-card-stack">
           {visibleTickets.map((ticket) => (
             <TicketCard
@@ -4155,19 +4100,6 @@ function BoardLane({
             </div>
           ) : null}
         </div>
-      </div>
-      <div
-        aria-hidden="true"
-        className="project-board-lane-scrollbar"
-        data-visible={String(scrollThumb.visible)}
-      >
-        <div
-          className="project-board-lane-scrollbar-thumb"
-          style={{
-            height: `${scrollThumb.height}px`,
-            transform: `translateY(${scrollThumb.top}px)`,
-          }}
-        />
       </div>
     </section>
   );
@@ -5975,8 +5907,6 @@ styleElement.textContent = `
     outline: none;
   }
 
-  .project-board-lanes,
-  .project-board-lane-scroll,
   .project-ticket-dialog-body,
   .project-ticket-comment-list [data-slot="scroll-area-viewport"] {
     scrollbar-color: transparent transparent;
@@ -5990,18 +5920,34 @@ styleElement.textContent = `
     scrollbar-color: var(--project-board-scrollbar) transparent;
   }
 
-  .project-board-lanes::-webkit-scrollbar,
-  .project-board-lane-scroll::-webkit-scrollbar,
-  .project-ticket-dialog-body::-webkit-scrollbar,
-  .project-ticket-comment-list [data-slot="scroll-area-viewport"]::-webkit-scrollbar {
-    height: 0;
-    width: 0;
-  }
-
   .project-ticket-dialog-body::-webkit-scrollbar,
   .project-ticket-comment-list [data-slot="scroll-area-viewport"]::-webkit-scrollbar {
     height: 2px;
     width: 2px;
+  }
+
+  /*
+   * CDXC:BoardScrollbars 2026-08-07:
+   * The board strip and every lane body keep the browser's own scrollbar so the
+   * bar stays clickable and draggable instead of wheel-only. Chromium paints
+   * ::-webkit-scrollbar geometry only while the scroller keeps scrollbar-width
+   * at auto and leaves scrollbar-color unset; either one hands rendering to the
+   * standard scrollbar and collapses the gutter to 0px, which is why these two
+   * scrollers stay out of the hidden-scrollbar rules above. The 8px box is the
+   * mouse target and the thumb's transparent borders keep the painted rail at
+   * the board's 2px width.
+   */
+  .project-board-lanes,
+  .project-board-lane-scroll {
+    scrollbar-width: auto;
+  }
+
+  .project-board-lanes::-webkit-scrollbar,
+  .project-board-lane-scroll::-webkit-scrollbar {
+    background: transparent;
+    display: block;
+    height: 8px;
+    width: 8px;
   }
 
   .project-board-lanes::-webkit-scrollbar-track,
@@ -6023,6 +5969,25 @@ styleElement.textContent = `
   .project-ticket-comment-list:hover [data-slot="scroll-area-viewport"]::-webkit-scrollbar-thumb,
   .project-ticket-comment-list:focus-within [data-slot="scroll-area-viewport"]::-webkit-scrollbar-thumb {
     background: var(--project-board-scrollbar);
+  }
+
+  .project-board-lanes::-webkit-scrollbar-thumb {
+    background-clip: content-box;
+    border-bottom: 3px solid transparent;
+    border-top: 3px solid transparent;
+  }
+
+  .project-board-lane-scroll::-webkit-scrollbar-thumb {
+    background-clip: content-box;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+  }
+
+  .project-board-lanes:hover::-webkit-scrollbar-thumb,
+  .project-board-lanes:focus-within::-webkit-scrollbar-thumb,
+  .project-board-lane:hover .project-board-lane-scroll::-webkit-scrollbar-thumb,
+  .project-board-lane:focus-within .project-board-lane-scroll::-webkit-scrollbar-thumb {
+    background-color: var(--project-board-scrollbar);
   }
 
   .project-ticket-comment-list [data-slot="scroll-area-scrollbar"] {
@@ -6941,6 +6906,11 @@ styleElement.textContent = `
      * sidebar scroll surface. The board strip owns the horizontal fade while
      * each lane body owns its vertical fade, leaving lane headers and custom
      * scrollbars unmasked.
+     *
+     * CDXC:BoardScrollbars 2026-08-07:
+     * The lane bar is the scroller's own scrollbar now, so it lives inside the
+     * mask and fades at the very ends of its travel like the ticket dialog's
+     * scrollbar already does.
      */
     --edge-fade-distance: 18px;
     gap: 0;
@@ -7059,28 +7029,6 @@ styleElement.textContent = `
     overflow-x: hidden;
     overflow-y: auto;
     padding-right: 0;
-  }
-
-  .project-board-lane-scrollbar {
-    bottom: 0;
-    opacity: 0;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 44px;
-    transition: opacity 120ms ease;
-    width: 2px;
-    z-index: 4;
-  }
-
-  .project-board-lane:hover .project-board-lane-scrollbar[data-visible="true"],
-  .project-board-lane:focus-within .project-board-lane-scrollbar[data-visible="true"] {
-    opacity: 1;
-  }
-
-  .project-board-lane-scrollbar-thumb {
-    background: var(--project-board-scrollbar);
-    width: 2px;
   }
 
   .project-board-card-stack {


### PR DESCRIPTION
From the Discord thread (BANOZZ): the Kanban scroll bars couldn't be clicked or dragged. Measured cause: there were no scrollbars at all.

## The bug (measured, not guessed)

Both board scrollers (`.project-board-lanes`, `.project-board-lane-scroll`) carried `scrollbar-width: none` + `scrollbar-color` + zero-sized `::-webkit-scrollbar`. In Chromium that generates **no scrollbar box whatsoever** — headless Chrome driven over CDP with real `Input.dispatchMouseEvent` measured a **0px scroll gutter** and zero scroll from track clicks or thumb drags at every offset along the edge (positive controls in the same harness proved the method detects working bars). The visible 2px lane rail was a decorative `pointer-events: none` div fed by a ResizeObserver — cosmetic by construction. The ticket dialog body shared the same rules and measured identically dead.

## What changes

- Board strip, lane bodies, and the ticket dialog body get **real 8px browser scrollbars**, styled down to the existing 2px hover-reveal rail via `background-clip: content-box` + transparent borders. The 8px box is the mouse target; visuals are unchanged at rest.
- The decorative overlay, its thumb state, ResizeObserver effect, and onScroll wiring are deleted (**net −31 lines** on the board fix).
- The comment list is untouched on purpose — its Radix ScrollArea paints its own working bar.
- One subtlety locked in by a test: the hover reveal sets `background-color`, not the `background` shorthand, which would reset the clip and fatten the rail to 8px.

After: same harness measures 8px gutters, track click pages the view, thumb drag scrolls — on all three scrollers.

## Verification

- `bun run typecheck` → exit 0; `bunx vitest run native/sidebar/` → all pass (pre-existing bun:test suite failure only)
- Regression source-tests are mutation-checked (flipping `scrollbar-width` back to `none` fails them).

## To test

Grab the horizontal board bar, a lane's vertical bar, and the bar on a ticket dialog's body — click the track, drag the thumb. Wheel/trackpad unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored standard browser scrollbars for board lanes and ticket dialogs.
  - Improved scrollbar usability by ensuring scrollbars remain visible and mouse-grabbable.
  - Added clearer hover and focus states for scrollbar controls.
  - Preserved existing comment-list scrollbar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->