### PR TITLE
fix(project-board): heal bead conversation links, add Resume, share links across board mounts

### DIFF
--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -1,5 +1,6 @@
 import {
   GXSERVER_PROTOCOL_VERSION,
+  type GxserverAgentResumePlan,
   type GxserverAppUserData,
   type GxserverCheckoutProjectNewBranchResult,
   type GxserverCreatePullRequestResult,
@@ -123,8 +124,11 @@ import { getCompletionSoundLabel } from "../../shared/completion-sound";
 import type { CompletionSoundSetting } from "../../shared/completion-sound";
 import { createAppToastRequest, type AppToastLevel } from "../../shared/app-toast-contract";
 import {
+  canonicalizeBeadConversationLinksForBoard,
   createBeadConversationLinkId,
   normalizeBeadConversationLinks,
+  resolveBeadConversationLinkBoardSessionId,
+  selectBeadConversationLinkStoreProjects,
   type BeadConversationLink,
   type ProjectBoardAgentOption,
   type ProjectBoardConversationLinkView,
@@ -613,6 +617,14 @@ const GPUI_AGENT_PROMPT_READY_DELAY_MS = 4_000;
 const GPUI_AGENT_PROMPT_STEP_DELAY_MS = 1_000;
 const GPUI_PROJECT_BOARD_RESTORABLE_LINK_CHECK_TTL_MS = 60_000;
 const GPUI_PROJECT_BOARD_RESTORABLE_LINK_CHECK_CACHE_MAX = 512;
+/*
+CDXC:ProjectBoardBeads 2026-08-07:
+Resuming a bead's closed conversation runs through the daemon's fork plan,
+which only knows how to continue Codex, Claude, and Pi conversations. gxserver
+stays the authority and rejects anything else, so this set exists to keep the
+board from offering a Resume the daemon would refuse.
+*/
+const GPUI_PROJECT_BOARD_RESUMABLE_AGENT_IDS = new Set(["claude", "codex", "pi"]);
 const GPUI_SIDEBAR_T3_BROWSER_ACCESS_REQUEST_MESSAGE_VERSION = 1;
 const GPUI_SIDEBAR_T3_BROWSER_ACCESS_REQUEST_MESSAGE_TYPE =
   "ghostex.gpui.sidebar.t3SessionBrowserAccessRequest";
@@ -1096,7 +1108,7 @@ class GpuiSidebarRuntime {
   private previousSessionsByHistoryId = new Map<string, SidebarPreviousSessionItem>();
   private projectBoardRestorableLinkChecks = new Map<
     string,
-    { checkedAt: number; restorable: boolean; title?: string }
+    { checkedAt: number; restorable: boolean; resumable: boolean; title?: string }
   >();
   private quickAutomationsOverviewOpen = false;
   private previousSessionsResult:
@@ -2147,17 +2159,43 @@ class GpuiSidebarRuntime {
     projectId?: string;
     projectPath?: string;
   }): Promise<GxserverProjectDomainState> {
+    return (await this.resolveGpuiProjectBoardDomainScope(request)).boardProject;
+  }
+
+  private async resolveGpuiProjectBoardDomainScope(request: {
+    projectId?: string;
+    projectPath?: string;
+  }): Promise<{
+    boardProject: GxserverProjectDomainState;
+    linkStoreProjects: GxserverProjectDomainState[];
+  }> {
+    const projects = await this.listGpuiProjectBoardDomainProjects();
+    const boardProject = this.selectGpuiProjectBoardDomainProject(request, projects);
+    return {
+      boardProject,
+      linkStoreProjects: selectBeadConversationLinkStoreProjects(boardProject, projects),
+    };
+  }
+
+  private async listGpuiProjectBoardDomainProjects(): Promise<GxserverProjectDomainState[]> {
     if (!this.client) {
       throw new Error("gxserver is unavailable.");
     }
-    // macOS `resolveProjectBoardProject` order: project id, then path, then
-    // the active project. Read fresh domain projects so link mutations from
-    // other clients are visible to every board response.
+    // Read fresh domain projects so link mutations from other clients are
+    // visible to every board response.
     const response = await this.client.rpc<{ projects?: GxserverProjectDomainState[] }>(
       "/api/listProjects",
       {},
     );
-    const projects = Array.isArray(response.projects) ? response.projects : [];
+    return Array.isArray(response.projects) ? response.projects : [];
+  }
+
+  private selectGpuiProjectBoardDomainProject(
+    request: { projectId?: string; projectPath?: string },
+    projects: readonly GxserverProjectDomainState[],
+  ): GxserverProjectDomainState {
+    // macOS `resolveProjectBoardProject` order: project id, then path, then
+    // the active project.
     const projectId = request.projectId?.trim();
     const byId = projectId
       ? projects.find((candidate) => candidate.projectId === projectId)
@@ -2183,27 +2221,34 @@ class GpuiSidebarRuntime {
     projectId?: string;
     projectPath?: string;
   }): Promise<ProjectBoardConversationState> {
-    const boardProject = await this.resolveGpuiProjectBoardDomainProject(request);
-    const sessionOptions = this.createGpuiProjectBoardSessionOptions(boardProject);
+    const { boardProject, linkStoreProjects } =
+      await this.resolveGpuiProjectBoardDomainScope(request);
+    const sessionOptions = this.createGpuiProjectBoardSessionOptions(
+      boardProject,
+      linkStoreProjects,
+    );
     const sessionById = new Map(sessionOptions.map((session) => [session.sessionId, session]));
-    const activeLinks = normalizeBeadConversationLinks(
-      boardProject.projectBoardConfig?.beadConversationLinks,
+    const activeLinks = canonicalizeBeadConversationLinksForBoard(
+      this.readGpuiProjectBoardConversationLinks(linkStoreProjects).filter(
+        (link) => link.status !== "archived",
+      ),
       boardProject.projectId,
-    ).filter((link) => link.status !== "archived");
+    );
     const linkViews: ProjectBoardConversationLinkView[] = [];
     for (const link of activeLinks) {
       const session = sessionById.get(link.ghostexSessionId);
-      const restorable = session
+      const availability = session
         ? undefined
-        : await this.checkGpuiProjectBoardLinkRestorable(boardProject, link.ghostexSessionId);
+        : await this.checkGpuiProjectBoardLinkAvailability(boardProject, link.ghostexSessionId);
       linkViews.push({
         ...link,
         agentId: link.agentId ?? session?.agentId,
         isFocused: session?.isFocused,
         isLive: Boolean(session),
-        isRestorable: restorable?.restorable === true,
+        isRestorable: availability?.restorable === true,
+        isResumable: availability?.resumable === true,
         isSleeping: session?.isSleeping,
-        sessionTitle: session?.label ?? restorable?.title,
+        sessionTitle: session?.label ?? availability?.title,
       });
     }
     return {
@@ -2221,6 +2266,17 @@ class GpuiSidebarRuntime {
       projectId: boardProject.projectId,
       sessions: sessionOptions,
     };
+  }
+
+  private readGpuiProjectBoardConversationLinks(
+    linkStoreProjects: readonly GxserverProjectDomainState[],
+  ): BeadConversationLink[] {
+    return linkStoreProjects.flatMap((project) =>
+      normalizeBeadConversationLinks(
+        project.projectBoardConfig?.beadConversationLinks,
+        project.projectId,
+      ),
+    );
   }
 
   private createGpuiProjectBoardAgentOptions(): ProjectBoardAgentOption[] {
@@ -2243,6 +2299,7 @@ class GpuiSidebarRuntime {
 
   private createGpuiProjectBoardSessionOptions(
     boardProject: GxserverProjectDomainState,
+    linkStoreProjects: readonly GxserverProjectDomainState[] = [],
   ): ProjectBoardSessionOption[] {
     const presentation = this.presentation;
     if (!presentation) {
@@ -2252,10 +2309,18 @@ class GpuiSidebarRuntime {
     macOS `createProjectBoardConversationProjects` parity: a bead can be worked
     from a sibling worktree while its ticket stays on the parent board, so the
     option list spans the worktree family.
+
+    CDXC:ProjectBoardBeads 2026-08-07:
+    Rows that mount the same Beads board are part of the same board too. Their
+    sessions belong in the list, or a link inherited from one of them reads as
+    dead while its session is still running.
     */
     const familyParentId =
       normalizeGpuiWorktreeParentProjectId(boardProject.worktree) ?? boardProject.projectId;
-    const relatedProjectIds = new Set<string>([boardProject.projectId]);
+    const relatedProjectIds = new Set<string>([
+      boardProject.projectId,
+      ...linkStoreProjects.map((project) => project.projectId),
+    ]);
     for (const candidate of this.domainProjects) {
       if (
         candidate.projectId === familyParentId ||
@@ -2294,15 +2359,21 @@ class GpuiSidebarRuntime {
     });
   }
 
-  private async checkGpuiProjectBoardLinkRestorable(
+  private async checkGpuiProjectBoardLinkAvailability(
     boardProject: GxserverProjectDomainState,
     ghostexSessionId: string,
-  ): Promise<{ restorable: boolean; title?: string }> {
+  ): Promise<{ restorable: boolean; resumable: boolean; title?: string }> {
     /*
     macOS resolves link restorability from its previous-sessions cache with a
     gxserver fallback; GPUI keeps no such cache, so non-live links check the
     daemon directly behind a short TTL because getState re-runs on the board's
     8s auto-refresh.
+
+    CDXC:ProjectBoardBeads 2026-08-07:
+    Previous-session history only carries rows that closed with a trusted
+    resume title, so a bead worked by a since-closed agent session usually has
+    no restorable row at all. The daemon can still plan a resume from the
+    session row's own agent identity, so ask it before calling the link dead.
     */
     const reference = parseGxserverPresentationProjectSessionId(ghostexSessionId) ?? {
       projectId: boardProject.projectId,
@@ -2314,9 +2385,10 @@ class GpuiSidebarRuntime {
     if (cached && now - cached.checkedAt < GPUI_PROJECT_BOARD_RESTORABLE_LINK_CHECK_TTL_MS) {
       return cached;
     }
-    let result: { checkedAt: number; restorable: boolean; title?: string } = {
+    let result: { checkedAt: number; restorable: boolean; resumable: boolean; title?: string } = {
       checkedAt: now,
       restorable: false,
+      resumable: false,
     };
     if (this.client) {
       try {
@@ -2324,6 +2396,7 @@ class GpuiSidebarRuntime {
         result = {
           checkedAt: now,
           restorable: Boolean(row),
+          resumable: row ? false : await this.checkGpuiProjectBoardLinkResumable(reference),
           title: row ? (row.displayTitle ?? row.primaryTitle ?? row.title) : undefined,
         };
       } catch {
@@ -2339,6 +2412,34 @@ class GpuiSidebarRuntime {
     }
     this.projectBoardRestorableLinkChecks.set(cacheKey, result);
     return result;
+  }
+
+  private async checkGpuiProjectBoardLinkResumable(reference: {
+    projectId: string;
+    sessionId: string;
+  }): Promise<boolean> {
+    // `/api/readAgentResumePlan` is the daemon's own answer to "can this
+    // conversation come back": it plans from the stored agent session id,
+    // session path, or trusted title, and returns no primary command when
+    // there is nothing to resume. Command construction stays in gxserver.
+    if (!this.client) {
+      return false;
+    }
+    try {
+      const response = await this.client.rpc<{ plan?: GxserverAgentResumePlan }>(
+        "/api/readAgentResumePlan",
+        { projectId: reference.projectId, sessionId: reference.sessionId },
+      );
+      return (
+        Boolean(normalizeNonEmptyString(response.plan?.primaryCommand)) &&
+        GPUI_PROJECT_BOARD_RESUMABLE_AGENT_IDS.has(
+          normalizeNonEmptyString(response.plan?.agentId) ?? "",
+        )
+      );
+    } catch {
+      // A removed session row answers with an error; that is a dead link.
+      return false;
+    }
   }
 
   private async findGpuiProjectBoardPreviousSessionRow(reference: {
@@ -2366,9 +2467,10 @@ class GpuiSidebarRuntime {
     );
   }
 
-  private async reloadGpuiProjectBoardDomainProject(
-    boardProject: GxserverProjectDomainState,
-  ): Promise<GxserverProjectDomainState> {
+  private async reloadGpuiProjectBoardDomainScope(boardProject: GxserverProjectDomainState): Promise<{
+    boardProject: GxserverProjectDomainState;
+    linkStoreProjects: GxserverProjectDomainState[];
+  }> {
     /*
     CDXC:ProjectBoardBeads 2026-08-07:
     Starting work can take minutes before the link is written (the worktree
@@ -2378,20 +2480,17 @@ class GpuiSidebarRuntime {
     snapshot taken before the session existed — otherwise a link that landed
     during the gap is dropped and its card reads as never worked.
     */
-    if (!this.client) {
-      return boardProject;
-    }
     try {
-      const response = await this.client.rpc<{ projects?: GxserverProjectDomainState[] }>(
-        "/api/listProjects",
-        {},
-      );
-      const projects = Array.isArray(response.projects) ? response.projects : [];
-      return (
-        projects.find((candidate) => candidate.projectId === boardProject.projectId) ?? boardProject
-      );
+      const projects = await this.listGpuiProjectBoardDomainProjects();
+      const latestBoardProject =
+        projects.find((candidate) => candidate.projectId === boardProject.projectId) ??
+        boardProject;
+      return {
+        boardProject: latestBoardProject,
+        linkStoreProjects: selectBeadConversationLinkStoreProjects(latestBoardProject, projects),
+      };
     } catch {
-      return boardProject;
+      return { boardProject, linkStoreProjects: [boardProject] };
     }
   }
 
@@ -2426,8 +2525,31 @@ class GpuiSidebarRuntime {
         session.projectId === args.session.projectId &&
         session.sessionId === args.session.sessionId,
     );
+    const { boardProject: latestBoardProject, linkStoreProjects } =
+      await this.reloadGpuiProjectBoardDomainScope(boardProject);
+    // A shared board is read across every row that mounts it, so update the row
+    // that already holds this conversation instead of adding a second copy.
+    const boardSessionId =
+      args.session.projectId === latestBoardProject.projectId
+        ? args.session.sessionId
+        : createGxserverPresentationProjectSessionId(
+            args.session.projectId,
+            args.session.sessionId,
+          );
+    const linkProject =
+      linkStoreProjects.find((storeProject) =>
+        normalizeBeadConversationLinks(
+          storeProject.projectBoardConfig?.beadConversationLinks,
+          storeProject.projectId,
+        ).some(
+          (link) =>
+            link.beadId === args.beadId &&
+            resolveBeadConversationLinkBoardSessionId(link, latestBoardProject.projectId) ===
+              boardSessionId,
+        ),
+      ) ?? latestBoardProject;
     const ghostexSessionId =
-      args.session.projectId === boardProject.projectId
+      args.session.projectId === linkProject.projectId
         ? args.session.sessionId
         : createGxserverPresentationProjectSessionId(
             args.session.projectId,
@@ -2442,24 +2564,23 @@ class GpuiSidebarRuntime {
       beadId: args.beadId,
       createdAt: now,
       ghostexSessionId,
-      id: createBeadConversationLinkId(boardProject.projectId, args.beadId, ghostexSessionId),
-      projectId: boardProject.projectId,
+      id: createBeadConversationLinkId(linkProject.projectId, args.beadId, ghostexSessionId),
+      projectId: linkProject.projectId,
       sessionPersistenceName: args.session.zmxName ?? presentationSession?.zmxName,
       sessionPersistenceProvider: "zmx",
       status: "active",
       updatedAt: now,
     };
-    const latestBoardProject = await this.reloadGpuiProjectBoardDomainProject(boardProject);
     const currentLinks = normalizeBeadConversationLinks(
-      latestBoardProject.projectBoardConfig?.beadConversationLinks,
-      latestBoardProject.projectId,
+      linkProject.projectBoardConfig?.beadConversationLinks,
+      linkProject.projectId,
     );
     const nextLinks = currentLinks.some((link) => link.id === nextLink.id)
       ? currentLinks.map((link) =>
           link.id === nextLink.id ? { ...link, ...nextLink, createdAt: link.createdAt } : link,
         )
       : [...currentLinks, nextLink];
-    await this.writeGpuiProjectBoardConversationLinks(latestBoardProject, nextLinks);
+    await this.writeGpuiProjectBoardConversationLinks(linkProject, nextLinks);
   }
 
   private async associateGpuiProjectBoardFocusedSession(request: {
@@ -2590,7 +2711,8 @@ class GpuiSidebarRuntime {
     if (!sessionId) {
       throw new Error("No linked conversation is selected.");
     }
-    const boardProject = await this.resolveGpuiProjectBoardDomainProject(request);
+    const { boardProject, linkStoreProjects } =
+      await this.resolveGpuiProjectBoardDomainScope(request);
     const reference = parseGxserverPresentationProjectSessionId(sessionId) ?? {
       projectId: boardProject.projectId,
       sessionId,
@@ -2612,7 +2734,17 @@ class GpuiSidebarRuntime {
     `restoredFromSessionId`, then remove the stopped history row).
     */
     const row = await this.findGpuiProjectBoardPreviousSessionRow(reference);
-    if (!row || !this.client) {
+    if (!row) {
+      await this.resumeGpuiProjectBoardConversation({
+        beadId: request.beadId?.trim() || undefined,
+        boardProject,
+        linkStoreProjects,
+        oldGhostexSessionId: sessionId,
+        reference,
+      });
+      return;
+    }
+    if (!this.client) {
       throw new Error("The linked Ghostex session is no longer available.");
     }
     const created = await this.client.rpc<{
@@ -2641,7 +2773,7 @@ class GpuiSidebarRuntime {
       })
       .catch(() => undefined);
     this.projectBoardRestorableLinkChecks.delete(`${reference.projectId}:${reference.sessionId}`);
-    await this.replaceGpuiProjectBoardConversationLinkSession(boardProject, {
+    await this.replaceGpuiProjectBoardConversationLinkSession(boardProject, linkStoreProjects, {
       beadId: request.beadId?.trim() || undefined,
       oldGhostexSessionId: sessionId,
       restoredProjectId,
@@ -2650,8 +2782,58 @@ class GpuiSidebarRuntime {
     this.focusLocalWorkspaceSession(restoredProjectId, restoredSessionId);
   }
 
+  private async resumeGpuiProjectBoardConversation(args: {
+    beadId?: string;
+    boardProject: GxserverProjectDomainState;
+    linkStoreProjects: readonly GxserverProjectDomainState[];
+    oldGhostexSessionId: string;
+    reference: { projectId: string; sessionId: string };
+  }): Promise<void> {
+    /*
+    CDXC:ProjectBoardBeads 2026-08-07:
+    A bead's session usually closes without leaving a restorable history row,
+    but the agent conversation it worked is still resumable from the session
+    row's agent identity. `/api/forkSession` is the daemon-owned path for that:
+    it plans the resume command in gxserver, starts the provider, and hands
+    back a live session, which the bead then follows through the same link
+    replacement the restore path uses.
+    */
+    if (!this.client) {
+      throw new Error("The linked Ghostex session is no longer available.");
+    }
+    const { fork } = await this.client.rpc<{ fork?: GxserverForkSessionResult }>(
+      "/api/forkSession",
+      {
+        projectId: args.reference.projectId,
+        reason: "projectBoardResumeConversation",
+        sessionId: args.reference.sessionId,
+      },
+    );
+    const resumedSessionId = normalizeNonEmptyString(fork?.session.sessionId);
+    if (!resumedSessionId) {
+      throw new Error("The linked conversation could not be resumed.");
+    }
+    const resumedProjectId =
+      normalizeNonEmptyString(fork?.session.projectId) ?? args.reference.projectId;
+    this.projectBoardRestorableLinkChecks.delete(
+      `${args.reference.projectId}:${args.reference.sessionId}`,
+    );
+    await this.replaceGpuiProjectBoardConversationLinkSession(
+      args.boardProject,
+      args.linkStoreProjects,
+      {
+        beadId: args.beadId,
+        oldGhostexSessionId: args.oldGhostexSessionId,
+        restoredProjectId: resumedProjectId,
+        restoredSessionId: resumedSessionId,
+      },
+    );
+    this.focusLocalWorkspaceSession(resumedProjectId, resumedSessionId);
+  }
+
   private async replaceGpuiProjectBoardConversationLinkSession(
     boardProject: GxserverProjectDomainState,
+    linkStoreProjects: readonly GxserverProjectDomainState[],
     args: {
       beadId?: string;
       oldGhostexSessionId: string;
@@ -2670,32 +2852,39 @@ class GpuiSidebarRuntime {
             args.restoredProjectId,
             args.restoredSessionId,
           );
-    const targetDuplicateId = args.beadId
-      ? createBeadConversationLinkId(boardProject.projectId, args.beadId, ghostexSessionId)
-      : undefined;
-    const currentLinks = normalizeBeadConversationLinks(
-      boardProject.projectBoardConfig?.beadConversationLinks,
-      boardProject.projectId,
+    await this.mutateGpuiProjectBoardConversationLinkStores(
+      boardProject,
+      linkStoreProjects,
+      (currentLinks, storeProject) => {
+        const targetDuplicateId = args.beadId
+          ? createBeadConversationLinkId(storeProject.projectId, args.beadId, ghostexSessionId)
+          : undefined;
+        return currentLinks.flatMap((link) => {
+          const isTarget =
+            resolveBeadConversationLinkBoardSessionId(link, boardProject.projectId) ===
+              args.oldGhostexSessionId && (!args.beadId || link.beadId === args.beadId);
+          const isDuplicateForTarget =
+            Boolean(targetDuplicateId) &&
+            link.beadId === args.beadId &&
+            link.id === targetDuplicateId;
+          if (!isTarget) {
+            return isDuplicateForTarget ? [] : [link];
+          }
+          return [
+            {
+              ...link,
+              ghostexSessionId,
+              id: createBeadConversationLinkId(
+                storeProject.projectId,
+                link.beadId,
+                ghostexSessionId,
+              ),
+              updatedAt: now,
+            },
+          ];
+        });
+      },
     );
-    const nextLinks = currentLinks.flatMap((link) => {
-      const isTarget =
-        link.ghostexSessionId === args.oldGhostexSessionId &&
-        (!args.beadId || link.beadId === args.beadId);
-      const isDuplicateForTarget =
-        Boolean(targetDuplicateId) && link.beadId === args.beadId && link.id === targetDuplicateId;
-      if (!isTarget) {
-        return isDuplicateForTarget ? [] : [link];
-      }
-      return [
-        {
-          ...link,
-          ghostexSessionId,
-          id: createBeadConversationLinkId(boardProject.projectId, link.beadId, ghostexSessionId),
-          updatedAt: now,
-        },
-      ];
-    });
-    await this.writeGpuiProjectBoardConversationLinks(boardProject, nextLinks);
   }
 
   private async unlinkGpuiProjectBoardConversation(request: {
@@ -2712,17 +2901,49 @@ class GpuiSidebarRuntime {
     if (!sessionId) {
       throw new Error("No linked conversation is selected.");
     }
-    const boardProject = await this.resolveGpuiProjectBoardDomainProject(request);
+    const { boardProject, linkStoreProjects } =
+      await this.resolveGpuiProjectBoardDomainScope(request);
     const now = new Date().toISOString();
-    const nextLinks = normalizeBeadConversationLinks(
-      boardProject.projectBoardConfig?.beadConversationLinks,
-      boardProject.projectId,
-    ).map((link) =>
-      link.beadId === beadId && link.ghostexSessionId === sessionId
-        ? { ...link, status: "archived" as const, updatedAt: now }
-        : link,
+    await this.mutateGpuiProjectBoardConversationLinkStores(
+      boardProject,
+      linkStoreProjects,
+      (currentLinks) =>
+        currentLinks.map((link) =>
+          link.beadId === beadId &&
+          resolveBeadConversationLinkBoardSessionId(link, boardProject.projectId) === sessionId
+            ? { ...link, status: "archived" as const, updatedAt: now }
+            : link,
+        ),
     );
-    await this.writeGpuiProjectBoardConversationLinks(boardProject, nextLinks);
+  }
+
+  private async mutateGpuiProjectBoardConversationLinkStores(
+    boardProject: GxserverProjectDomainState,
+    linkStoreProjects: readonly GxserverProjectDomainState[],
+    mutate: (
+      currentLinks: BeadConversationLink[],
+      storeProject: GxserverProjectDomainState,
+    ) => BeadConversationLink[],
+  ): Promise<void> {
+    /*
+    CDXC:ProjectBoardBeads 2026-08-07:
+    The board reads links from every project row that mounts the same Beads
+    board, so a link the user acts on can be stored on a row other than the one
+    whose board is open. Apply link mutations to each row that actually holds a
+    matching link; a row whose links come back unchanged is never written.
+    */
+    const projects = linkStoreProjects.length > 0 ? linkStoreProjects : [boardProject];
+    for (const storeProject of projects) {
+      const currentLinks = normalizeBeadConversationLinks(
+        storeProject.projectBoardConfig?.beadConversationLinks,
+        storeProject.projectId,
+      );
+      const nextLinks = mutate(currentLinks, storeProject);
+      if (JSON.stringify(nextLinks) === JSON.stringify(currentLinks)) {
+        continue;
+      }
+      await this.writeGpuiProjectBoardConversationLinks(storeProject, nextLinks);
+    }
   }
 
   private handleGpuiWorkspaceTabSessionSelected(payload: unknown): void {

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -2236,7 +2236,9 @@ class GpuiSidebarRuntime {
     );
     const linkViews: ProjectBoardConversationLinkView[] = [];
     for (const link of activeLinks) {
-      const session = sessionById.get(link.ghostexSessionId);
+      const session =
+        sessionById.get(link.ghostexSessionId) ??
+        this.findGpuiProjectBoardLinkedSessionOption(boardProject, link.ghostexSessionId);
       const availability = session
         ? undefined
         : await this.checkGpuiProjectBoardLinkAvailability(boardProject, link.ghostexSessionId);
@@ -2357,6 +2359,50 @@ class GpuiSidebarRuntime {
         },
       ];
     });
+  }
+
+  private findGpuiProjectBoardLinkedSessionOption(
+    boardProject: GxserverProjectDomainState,
+    ghostexSessionId: string,
+  ): ProjectBoardSessionOption | undefined {
+    /*
+    CDXC:ProjectBoardBeads 2026-08-07:
+    The option list is scoped to the board's worktree family and board mounts,
+    but a bead can be worked from any project. Jump already focuses such a
+    session straight from presentation, so liveness is resolved the same way —
+    otherwise a card offers to resume a conversation that is running right now.
+    */
+    const presentation = this.presentation;
+    if (!presentation) {
+      return undefined;
+    }
+    const reference = parseGxserverPresentationProjectSessionId(ghostexSessionId) ?? {
+      projectId: boardProject.projectId,
+      sessionId: ghostexSessionId,
+    };
+    const session = presentation.sessions.find(
+      (candidate) =>
+        candidate.projectId === reference.projectId &&
+        candidate.sessionId === reference.sessionId &&
+        (candidate.kind === "terminal" || candidate.kind === "agent"),
+    );
+    if (!session) {
+      return undefined;
+    }
+    const isBoardProject = session.projectId === boardProject.projectId;
+    const projectTitle = presentation.projects.find(
+      (project) => project.projectId === session.projectId,
+    )?.title;
+    return {
+      agentId: session.agentName ?? session.agentId,
+      isFocused:
+        session.projectId === this.activeProjectId && session.sessionId === this.focusedSessionId,
+      isSleeping: this.isSleepingLocalPresentationSession(session.projectId, session.sessionId),
+      label: isBoardProject
+        ? session.title
+        : `${projectTitle ?? session.projectId} · ${session.title}`,
+      sessionId: ghostexSessionId,
+    };
   }
 
   private async checkGpuiProjectBoardLinkAvailability(
@@ -2568,6 +2614,7 @@ class GpuiSidebarRuntime {
       projectId: linkProject.projectId,
       sessionPersistenceName: args.session.zmxName ?? presentationSession?.zmxName,
       sessionPersistenceProvider: "zmx",
+      sessionProjectId: args.session.projectId,
       status: "active",
       updatedAt: now,
     };
@@ -2748,7 +2795,7 @@ class GpuiSidebarRuntime {
       throw new Error("The linked Ghostex session is no longer available.");
     }
     const created = await this.client.rpc<{
-      session?: { projectId?: string; sessionId?: string };
+      session?: { projectId?: string; sessionId?: string; zmxName?: string };
     }>("/api/createSession", {
       kind: "terminal",
       lifecycleState: "running",
@@ -2778,6 +2825,7 @@ class GpuiSidebarRuntime {
       oldGhostexSessionId: sessionId,
       restoredProjectId,
       restoredSessionId,
+      restoredSessionPersistenceName: normalizeNonEmptyString(created.session?.zmxName),
     });
     this.focusLocalWorkspaceSession(restoredProjectId, restoredSessionId);
   }
@@ -2826,6 +2874,7 @@ class GpuiSidebarRuntime {
         oldGhostexSessionId: args.oldGhostexSessionId,
         restoredProjectId: resumedProjectId,
         restoredSessionId: resumedSessionId,
+        restoredSessionPersistenceName: normalizeNonEmptyString(fork?.session.zmxName),
       },
     );
     this.focusLocalWorkspaceSession(resumedProjectId, resumedSessionId);
@@ -2839,6 +2888,7 @@ class GpuiSidebarRuntime {
       oldGhostexSessionId: string;
       restoredProjectId: string;
       restoredSessionId: string;
+      restoredSessionPersistenceName?: string;
     },
   ): Promise<void> {
     // macOS `replaceProjectBoardConversationLinkSession`: every link on the
@@ -2879,6 +2929,11 @@ class GpuiSidebarRuntime {
                 link.beadId,
                 ghostexSessionId,
               ),
+              // The stored provider name describes the session being replaced,
+              // so it is re-stated from the new session rather than left to
+              // describe a session this link no longer points at.
+              sessionPersistenceName: args.restoredSessionPersistenceName,
+              sessionProjectId: args.restoredProjectId,
               updatedAt: now,
             },
           ];

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -2366,6 +2366,35 @@ class GpuiSidebarRuntime {
     );
   }
 
+  private async reloadGpuiProjectBoardDomainProject(
+    boardProject: GxserverProjectDomainState,
+  ): Promise<GxserverProjectDomainState> {
+    /*
+    CDXC:ProjectBoardBeads 2026-08-07:
+    Starting work can take minutes before the link is written (the worktree
+    path registers a project, runs setup, and refreshes presentation), and
+    /api/updateProject replaces projectBoardConfig wholesale. Re-read the row
+    so the link write extends the current links instead of persisting a
+    snapshot taken before the session existed — otherwise a link that landed
+    during the gap is dropped and its card reads as never worked.
+    */
+    if (!this.client) {
+      return boardProject;
+    }
+    try {
+      const response = await this.client.rpc<{ projects?: GxserverProjectDomainState[] }>(
+        "/api/listProjects",
+        {},
+      );
+      const projects = Array.isArray(response.projects) ? response.projects : [];
+      return (
+        projects.find((candidate) => candidate.projectId === boardProject.projectId) ?? boardProject
+      );
+    } catch {
+      return boardProject;
+    }
+  }
+
   private async writeGpuiProjectBoardConversationLinks(
     boardProject: GxserverProjectDomainState,
     nextLinks: BeadConversationLink[],
@@ -2420,16 +2449,17 @@ class GpuiSidebarRuntime {
       status: "active",
       updatedAt: now,
     };
+    const latestBoardProject = await this.reloadGpuiProjectBoardDomainProject(boardProject);
     const currentLinks = normalizeBeadConversationLinks(
-      boardProject.projectBoardConfig?.beadConversationLinks,
-      boardProject.projectId,
+      latestBoardProject.projectBoardConfig?.beadConversationLinks,
+      latestBoardProject.projectId,
     );
     const nextLinks = currentLinks.some((link) => link.id === nextLink.id)
       ? currentLinks.map((link) =>
           link.id === nextLink.id ? { ...link, ...nextLink, createdAt: link.createdAt } : link,
         )
       : [...currentLinks, nextLink];
-    await this.writeGpuiProjectBoardConversationLinks(boardProject, nextLinks);
+    await this.writeGpuiProjectBoardConversationLinks(latestBoardProject, nextLinks);
   }
 
   private async associateGpuiProjectBoardFocusedSession(request: {

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -13,8 +13,10 @@ import {
   parseProjectBoardCommentText,
   priorityLabel,
   prioritySelectValue,
+  conversationLinkActionKind,
   conversationLinkLabel,
   conversationLinkStatusText,
+  isUsableConversationLink,
   formatShortDate,
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
@@ -351,5 +353,38 @@ describe("project board conversation link presentation", () => {
         agentSessionId: undefined,
       }),
     ).toBe("Agent session");
+  });
+});
+
+describe("project board conversation link actions", () => {
+  const closedSessionLink = {
+    agentName: "Claude Code",
+    agentSessionId: "019a1b2c3d4e5f",
+    beadId: "ghostex-95421485",
+    createdAt: "2026-08-05T09:00:00.000Z",
+    ghostexSessionId: "session-a",
+    id: "project-a:ghostex-95421485:session-a",
+    projectId: "project-a",
+    status: "active" as const,
+    updatedAt: "2026-08-06T11:30:00.000Z",
+  };
+
+  test("offers resume when only the agent conversation survives the session", () => {
+    expect(conversationLinkActionKind({ ...closedSessionLink, isResumable: true })).toBe("resume");
+    expect(isUsableConversationLink({ ...closedSessionLink, isResumable: true })).toBe(true);
+  });
+
+  test("jumps to a session Ghostex can still open", () => {
+    expect(conversationLinkActionKind({ ...closedSessionLink, isLive: true })).toBe("jump");
+    expect(conversationLinkActionKind({ ...closedSessionLink, isRestorable: true })).toBe("jump");
+    expect(
+      conversationLinkActionKind({ ...closedSessionLink, isLive: true, isResumable: true }),
+    ).toBe("jump");
+  });
+
+  test("offers nothing when there is no way back to the conversation", () => {
+    expect(conversationLinkActionKind(closedSessionLink)).toBe("none");
+    expect(conversationLinkActionKind(undefined)).toBe("none");
+    expect(isUsableConversationLink(closedSessionLink)).toBe(false);
   });
 });

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -13,6 +13,9 @@ import {
   parseProjectBoardCommentText,
   priorityLabel,
   prioritySelectValue,
+  conversationLinkLabel,
+  conversationLinkStatusText,
+  formatShortDate,
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
   type BoardTicket,
@@ -291,3 +294,62 @@ describe("project board issue prefix", () => {
   });
 });
 
+
+describe("project board conversation link presentation", () => {
+  const closedSessionLink = {
+    agentName: "Claude Code",
+    agentSessionId: "019a1b2c3d4e5f",
+    beadId: "ghostex-95421485",
+    createdAt: "2026-08-05T09:00:00.000Z",
+    ghostexSessionId: "session-a",
+    id: "project-a:ghostex-95421485:session-a",
+    projectId: "project-a",
+    status: "active" as const,
+    updatedAt: "2026-08-06T11:30:00.000Z",
+  };
+
+  test("keeps naming the agent that worked a bead after its session is gone", () => {
+    expect(conversationLinkLabel(closedSessionLink)).toBe("Claude Code");
+    expect(conversationLinkStatusText(closedSessionLink)).toBe(
+      `Last worked ${formatShortDate(closedSessionLink.updatedAt)} · 019a1b2c`,
+    );
+  });
+
+  test("reports live, sleeping, and restorable sessions unchanged", () => {
+    expect(conversationLinkStatusText({ ...closedSessionLink, isLive: true })).toBe(
+      "Live · 019a1b2c",
+    );
+    expect(
+      conversationLinkStatusText({ ...closedSessionLink, isLive: true, isSleeping: true }),
+    ).toBe("Sleeping · 019a1b2c");
+    expect(conversationLinkStatusText({ ...closedSessionLink, isRestorable: true })).toBe(
+      "Restorable · 019a1b2c",
+    );
+  });
+
+  test("omits an unusable last-worked date", () => {
+    expect(
+      conversationLinkStatusText({
+        ...closedSessionLink,
+        agentSessionId: undefined,
+        updatedAt: "not-a-date",
+      }),
+    ).toBe("Last worked");
+  });
+
+  test("falls back to the session title, then any agent identity", () => {
+    expect(conversationLinkLabel({ ...closedSessionLink, sessionTitle: "Fix links" })).toBe(
+      "Fix links",
+    );
+    expect(conversationLinkLabel({ ...closedSessionLink, agentName: undefined })).toBe(
+      "019a1b2c3d4e5f",
+    );
+    expect(
+      conversationLinkLabel({
+        ...closedSessionLink,
+        agentName: undefined,
+        agentSessionId: undefined,
+      }),
+    ).toBe("Agent session");
+  });
+});

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -1,5 +1,7 @@
 import Fuse from "fuse.js";
 
+import type { ProjectBoardConversationLinkView } from "../../shared/bead-conversation-links";
+
 /*
   CDXC:ProjectBoard 2026-05-23-14:10:
   Shared Beads board helpers keep display-id formatting, t-shirt estimate mapping, and filter logic consistent between the Project WKWebView surface and future Storybook coverage.
@@ -733,5 +735,30 @@ export function formatShortDate(value?: string): string {
     return "";
   }
   return date.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+}
+
+export function conversationLinkLabel(link: ProjectBoardConversationLinkView): string {
+  return link.sessionTitle || link.agentName || link.agentId || link.agentSessionId || "Agent session";
+}
+
+export function conversationLinkStatusText(link: ProjectBoardConversationLinkView): string {
+  /*
+   * CDXC:ProjectBoardBeads 2026-08-07:
+   * A closed agent session is the normal end state of bead work, not a broken
+   * link, so the card keeps the worker as history ("Last worked 6 Aug")
+   * instead of showing a dangling "Unavailable".
+   */
+  const lastWorkedDate = formatShortDate(link.updatedAt);
+  const sessionStatus = link.isSleeping
+    ? "Sleeping"
+    : link.isLive
+      ? "Live"
+      : link.isRestorable
+        ? "Restorable"
+        : lastWorkedDate
+          ? `Last worked ${lastWorkedDate}`
+          : "Last worked";
+  const agentSessionPreview = link.agentSessionId ? ` · ${link.agentSessionId.slice(0, 8)}` : "";
+  return `${sessionStatus}${agentSessionPreview}`;
 }
 

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -741,6 +741,30 @@ export function conversationLinkLabel(link: ProjectBoardConversationLinkView): s
   return link.sessionTitle || link.agentName || link.agentId || link.agentSessionId || "Agent session";
 }
 
+export type ProjectBoardConversationLinkActionKind = "jump" | "none" | "resume";
+
+export function conversationLinkActionKind(
+  link: ProjectBoardConversationLinkView | undefined,
+): ProjectBoardConversationLinkActionKind {
+  /*
+   * CDXC:ProjectBoardBeads 2026-08-07:
+   * Ghostex can open a live or restorable session directly. When the session
+   * row is gone from restorable history the agent conversation it worked can
+   * still be resumed into a fresh session, which is a different promise to the
+   * user and gets its own affordance.
+   */
+  if (link?.isLive || link?.isRestorable) {
+    return "jump";
+  }
+  return link?.isResumable ? "resume" : "none";
+}
+
+export function isUsableConversationLink(
+  link: ProjectBoardConversationLinkView | undefined,
+): boolean {
+  return conversationLinkActionKind(link) !== "none";
+}
+
 export function conversationLinkStatusText(link: ProjectBoardConversationLinkView): string {
   /*
    * CDXC:ProjectBoardBeads 2026-08-07:

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -81,6 +81,7 @@ import {
   boardStatusBeadsValue,
   boardStatusLabel,
   buildAgentWorkPrompt,
+  conversationLinkActionKind,
   conversationLinkLabel,
   conversationLinkStatusText,
   ensureIssuePrefix,
@@ -92,6 +93,7 @@ import {
   formatShortDate,
   getBlockedByIds,
   getBlockingIds,
+  isUsableConversationLink,
   normalizeBeadsPayload,
   normalizeDisplayIssueKey,
   normalizeIssuePrefix,
@@ -2315,7 +2317,11 @@ function ProjectBoardApp() {
   const contextMenuPrimaryLink = contextMenuTicket
     ? getPrimaryUsableConversationLink(selectBeadConversationLinks(linksByBeadKey, contextMenuTicket.id))
     : undefined;
-  const contextMenuPrimaryActionLabel = contextMenuPrimaryLink ? "Go to Session" : "Start work";
+  const contextMenuPrimaryActionLabel = contextMenuPrimaryLink
+    ? conversationLinkActionKind(contextMenuPrimaryLink) === "resume"
+      ? "Resume Session"
+      : "Go to Session"
+    : "Start work";
   const contextMenuPrimaryActionDisabled =
     Boolean(conversationAction) || (!contextMenuPrimaryLink && conversationState.agents.length === 0);
 
@@ -3862,6 +3868,7 @@ function ConversationSection({
           <div className="project-ticket-conversation-list">
             {links.map((link) => {
               const label = conversationLinkLabel(link);
+              const actionKind = conversationLinkActionKind(link);
               return (
                 <div className="project-ticket-conversation-row" key={link.id}>
                   <div className="project-ticket-conversation-main">
@@ -3875,14 +3882,18 @@ function ConversationSection({
                   </div>
                   <div className="project-ticket-conversation-actions">
                     <Button
-                      aria-label="Jump to linked conversation"
-                      disabled={!isUsableConversationLink(link) || hasActiveConversationAction}
+                      aria-label={
+                        actionKind === "resume"
+                          ? "Resume linked conversation"
+                          : "Jump to linked conversation"
+                      }
+                      disabled={actionKind === "none" || hasActiveConversationAction}
                       onClick={() => onJumpToConversation(link)}
                       size="icon-sm"
                       type="button"
                       variant="ghost"
                     >
-                      <IconExternalLink />
+                      {actionKind === "resume" ? <IconPlayerPlay /> : <IconExternalLink />}
                     </Button>
                     <Button
                       aria-label="Unlink conversation"
@@ -3905,10 +3916,6 @@ function ConversationSection({
       )}
     </section>
   );
-}
-
-function isUsableConversationLink(link: ProjectBoardConversationLinkView | undefined): boolean {
-  return Boolean(link?.isLive || link?.isRestorable);
 }
 
 function getPrimaryUsableConversationLink(
@@ -4185,9 +4192,8 @@ function TicketCard({
   const primaryLink = getPrimaryUsableConversationLink(links) ?? links[0];
   const additionalLinkCount = primaryLink ? links.length - 1 : 0;
   const primaryLinkLabel = primaryLink ? conversationLinkLabel(primaryLink) : "";
-  const jumpDisabled =
-    !isUsableConversationLink(primaryLink) ||
-    Boolean(conversationAction);
+  const primaryLinkActionKind = conversationLinkActionKind(primaryLink);
+  const jumpDisabled = primaryLinkActionKind === "none" || Boolean(conversationAction);
 
   return (
     <Card
@@ -4260,7 +4266,11 @@ function TicketCard({
               </span>
             </TooltipProvider>
             <Button
-              aria-label="Jump to linked conversation"
+              aria-label={
+                primaryLinkActionKind === "resume"
+                  ? "Resume linked conversation"
+                  : "Jump to linked conversation"
+              }
               disabled={jumpDisabled}
               onClick={(event) => {
                 event.stopPropagation();
@@ -4270,7 +4280,7 @@ function TicketCard({
               type="button"
               variant="ghost"
             >
-              <IconExternalLink />
+              {primaryLinkActionKind === "resume" ? <IconPlayerPlay /> : <IconExternalLink />}
             </Button>
           </div>
         ) : null}

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -81,6 +81,8 @@ import {
   boardStatusBeadsValue,
   boardStatusLabel,
   buildAgentWorkPrompt,
+  conversationLinkLabel,
+  conversationLinkStatusText,
   ensureIssuePrefix,
   ensureWorkflowStatuses,
   extractDescriptionImageReferences,
@@ -115,6 +117,8 @@ import {
   type TshirtSize,
 } from "./project-board-shared";
 import {
+  indexBeadConversationLinksByBead,
+  selectBeadConversationLinks,
   type ProjectBoardAgentOption,
   type ProjectBoardBridgeRequest,
   type ProjectBoardBridgeResponse,
@@ -1245,16 +1249,13 @@ function ProjectBoardApp() {
   const showInitialBoardLoadingOverlay =
     activeSurfaceTab === "board" && loadState === "loading" && !hasCompletedInitialBoardLoad;
 
-  const linksByBeadId = useMemo(() => {
-    const result = new Map<string, ProjectBoardConversationLinkView[]>();
-    const newestFirstLinks = [...conversationState.links].sort(compareConversationLinksNewestFirst);
-    for (const link of newestFirstLinks) {
-      const current = result.get(link.beadId) ?? [];
-      current.push(link);
-      result.set(link.beadId, current);
-    }
-    return result;
-  }, [conversationState.links]);
+  const linksByBeadKey = useMemo(
+    () =>
+      indexBeadConversationLinksByBead(
+        [...conversationState.links].sort(compareConversationLinksNewestFirst),
+      ),
+    [conversationState.links],
+  );
 
   const ticketOptions = useMemo(
     () =>
@@ -2227,7 +2228,9 @@ function ProjectBoardApp() {
     }
   };
 
-  const detailConversationLinks = detail.ticket ? (linksByBeadId.get(detail.ticket.id) ?? []) : [];
+  const detailConversationLinks = detail.ticket
+    ? selectBeadConversationLinks(linksByBeadKey, detail.ticket.id)
+    : [];
   const detailPrimaryConversationLink = getPrimaryUsableConversationLink(detailConversationLinks);
   const detailCommentMetadataLink = detailPrimaryConversationLink ?? detailConversationLinks[0];
   const detailPrimaryActionLabel =
@@ -2310,7 +2313,7 @@ function ProjectBoardApp() {
     ? tickets.find((ticket) => ticket.id === ticketContextMenu.ticketId)
     : undefined;
   const contextMenuPrimaryLink = contextMenuTicket
-    ? getPrimaryUsableConversationLink(linksByBeadId.get(contextMenuTicket.id) ?? [])
+    ? getPrimaryUsableConversationLink(selectBeadConversationLinks(linksByBeadKey, contextMenuTicket.id))
     : undefined;
   const contextMenuPrimaryActionLabel = contextMenuPrimaryLink ? "Go to Session" : "Start work";
   const contextMenuPrimaryActionDisabled =
@@ -2670,7 +2673,7 @@ function ProjectBoardApp() {
                     column={column}
                     conversationAction={conversationAction}
                     key={column.key}
-                    linksByBeadId={linksByBeadId}
+                    linksByBeadKey={linksByBeadKey}
                     onAddTicket={openNewTicket}
                     onJumpToConversation={jumpToConversation}
                     onOpenContextMenu={(ticket, point) =>
@@ -3904,10 +3907,6 @@ function ConversationSection({
   );
 }
 
-function conversationLinkLabel(link: ProjectBoardConversationLinkView): string {
-  return link.sessionTitle || link.agentName || link.agentId || link.agentSessionId || "Agent session";
-}
-
 function isUsableConversationLink(link: ProjectBoardConversationLinkView | undefined): boolean {
   return Boolean(link?.isLive || link?.isRestorable);
 }
@@ -3931,18 +3930,6 @@ function ConversationLinkName({
       <TooltipContent side="bottom">{label}</TooltipContent>
     </Tooltip>
   );
-}
-
-function conversationLinkStatusText(link: ProjectBoardConversationLinkView): string {
-  const sessionStatus = link.isSleeping
-    ? "Sleeping"
-    : link.isLive
-      ? "Live"
-      : link.isRestorable
-        ? "Restorable"
-        : "Unavailable";
-  const agentSessionPreview = link.agentSessionId ? ` · ${link.agentSessionId.slice(0, 8)}` : "";
-  return `${sessionStatus}${agentSessionPreview}`;
 }
 
 function projectBoardCommentMetadataFromLink(
@@ -4027,7 +4014,7 @@ function automationTriageStatusWeight(status: AutomationRun["status"]): number {
 function BoardLane({
   column,
   conversationAction,
-  linksByBeadId,
+  linksByBeadKey,
   onAddTicket,
   onJumpToConversation,
   onOpenContextMenu,
@@ -4036,7 +4023,7 @@ function BoardLane({
 }: {
   column: (typeof BOARD_COLUMNS)[number];
   conversationAction: ConversationActionState;
-  linksByBeadId: Map<string, ProjectBoardConversationLinkView[]>;
+  linksByBeadKey: Map<string, ProjectBoardConversationLinkView[]>;
   onAddTicket: (status: BoardStatusKey) => void;
   onJumpToConversation: (link: ProjectBoardConversationLinkView) => void;
   onOpenContextMenu: (ticket: BoardTicket, point: { x: number; y: number }) => void;
@@ -4142,7 +4129,7 @@ function BoardLane({
             <TicketCard
               conversationAction={conversationAction}
               key={ticket.id}
-              links={linksByBeadId.get(ticket.id) ?? []}
+              links={selectBeadConversationLinks(linksByBeadKey, ticket.id)}
               onJumpToConversation={onJumpToConversation}
               onOpenContextMenu={onOpenContextMenu}
               onOpenTicket={onOpenTicket}

--- a/shared/bead-conversation-links.test.ts
+++ b/shared/bead-conversation-links.test.ts
@@ -7,7 +7,9 @@ import {
   createBeadConversationLinkId,
   indexBeadConversationLinksByBead,
   normalizeBeadConversationLinks,
+  parseBeadConversationLinkSessionPersistenceName,
   resolveBeadConversationLinkBoardSessionId,
+  resolveBeadConversationLinkSessionReference,
   selectBeadConversationLinks,
   selectBeadConversationLinkStoreProjects,
 } from "./bead-conversation-links";
@@ -222,5 +224,119 @@ describe("board-relative bead conversation links", () => {
         "P1",
       ),
     ).toBe("G1");
+  });
+});
+
+describe("bead conversation link session owners", () => {
+  /*
+   * Live repro (2026-08-07): one demo bead rendered two identical rows because
+   * each board mount stored its own link for the same worked session, and the
+   * bare session id was read as belonging to whichever row stored it. The
+   * session actually lived in a third project, which is also why the resume
+   * plan lookup missed.
+   */
+  const storedLink = (projectId: string, updatedAt: string) => ({
+    beadId: "agent-bo-95421491",
+    createdAt: updatedAt,
+    ghostexSessionId: "G45qx",
+    id: `${projectId}:agent-bo-95421491:G45qx`,
+    projectId,
+    sessionPersistenceName: "S60-P9gzj-G45qx",
+    updatedAt,
+  });
+
+  test("should collapse one conversation stored by two board mounts", () => {
+    const canonical = canonicalizeBeadConversationLinksForBoard(
+      [
+        storedLink("P3mjq", "2026-08-07T05:00:04.000Z"),
+        storedLink("P85fx", "2026-08-07T05:35:00.000Z"),
+      ],
+      "P85fx",
+    );
+
+    expect(canonical).toHaveLength(1);
+    expect(canonical[0]?.projectId).toBe("P85fx");
+    expect(canonical[0]?.ghostexSessionId).toBe(
+      createGxserverPresentationProjectSessionId("P9gzj", "G45qx"),
+    );
+  });
+
+  test("should collapse the pair when only one row records the session owner", () => {
+    /*
+     * Only the row that wrote the link while the session was live is
+     * guaranteed to carry the provider name, so one side of a duplicate pair
+     * can be left guessing its own project as the owner.
+     */
+    const canonical = canonicalizeBeadConversationLinksForBoard(
+      [
+        { ...storedLink("P3mjq", "2026-08-07T05:00:04.000Z"), sessionPersistenceName: undefined },
+        storedLink("P85fx", "2026-08-07T05:35:00.000Z"),
+      ],
+      "P85fx",
+    );
+
+    expect(canonical).toHaveLength(1);
+    expect(canonical[0]?.ghostexSessionId).toBe(
+      createGxserverPresentationProjectSessionId("P9gzj", "G45qx"),
+    );
+  });
+
+  test("should keep two conversations that name different owning projects", () => {
+    const canonical = canonicalizeBeadConversationLinksForBoard(
+      [
+        storedLink("P3mjq", "2026-08-07T05:00:04.000Z"),
+        {
+          ...storedLink("P85fx", "2026-08-07T05:35:00.000Z"),
+          sessionPersistenceName: "S60-P2def-G45qx",
+        },
+      ],
+      "P85fx",
+    );
+
+    expect(canonical).toHaveLength(2);
+  });
+
+  test("should read the owning project out of the zmx session name", () => {
+    expect(parseBeadConversationLinkSessionPersistenceName("S60-P9gzj-G45qx")).toEqual({
+      projectId: "P9gzj",
+      sessionId: "G45qx",
+    });
+    expect(parseBeadConversationLinkSessionPersistenceName("ghostex-work")).toBeUndefined();
+    expect(parseBeadConversationLinkSessionPersistenceName("S60-P9gzj")).toBeUndefined();
+    expect(parseBeadConversationLinkSessionPersistenceName("S60-X9gzj-G45qx")).toBeUndefined();
+    expect(parseBeadConversationLinkSessionPersistenceName(undefined)).toBeUndefined();
+  });
+
+  test("should prefer explicit session owners over the zmx session name", () => {
+    expect(
+      resolveBeadConversationLinkSessionReference({
+        ...storedLink("P3mjq", "2026-08-07T05:00:04.000Z"),
+        sessionProjectId: "P1abc",
+      }),
+    ).toEqual({ projectId: "P1abc", sessionId: "G45qx" });
+
+    expect(
+      resolveBeadConversationLinkSessionReference({
+        ...storedLink("P3mjq", "2026-08-07T05:00:04.000Z"),
+        ghostexSessionId: createGxserverPresentationProjectSessionId("P2def", "G45qx"),
+        sessionProjectId: "P1abc",
+      }),
+    ).toEqual({ projectId: "P2def", sessionId: "G45qx" });
+  });
+
+  test("should fall back to the storing project when nothing names the session owner", () => {
+    expect(
+      resolveBeadConversationLinkSessionReference({
+        ...storedLink("P3mjq", "2026-08-07T05:00:04.000Z"),
+        sessionPersistenceName: undefined,
+      }),
+    ).toEqual({ projectId: "P3mjq", sessionId: "G45qx" });
+
+    expect(
+      resolveBeadConversationLinkSessionReference({
+        ...storedLink("P3mjq", "2026-08-07T05:00:04.000Z"),
+        sessionPersistenceName: "S60-P9gzj-G99zz",
+      }),
+    ).toEqual({ projectId: "P3mjq", sessionId: "G45qx" });
   });
 });

--- a/shared/bead-conversation-links.test.ts
+++ b/shared/bead-conversation-links.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "vitest";
+import { createGxserverPresentationProjectSessionId } from "./gxserver-presentation-sidebar-projection";
 import {
   beadConversationLinkMatchKey,
+  beadConversationLinkStoreKey,
+  canonicalizeBeadConversationLinksForBoard,
   createBeadConversationLinkId,
   indexBeadConversationLinksByBead,
   normalizeBeadConversationLinks,
+  resolveBeadConversationLinkBoardSessionId,
   selectBeadConversationLinks,
+  selectBeadConversationLinkStoreProjects,
 } from "./bead-conversation-links";
 
 describe("bead conversation links", () => {
@@ -124,5 +129,98 @@ describe("bead conversation link matching", () => {
 
   test("should return no links for a bead nothing was ever linked to", () => {
     expect(selectBeadConversationLinks(indexBeadConversationLinksByBead([]), "zmux-1")).toEqual([]);
+  });
+});
+
+describe("bead conversation link stores", () => {
+  const project = (projectId: string, path: string, beadsDirectory?: string) => ({
+    path,
+    projectBoardConfig: beadsDirectory ? { beadsDirectory } : {},
+    projectId,
+  });
+
+  test("should treat project rows pointed at one beads directory as a single link store", () => {
+    /*
+     * The same board can be mounted by two project rows (a checkout and its
+     * worktree, or the same folder registered twice). Each row keeps its own
+     * beadConversationLinks, so a card must read every row that shares the
+     * board or half its history is invisible.
+     */
+    const board = project("P1", "/code/app");
+    const mirror = project("P2", "/code/app-worktree", "/code/app");
+    const unrelated = project("P3", "/code/other");
+
+    expect(
+      selectBeadConversationLinkStoreProjects(board, [board, mirror, unrelated]).map(
+        (entry) => entry.projectId,
+      ),
+    ).toEqual(["P1", "P2"]);
+  });
+
+  test("should fall back to the project path when no beads directory is configured", () => {
+    const board = project("P1", "/code/app/");
+    const duplicate = project("P2", "/code/app");
+
+    expect(beadConversationLinkStoreKey(board)).toBe("/code/app");
+    expect(
+      selectBeadConversationLinkStoreProjects(board, [duplicate]).map((entry) => entry.projectId),
+    ).toEqual(["P1", "P2"]);
+  });
+
+  test("should keep a pathless project row to itself", () => {
+    const board = { projectBoardConfig: {}, projectId: "P1" };
+    const other = { projectBoardConfig: {}, projectId: "P2" };
+
+    expect(selectBeadConversationLinkStoreProjects(board, [other])).toEqual([board]);
+  });
+});
+
+describe("board-relative bead conversation links", () => {
+  const link = (projectId: string, ghostexSessionId: string, updatedAt: string) => ({
+    beadId: "ghostex-95421485",
+    ghostexSessionId,
+    id: `${projectId}:ghostex-95421485:${ghostexSessionId}`,
+    projectId,
+    updatedAt,
+  });
+
+  test("should leave links owned by the board project untouched", () => {
+    const links = [link("P1", "G1", "2026-08-06T10:00:00.000Z")];
+
+    expect(canonicalizeBeadConversationLinksForBoard(links, "P1")).toEqual(links);
+  });
+
+  test("should re-express a sibling row's link against the board project", () => {
+    const links = [link("P2", "G1", "2026-08-06T10:00:00.000Z")];
+
+    expect(canonicalizeBeadConversationLinksForBoard(links, "P1")[0]?.ghostexSessionId).toBe(
+      createGxserverPresentationProjectSessionId("P2", "G1"),
+    );
+  });
+
+  test("should collapse one conversation stored by two rows, keeping the newest", () => {
+    const scoped = createGxserverPresentationProjectSessionId("P1", "G1");
+    const links = [
+      link("P2", scoped, "2026-08-05T10:00:00.000Z"),
+      link("P1", "G1", "2026-08-06T10:00:00.000Z"),
+    ];
+
+    const canonical = canonicalizeBeadConversationLinksForBoard(links, "P1");
+
+    expect(canonical).toHaveLength(1);
+    expect(canonical[0]?.projectId).toBe("P1");
+    expect(canonical[0]?.updatedAt).toBe("2026-08-06T10:00:00.000Z");
+  });
+
+  test("should resolve the board-relative session id a link points at", () => {
+    expect(resolveBeadConversationLinkBoardSessionId(link("P2", "G1", ""), "P1")).toBe(
+      createGxserverPresentationProjectSessionId("P2", "G1"),
+    );
+    expect(
+      resolveBeadConversationLinkBoardSessionId(
+        link("P2", createGxserverPresentationProjectSessionId("P1", "G1"), ""),
+        "P1",
+      ),
+    ).toBe("G1");
   });
 });

--- a/shared/bead-conversation-links.test.ts
+++ b/shared/bead-conversation-links.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "vitest";
 import {
+  beadConversationLinkMatchKey,
   createBeadConversationLinkId,
+  indexBeadConversationLinksByBead,
   normalizeBeadConversationLinks,
+  selectBeadConversationLinks,
 } from "./bead-conversation-links";
 
 describe("bead conversation links", () => {
@@ -71,5 +74,55 @@ describe("bead conversation links", () => {
         status: "archived",
       },
     ]);
+  });
+});
+
+describe("bead conversation link matching", () => {
+  const link = (beadId: string, ghostexSessionId: string) => ({
+    beadId,
+    ghostexSessionId,
+    id: `${beadId}:${ghostexSessionId}`,
+  });
+
+  test("should keep a link matched to its bead after a prefix rename", () => {
+    /*
+     * A board load can rename every issue prefix (zmux-95421485 becomes
+     * ghostex-95421485). Links persist the id they were written with, so the
+     * lookup must survive the rename instead of orphaning the conversation.
+     */
+    const index = indexBeadConversationLinksByBead([link("zmux-95421485", "session-a")]);
+
+    expect(selectBeadConversationLinks(index, "ghostex-95421485").map((entry) => entry.id)).toEqual([
+      "zmux-95421485:session-a",
+    ]);
+  });
+
+  test("should group pre-rename and post-rename links under one bead", () => {
+    const index = indexBeadConversationLinksByBead([
+      link("ghostex-95421485", "session-b"),
+      link("zmux-95421485", "session-a"),
+    ]);
+
+    expect(selectBeadConversationLinks(index, "ghostex-95421485").map((entry) => entry.id)).toEqual([
+      "ghostex-95421485:session-b",
+      "zmux-95421485:session-a",
+    ]);
+  });
+
+  test("should not match links belonging to a different bead", () => {
+    const index = indexBeadConversationLinksByBead([link("zmux-95421485", "session-a")]);
+
+    expect(selectBeadConversationLinks(index, "ghostex-11112222")).toEqual([]);
+  });
+
+  test("should match hyphenated prefixes on the trailing issue id only", () => {
+    expect(beadConversationLinkMatchKey("agent-bo-95421485")).toBe("95421485");
+    expect(beadConversationLinkMatchKey(" ZMUX-95421485 ")).toBe("95421485");
+    expect(beadConversationLinkMatchKey("95421485")).toBe("95421485");
+    expect(beadConversationLinkMatchKey("zmux-")).toBe("zmux-");
+  });
+
+  test("should return no links for a bead nothing was ever linked to", () => {
+    expect(selectBeadConversationLinks(indexBeadConversationLinksByBead([]), "zmux-1")).toEqual([]);
   });
 });

--- a/shared/bead-conversation-links.ts
+++ b/shared/bead-conversation-links.ts
@@ -30,6 +30,14 @@ export type BeadConversationLink = {
   projectId: string;
   sessionPersistenceName?: string;
   sessionPersistenceProvider?: "tmux" | "zmx" | "zellij";
+  /**
+   * CDXC:ProjectBoardBeads 2026-08-07:
+   * The project the Ghostex session belongs to, which is not always the
+   * project row storing the link: a bead can be worked from a sibling project
+   * while its card lives here. Recorded explicitly on new links so resolving
+   * the session never depends on parsing a provider session name.
+   */
+  sessionProjectId?: string;
   status: BeadConversationLinkStatus;
   updatedAt: string;
 };
@@ -185,6 +193,7 @@ export function normalizeBeadConversationLink(
       projectId: normalizeNonEmptyString(record.projectId) ?? fallbackProjectId,
       sessionPersistenceName: normalizeNonEmptyString(record.sessionPersistenceName),
       sessionPersistenceProvider: normalizePersistenceProvider(record.sessionPersistenceProvider),
+      sessionProjectId: normalizeNonEmptyString(record.sessionProjectId),
       status: record.status === "archived" ? "archived" : "active",
       updatedAt: normalizeDateString(record.updatedAt) ?? now,
     },
@@ -276,14 +285,73 @@ export function selectBeadConversationLinkStoreProjects<
   return storeProjects;
 }
 
+/*
+ * CDXC:ProjectBoardBeads 2026-08-07:
+ * gxserver names a zmx session "{serverId}-{projectId}-{sessionId}", which is
+ * the only record older links carry of the project their session belongs to.
+ * Links written from now on store that project explicitly; this parser keeps
+ * the ones written before that readable.
+ */
+export function parseBeadConversationLinkSessionPersistenceName(
+  sessionPersistenceName: string | undefined,
+): { projectId: string; sessionId: string } | undefined {
+  const parts = (sessionPersistenceName ?? "").trim().split("-");
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  const [serverId, projectId, sessionId] = parts;
+  if (!serverId?.startsWith("S") || !projectId?.startsWith("P") || !sessionId?.startsWith("G")) {
+    return undefined;
+  }
+  return { projectId, sessionId };
+}
+
+export function resolveBeadConversationLinkSessionReference(
+  link: Pick<
+    BeadConversationLink,
+    "ghostexSessionId" | "projectId" | "sessionPersistenceName" | "sessionProjectId"
+  >,
+): { projectId: string; sessionId: string } {
+  const { projectId, sessionId } = resolveBeadConversationLinkSessionOwner(link);
+  return { projectId, sessionId };
+}
+
+function resolveBeadConversationLinkSessionOwner(
+  link: Pick<
+    BeadConversationLink,
+    "ghostexSessionId" | "projectId" | "sessionPersistenceName" | "sessionProjectId"
+  >,
+): { isKnown: boolean; projectId: string; sessionId: string } {
+  /*
+   * A bead's session does not have to live in the project row that stores the
+   * link, so the storing row is the last resort rather than the assumption:
+   * reading it as the owner points session lookups (resume plans, forks, live
+   * matching) at a project that never held the session. `isKnown` marks the
+   * difference between evidence and that last-resort guess.
+   */
+  const scoped = parseGxserverPresentationProjectSessionId(link.ghostexSessionId);
+  if (scoped) {
+    return { isKnown: true, projectId: scoped.projectId, sessionId: scoped.sessionId };
+  }
+  const sessionProjectId = link.sessionProjectId?.trim();
+  if (sessionProjectId) {
+    return { isKnown: true, projectId: sessionProjectId, sessionId: link.ghostexSessionId };
+  }
+  const persisted = parseBeadConversationLinkSessionPersistenceName(link.sessionPersistenceName);
+  if (persisted && persisted.sessionId === link.ghostexSessionId) {
+    return { isKnown: true, projectId: persisted.projectId, sessionId: persisted.sessionId };
+  }
+  return { isKnown: false, projectId: link.projectId, sessionId: link.ghostexSessionId };
+}
+
 export function resolveBeadConversationLinkBoardSessionId(
-  link: Pick<BeadConversationLink, "ghostexSessionId" | "projectId">,
+  link: Pick<
+    BeadConversationLink,
+    "ghostexSessionId" | "projectId" | "sessionPersistenceName" | "sessionProjectId"
+  >,
   boardProjectId: string,
 ): string {
-  const reference = parseGxserverPresentationProjectSessionId(link.ghostexSessionId) ?? {
-    projectId: link.projectId,
-    sessionId: link.ghostexSessionId,
-  };
+  const reference = resolveBeadConversationLinkSessionReference(link);
   return reference.projectId === boardProjectId
     ? reference.sessionId
     : createGxserverPresentationProjectSessionId(reference.projectId, reference.sessionId);
@@ -292,23 +360,62 @@ export function resolveBeadConversationLinkBoardSessionId(
 export function canonicalizeBeadConversationLinksForBoard<
   TLink extends Pick<
     BeadConversationLink,
-    "beadId" | "ghostexSessionId" | "projectId" | "updatedAt"
+    | "beadId"
+    | "ghostexSessionId"
+    | "projectId"
+    | "sessionPersistenceName"
+    | "sessionProjectId"
+    | "updatedAt"
   >,
 >(links: readonly TLink[], boardProjectId: string): TLink[] {
-  // A session id is stored relative to the row that owns the link, so the same
-  // conversation reads differently from each row of a shared board. Re-express
-  // every link against the board project, then keep the newest record of each.
-  const byConversation = new Map<string, TLink>();
-  for (const link of links) {
-    const ghostexSessionId = resolveBeadConversationLinkBoardSessionId(link, boardProjectId);
-    const key = `${beadConversationLinkMatchKey(link.beadId)}${ghostexSessionId}`;
-    const current = byConversation.get(key);
-    if (current && Date.parse(current.updatedAt) >= Date.parse(link.updatedAt)) {
+  /*
+   * A session id is stored relative to the row that owns the link, so the same
+   * conversation reads differently from each row of a shared board. Re-express
+   * every link against the board project, then keep the newest record of each.
+   *
+   * Only the row that wrote a link while the session was live is sure which
+   * project the session belongs to; another row falls back to naming itself. So
+   * links for one bead and session id adopt the owner their evidence agrees on,
+   * and stay apart only when that evidence genuinely disagrees.
+   */
+  const resolved = links.map((link) => ({
+    link,
+    owner: resolveBeadConversationLinkSessionOwner(link),
+  }));
+  const knownOwnersByConversation = new Map<string, Set<string>>();
+  for (const entry of resolved) {
+    if (!entry.owner.isKnown) {
       continue;
     }
-    byConversation.set(key, { ...link, ghostexSessionId });
+    const key = beadConversationSessionKey(entry.link.beadId, entry.owner.sessionId);
+    const owners = knownOwnersByConversation.get(key) ?? new Set<string>();
+    owners.add(entry.owner.projectId);
+    knownOwnersByConversation.set(key, owners);
+  }
+  const byConversation = new Map<string, TLink>();
+  for (const entry of resolved) {
+    const knownOwners = knownOwnersByConversation.get(
+      beadConversationSessionKey(entry.link.beadId, entry.owner.sessionId),
+    );
+    const agreedOwner =
+      !entry.owner.isKnown && knownOwners?.size === 1 ? [...knownOwners][0] : undefined;
+    const projectId = agreedOwner ?? entry.owner.projectId;
+    const ghostexSessionId =
+      projectId === boardProjectId
+        ? entry.owner.sessionId
+        : createGxserverPresentationProjectSessionId(projectId, entry.owner.sessionId);
+    const key = beadConversationSessionKey(entry.link.beadId, ghostexSessionId);
+    const current = byConversation.get(key);
+    if (current && Date.parse(current.updatedAt) >= Date.parse(entry.link.updatedAt)) {
+      continue;
+    }
+    byConversation.set(key, { ...entry.link, ghostexSessionId });
   }
   return [...byConversation.values()];
+}
+
+function beadConversationSessionKey(beadId: string, sessionId: string): string {
+  return `${beadConversationLinkMatchKey(beadId)}\u001f${sessionId}`;
 }
 
 function normalizeNonEmptyString(value: unknown): string | undefined {

--- a/shared/bead-conversation-links.ts
+++ b/shared/bead-conversation-links.ts
@@ -7,6 +7,10 @@
  */
 
 import type { AppToastLevel } from "./app-toast-contract";
+import {
+  createGxserverPresentationProjectSessionId,
+  parseGxserverPresentationProjectSessionId,
+} from "./gxserver-presentation-sidebar-projection";
 import type { SidebarAgentIcon } from "./sidebar-agents";
 
 import type { DiagnosticLoggingSettings } from "./ghostex-settings";
@@ -48,9 +52,22 @@ export type ProjectBoardAgentOption = {
   label: string;
 };
 
+export type BeadConversationLinkStoreProject = {
+  path?: string;
+  projectBoardConfig?: Record<string, unknown>;
+  projectId: string;
+};
+
 export type ProjectBoardConversationLinkView = BeadConversationLink & {
   isFocused?: boolean;
   isLive?: boolean;
+  /**
+   * CDXC:ProjectBoardBeads 2026-08-07:
+   * The Ghostex session row is gone from restorable history, but the agent
+   * conversation it worked can still be resumed from the row's own agent
+   * identity, so the card offers Resume instead of a dead affordance.
+   */
+  isResumable?: boolean;
   isRestorable?: boolean;
   isSleeping?: boolean;
   sessionTitle?: string;
@@ -224,6 +241,74 @@ export function selectBeadConversationLinks<TLink>(
   beadId: string,
 ): TLink[] {
   return index.get(beadConversationLinkMatchKey(beadId)) ?? [];
+}
+
+/*
+ * CDXC:ProjectBoardBeads 2026-08-07:
+ * One Beads board can be mounted by several project rows — a checkout and its
+ * worktree, or the same folder registered twice — and every row keeps its own
+ * beadConversationLinks. Links are read across the rows that share a board so
+ * a card shows the work that happened, whichever row it was started from.
+ * Writes stay on their own row, so this needs no storage change.
+ */
+export function beadConversationLinkStoreKey(project: BeadConversationLinkStoreProject): string {
+  const configured = project.projectBoardConfig?.beadsDirectory;
+  const directory = typeof configured === "string" && configured.trim() ? configured : project.path;
+  return typeof directory === "string" ? directory.trim().replace(/\/+$/u, "") : "";
+}
+
+export function selectBeadConversationLinkStoreProjects<
+  TProject extends BeadConversationLinkStoreProject,
+>(boardProject: TProject, projects: readonly TProject[]): TProject[] {
+  const boardStoreKey = beadConversationLinkStoreKey(boardProject);
+  const storeProjects = [boardProject];
+  if (!boardStoreKey) {
+    return storeProjects;
+  }
+  for (const candidate of projects) {
+    if (
+      candidate.projectId !== boardProject.projectId &&
+      beadConversationLinkStoreKey(candidate) === boardStoreKey
+    ) {
+      storeProjects.push(candidate);
+    }
+  }
+  return storeProjects;
+}
+
+export function resolveBeadConversationLinkBoardSessionId(
+  link: Pick<BeadConversationLink, "ghostexSessionId" | "projectId">,
+  boardProjectId: string,
+): string {
+  const reference = parseGxserverPresentationProjectSessionId(link.ghostexSessionId) ?? {
+    projectId: link.projectId,
+    sessionId: link.ghostexSessionId,
+  };
+  return reference.projectId === boardProjectId
+    ? reference.sessionId
+    : createGxserverPresentationProjectSessionId(reference.projectId, reference.sessionId);
+}
+
+export function canonicalizeBeadConversationLinksForBoard<
+  TLink extends Pick<
+    BeadConversationLink,
+    "beadId" | "ghostexSessionId" | "projectId" | "updatedAt"
+  >,
+>(links: readonly TLink[], boardProjectId: string): TLink[] {
+  // A session id is stored relative to the row that owns the link, so the same
+  // conversation reads differently from each row of a shared board. Re-express
+  // every link against the board project, then keep the newest record of each.
+  const byConversation = new Map<string, TLink>();
+  for (const link of links) {
+    const ghostexSessionId = resolveBeadConversationLinkBoardSessionId(link, boardProjectId);
+    const key = `${beadConversationLinkMatchKey(link.beadId)}${ghostexSessionId}`;
+    const current = byConversation.get(key);
+    if (current && Date.parse(current.updatedAt) >= Date.parse(link.updatedAt)) {
+      continue;
+    }
+    byConversation.set(key, { ...link, ghostexSessionId });
+  }
+  return [...byConversation.values()];
 }
 
 function normalizeNonEmptyString(value: unknown): string | undefined {

--- a/shared/bead-conversation-links.ts
+++ b/shared/bead-conversation-links.ts
@@ -185,6 +185,47 @@ export function createBeadConversationLinkId(
     .join(":");
 }
 
+/*
+ * CDXC:ProjectBoardBeads 2026-08-07:
+ * Beads rewrites every issue id when a board's issue prefix is reconciled
+ * (zmux-95421485 becomes ghostex-95421485), but a persisted link keeps the id
+ * it was written with. Matching links to a bead by the trailing issue id keeps
+ * the conversation attached across those renames — including for links that
+ * were already orphaned by an earlier rename — while still separating two
+ * different beads.
+ */
+export function beadConversationLinkMatchKey(beadId: string): string {
+  const normalized = beadId.trim().toLowerCase();
+  const separatorIndex = normalized.lastIndexOf("-");
+  if (separatorIndex <= 0) {
+    return normalized;
+  }
+  return normalized.slice(separatorIndex + 1) || normalized;
+}
+
+export function indexBeadConversationLinksByBead<TLink extends Pick<BeadConversationLink, "beadId">>(
+  links: readonly TLink[],
+): Map<string, TLink[]> {
+  const result = new Map<string, TLink[]>();
+  for (const link of links) {
+    const key = beadConversationLinkMatchKey(link.beadId);
+    const current = result.get(key);
+    if (current) {
+      current.push(link);
+      continue;
+    }
+    result.set(key, [link]);
+  }
+  return result;
+}
+
+export function selectBeadConversationLinks<TLink>(
+  index: ReadonlyMap<string, TLink[]>,
+  beadId: string,
+): TLink[] {
+  return index.get(beadConversationLinkMatchKey(beadId)) ?? [];
+}
+
 function normalizeNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }


### PR DESCRIPTION
This is the fix you asked for in our Discord thread (BANOZZ): agents weren't being associated with the beads they worked on, and the association was lost after the session closed. Implemented inside the existing `beadConversationLinks` mechanism — no new storage, no daemon changes.

## Root causes found

1. **`bd renamePrefix` orphaned every stored link.** `ensureIssuePrefix` runs on board refreshes and can rewrite every issue id, while links keep the id they were written with; lookup was exact-match, so it missed silently (`project-board-shared.ts` even documented this).
2. **A slow Start work dropped concurrent links.** `/api/updateProject` replaces `projectBoardConfig` wholesale, and the worktree Start-work path can spend minutes between resolving the project row and writing — any link written in that gap was clobbered.
3. **Closed sessions read as dead ends.** Previous-session history only lists rows that closed with a trusted resume title, so an ordinary closed agent session rendered "Unavailable" — even though the daemon still holds its row and can plan a resume.
4. **Every lookup assumed a link's session lived in the project row that stored the link.** False whenever the session ran elsewhere (worktrees, shared boards) — this single wrong assumption produced duplicate rows on shared boards *and* resume planning that asked the wrong project.

## What changes

- **Rename-tolerant matching**: links match beads by the trailing issue id, healing links *already* orphaned by past renames — read-side only, retroactive, no migration.
- **Write race fixed**: the project row is re-read immediately before merging a link (graceful fallback to the snapshot on RPC failure).
- **Resume for closed conversations**: when history has nothing, the board asks `/api/readAgentResumePlan`; a plannable link gets a Resume affordance that runs `/api/forkSession` — the daemon plans and starts the resume (for Claude: `claude --resume <id> --fork-session`), and the bead re-points at the new session through the existing replace path. Gated on both resume- and fork-support so the board never offers what gxserver would refuse; unresumable links keep a disabled button rather than a lying one. Jump semantics are now four-state: live → focus · restorable → restore+relink · resumable → fork-resume+relink · nothing → disabled.
- **Shared boards show one history**: links are read from every project row mounting the same beads directory, re-expressed against the board project, deduped by owner agreement. Unlink/relink/upsert apply to whichever row owns the link.
- **Owning-project resolution**: one precedence chain (namespaced session id → new `sessionProjectId` field, written on all new links → parsed zmx `sessionPersistenceName`, cross-checked → storing row) feeds every session lookup: resume planning, history, fork, liveness, unlink/relink. Session ids are only unique per project, so dedupe keys on owner agreement, not bare ids.
- Dead links render `Last worked <date>` instead of "Unavailable".

## Verification

- `bun run typecheck` → exit 0; full `bun run test` → all pass (pre-existing bun:test suite failure only)
- 20+ new unit tests across the link helpers, all written red-first (including the exact duplicate-pair repro from a real dual-mounted board)
- `gpui/sidebar/gxserver-runtime.ts` sits outside the root tsconfig; edits were type-verified with a scratch tsconfig and every pre-existing diagnostic mapped line-by-line to the base commit — zero new diagnostics.
- Verified live on a real board: a closed worker session that previously rendered "No linked conversation yet" now resolves its title and offers restore/resume; the dual-mount duplicate collapsed.

## Merge notes

Touches `tasks-placeholder.tsx` + source tests like the people/toolbar PRs — later-landing PRs need a trivial anchor rebase (known resolutions, happy to rebase).

Still open, deliberately (design conversation, not this PR): links for work dispatched *outside* Start work / Associate focused (external orchestrators) — that's the `ghostex board start-work` proposal from the Discord thread, written up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project-board conversation links now work across related projects, shared boards, and sibling worktrees.
  * Links clearly indicate whether conversations are live, sleeping, restorable, or resumable.
  * Added actions to jump to active conversations or resume unavailable ones.
  * Resuming a conversation automatically updates the board link and focuses the restored session.
  * Improved labels, status text, accessibility descriptions, and disabled states for conversation actions.

* **Bug Fixes**
  * Improved link matching, duplicate handling, session discovery, and persistence across board layouts and renamed items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->