### PR TITLE
fix(sidebar): show global actions on project rows and update them instantly

### DIFF
--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -3445,6 +3445,18 @@ class GpuiSidebarRuntime {
       onError: () => {
         this.recoverPresentationStream(clientId);
       },
+      /*
+      CDXC:GlobalActions 2026-08-07:
+      Global Action writes reach this surface only as this announcement. They
+      are not project writes, so they produce no projectUpdated delta, and the
+      Settings window that made the write is a different surface whose response
+      never lands here. Refetch the HUD the same way a project Action edit
+      already does, so a Global Action flagged for the project row appears and
+      disappears with the toggle instead of on the next unrelated delta.
+      */
+      onGlobalSidebarCommands: () => {
+        this.refreshSidebarHudFromClient();
+      },
       onRendererCommand: (command) => this.handleGxserverRendererCommand(command),
       onSidebarProjectCollections: (state) => {
         this.forwardSidebarProjectCollectionsFromGxserver(state);
@@ -15031,6 +15043,7 @@ class GpuiGxserverClient {
     onClose,
     onDelta,
     onError,
+    onGlobalSidebarCommands,
     onRendererCommand,
     onSessionChatEvent,
     onSidebarProjectCollections,
@@ -15041,6 +15054,7 @@ class GpuiGxserverClient {
     onClose: () => void;
     onDelta: (delta: GxserverPresentationDelta, revision: number) => void;
     onError: () => void;
+    onGlobalSidebarCommands?: () => void;
     onRendererCommand?: GpuiRendererCommandHandler;
     onSessionChatEvent?: (event: GxserverSessionChatEvent) => void;
     onSidebarProjectCollections?: (state: GxserverSidebarProjectCollectionsState) => void;
@@ -15094,6 +15108,16 @@ class GpuiGxserverClient {
         isSidebarProjectCollectionsState(message.sidebarProjectCollections)
       ) {
         onSidebarProjectCollections(message.sidebarProjectCollections);
+        return;
+      }
+      /*
+      CDXC:GlobalActions 2026-08-07:
+      The Global Actions announcement carries no list — the handler refetches
+      the HUD, which is the one projection of it — so there is no payload to
+      shape-validate before forwarding it.
+      */
+      if (message.type === "globalSidebarCommandsChanged" && onGlobalSidebarCommands) {
+        onGlobalSidebarCommands();
         return;
       }
       /*

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -116,8 +116,10 @@ import {
   DEFAULT_BROWSER_LAUNCH_URL,
   isSidebarCommandRunMode,
   isSidebarCommandConfigured,
+  isSidebarCommandScope,
   normalizeSidebarCommandLinks,
   type SidebarCommandButton,
+  type SidebarCommandScope,
 } from "../../shared/sidebar-commands";
 import { getCompletionSoundLabel } from "../../shared/completion-sound";
 import type { CompletionSoundSetting } from "../../shared/completion-sound";
@@ -585,6 +587,7 @@ const GPUI_SIDEBAR_COMMAND_SELECTOR_MESSAGE_KEYS = new Set([
   "commandId",
   "groupId",
   "runMode",
+  "scope",
   "type",
 ]);
 const GPUI_SIDEBAR_GXSERVER_FOCUS_STATE_MESSAGE_VERSION = 1;
@@ -650,8 +653,6 @@ const GPUI_SIDEBAR_WORKSPACE_TERMINAL_RUNTIME_ACTION_MESSAGE_TYPE =
 const GPUI_SIDEBAR_SESSION_COMPLETION_SOUND_MESSAGE_VERSION = 1;
 const GPUI_SIDEBAR_SESSION_COMPLETION_SOUND_MESSAGE_TYPE =
   "ghostex.gpui.sidebar.sessionCompletionSound";
-/** Which Actions list a run-by-id selector names. Absent means project. */
-type SidebarCommandScope = "global" | "project";
 const GPUI_SIDEBAR_GLOBAL_ACTIONS_MESSAGE_VERSION = 1;
 const GPUI_SIDEBAR_GLOBAL_ACTIONS_MESSAGE_TYPE = "ghostex.gpui.sidebar.globalActions";
 /*
@@ -5742,7 +5743,20 @@ class GpuiSidebarRuntime {
           this.handleUnsupportedSidebarMessage(message);
           return;
         }
-        this.runSidebarCommand(commandId, message);
+        /*
+        CDXC:GlobalActions 2026-08-07:
+        Project rows can run either list, so the renderer names the scope.
+        Validate the value like runMode rather than trusting the annotation: an
+        unrecognized scope is an unsupported no-op, never a silent fallback to
+        the project list, which would run an Action the user did not click. An
+        absent scope stays project, which is what every sender that predates
+        Global Actions sends.
+        */
+        if (message.scope !== undefined && !isSidebarCommandScope(message.scope)) {
+          this.handleUnsupportedSidebarMessage(message);
+          return;
+        }
+        this.runSidebarCommand(commandId, message, message.scope ?? "project");
         return;
       }
       case "runGhostexHotkeyAction": {
@@ -13541,6 +13555,13 @@ class GpuiSidebarRuntime {
       name,
       playCompletionSound: message.actionType === "terminal" ? message.playCompletionSound : false,
       operation: "save",
+      /*
+      CDXC:GlobalActions 2026-08-07:
+      gxserver stores showOnProjectRow for both lists, so a global save that
+      omits it writes the flag back as false and the Settings toggle never
+      sticks. Forward it exactly like the project save above.
+      */
+      showOnProjectRow: message.showOnProjectRow,
       target: "globalCommand",
       url,
     });
@@ -14552,12 +14573,20 @@ class GpuiSidebarRuntime {
     /*
      * CDXC:GlobalActions 2026-08-01:
      * A global-scoped selector names an action that belongs to no project, so
-     * it resolves against the global list and never carries a row's group id.
-     * Project selectors keep the per-project resolution above: the two scopes
-     * pick different lists rather than falling through to each other.
+     * it resolves against the global list. Project selectors keep the
+     * per-project resolution above: the two scopes pick different lists rather
+     * than falling through to each other.
+     *
+     * CDXC:GlobalActions 2026-08-07:
+     * Scope and group id answer different questions, so a global selector may
+     * carry one: the scope picks the list, the group id picks the project to
+     * activate before dispatching. That is what makes a Global Action on a
+     * project row run in the row the user clicked instead of whichever project
+     * happened to be active. The tab strip still sends no group id — its
+     * normalizer rejects the key — so it keeps running in the active project.
      */
     const groupId =
-      scope === "global" || originalMessage.type !== "runSidebarCommand"
+      originalMessage.type !== "runSidebarCommand"
         ? undefined
         : normalizeNonEmptyString(originalMessage.groupId ?? "");
     const targetProjectId = groupId

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -2339,6 +2339,7 @@ async fn route_http(
                     mutation.global_command_update,
                     Some(GlobalSidebarCommandUpdate::Order { .. })
                 );
+                let global_command_written = mutation.global_command_update.is_some();
                 let mut updated_projects = Vec::new();
                 for update in mutation.updates {
                     let project = repository.update_project(&update.params)?;
@@ -2354,9 +2355,20 @@ async fn route_http(
                 /*
                 CDXC:GlobalActions 2026-08-01-16:00:
                 A Global Action write touches no project row, so it schedules no
-                projectUpdated presentation delta. Clients pick the new list up
-                from the refreshed HUD this call returns and from their next HUD
-                poll, the same way they already do for action edits.
+                projectUpdated presentation delta.
+
+                CDXC:GlobalActions 2026-08-07:
+                It announces itself with its own event instead. Only the caller
+                sees the refreshed HUD this response carries; every other live
+                surface learns about HUD changes from a broadcast, and none of
+                them polls the HUD on a timer. The GPUI sidebar refetches it
+                when a projectUpdated delta arrives, which is why a project
+                Action edit reaches the row at once and a Global Action edit did
+                not — the row kept the stale list until some unrelated project
+                delta happened to fire. The event carries no list, because
+                /api/readSidebarHud stays the single projection of it, and it
+                bumps the presentation revision so snapshot pollers converge as
+                well, exactly like the sidebar-collection writes below.
                 */
                 match mutation.global_command_update {
                     Some(GlobalSidebarCommandUpdate::Save {
@@ -2370,6 +2382,16 @@ async fn route_http(
                         repository.order_global_sidebar_commands(&command_ids)?
                     }
                     None => {}
+                }
+                if global_command_written {
+                    let _event_sequence = lock_presentation_event_sequence(&state)?;
+                    let revision = increment_presentation_revision(db)?;
+                    state.event_hub.broadcast(json!({
+                        "protocolVersion": GXSERVER_PROTOCOL_VERSION,
+                        "revision": revision,
+                        "serverId": state.metadata.server_id.clone(),
+                        "type": "globalSidebarCommandsChanged",
+                    }));
                 }
                 let projects = repository.list_projects()?;
                 let mut hud = read_sidebar_hud(&projects, hud_active_project_id.as_deref());
@@ -13486,6 +13508,75 @@ mod tests {
         let body = response_json(missing.response).await;
         assert_eq!(body["error"], json!("notFound"));
         assert_eq!(body["message"], json!("Project P9zzz does not exist."));
+    }
+
+    /*
+    CDXC:GlobalActions 2026-08-07:
+    Only the caller reads this response. The sidebar row that renders Global
+    Actions lives in another surface that refetches the HUD when the daemon
+    announces a change and never polls it, so a Global Action write has to
+    broadcast the way a project Action write already does through its
+    projectUpdated delta. Without the announcement the row kept the stale list
+    until an unrelated project delta happened to fire.
+    */
+    #[tokio::test]
+    async fn global_sidebar_command_write_broadcasts_a_hud_change_event() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = get_gxserver_paths(Some(temp.path().to_path_buf()));
+        /*
+        `ensure_gxserver_storage_layout` creates the state directories but not
+        the config directory, so a temp home has nowhere to write the default
+        config. A real install always has one.
+        */
+        std::fs::create_dir_all(paths.config_file.parent().expect("config directory"))
+            .expect("create config directory");
+        let state = test_app_state(paths);
+        let token = state.auth_token.clone();
+        let mut events = state.event_hub.subscribe();
+
+        let saved = route_http(
+            state.clone(),
+            rpc_request(
+                "/api/mutateSidebarHudSettings",
+                &token,
+                json!({
+                    "params": {
+                        "actionType": "terminal",
+                        "command": "echo global",
+                        "commandId": "custom-global-action",
+                        "name": "Global Action",
+                        "operation": "save",
+                        "showOnProjectRow": true,
+                        "target": "globalCommand"
+                    }
+                }),
+            ),
+            "request-save-global-sidebar-command".to_string(),
+        )
+        .await;
+        assert_eq!(saved.response.status(), StatusCode::OK);
+        let body = response_json(saved.response).await;
+        assert_eq!(
+            body["result"]["hud"]["globalCommands"][0]["commandId"],
+            json!("custom-global-action")
+        );
+        assert_eq!(
+            body["result"]["hud"]["globalCommands"][0]["showOnProjectRow"],
+            json!(true)
+        );
+
+        let mut broadcast_types = Vec::new();
+        while let Ok(event) = events.try_recv() {
+            if let Some(event_type) = event["type"].as_str() {
+                broadcast_types.push(event_type.to_string());
+            }
+        }
+        assert!(
+            broadcast_types
+                .iter()
+                .any(|event_type| event_type == "globalSidebarCommandsChanged"),
+            "expected a globalSidebarCommandsChanged broadcast, saw {broadcast_types:?}"
+        );
     }
 
     #[tokio::test]

--- a/shared/gxserver-protocol.ts
+++ b/shared/gxserver-protocol.ts
@@ -2628,6 +2628,20 @@ export type GxserverEvent =
       sidebarProjectCollections: GxserverSidebarProjectCollectionsState;
       type: "sidebarProjectCollectionsChanged";
     }
+  /*
+   * CDXC:GlobalActions 2026-08-07:
+   * A Global Action write is not a project write, so it produces no
+   * presentation delta and live surfaces would otherwise keep a stale list.
+   * The event announces the change and bumps the presentation revision; it
+   * carries no commands, because `/api/readSidebarHud` stays the single
+   * projection of the Global Actions list.
+   */
+  | {
+      protocolVersion: GxserverProtocolVersion;
+      revision: GxserverPresentationRevision;
+      serverId: GxserverServerId;
+      type: "globalSidebarCommandsChanged";
+    }
   | GxserverSessionChatSnapshotEvent
   | GxserverSessionChatAppendedEvent
   | GxserverSessionChatReplacedEvent

--- a/shared/session-grid-contract-sidebar.ts
+++ b/shared/session-grid-contract-sidebar.ts
@@ -9,6 +9,7 @@ import type {
   SidebarCommandButton,
   SidebarCommandLink,
   SidebarCommandRunMode,
+  SidebarCommandScope,
 } from "./sidebar-commands";
 import type {
   SidebarGitAction,
@@ -2567,11 +2568,20 @@ export type SidebarToExtensionMessage =
       project, activates that project through the existing focus flow, and only
       then dispatches the trusted launch — the message never gains launch
       metadata or project paths.
+
+      CDXC:GlobalActions 2026-08-07:
+      Project rows also render Global Actions flagged showOnProjectRow, so the
+      selector must say which list its id belongs to: the two scopes are
+      separate id spaces and an id alone cannot pick one. Scope stays optional
+      and absent means project, so senders that only ever run Project Actions
+      are unchanged. A global selector may still carry the row's group id —
+      that names the project the Action runs in, not the list it came from.
       */
       type: "runSidebarCommand";
       commandId: string;
       groupId?: string;
       runMode?: SidebarCommandRunMode;
+      scope?: SidebarCommandScope;
     }
   | {
       type: "endSidebarCommandRun";
@@ -2710,6 +2720,14 @@ export type SidebarToExtensionMessage =
       links?: SidebarCommandLink[];
       name: string;
       playCompletionSound: boolean;
+      /*
+       * CDXC:GlobalActions 2026-08-07:
+       * Settings offers the project-row toggle on Global Actions too, and
+       * gxserver stores it for both lists. The field was missing here, so the
+       * host had nothing to forward and every global save wrote the flag back
+       * as false — the toggle looked saved and did nothing.
+       */
+      showOnProjectRow: boolean;
       command?: string;
       url?: string;
     }

--- a/shared/sidebar-commands.ts
+++ b/shared/sidebar-commands.ts
@@ -47,6 +47,14 @@ export function getSidebarCommandPreviewLabel(command: SidebarCommandButton): st
 
 export type DefaultSidebarCommandId = (typeof DEFAULT_SIDEBAR_COMMANDS)[number]["commandId"];
 export type SidebarActionType = "browser" | "terminal";
+/**
+ * CDXC:GlobalActions 2026-08-07:
+ * Which Actions list a run-by-id selector names. Global and project Actions are
+ * separate id spaces, so a selector carrying only an id is ambiguous once a
+ * surface can run either. Absent means project, which keeps every sender that
+ * predates Global Actions unchanged.
+ */
+export type SidebarCommandScope = "global" | "project";
 export type SidebarCommandRunMode = "default" | "debug";
 export type SidebarCommandLinkTarget = "integrated" | "external";
 
@@ -128,6 +136,10 @@ export function normalizeSidebarCommandLinks(candidate: unknown): SidebarCommand
 
 export function isSidebarCommandRunMode(value: unknown): value is SidebarCommandRunMode {
   return value === "default" || value === "debug";
+}
+
+export function isSidebarCommandScope(value: unknown): value is SidebarCommandScope {
+  return value === "global" || value === "project";
 }
 
 export function getFirstBrowserSidebarCommandUrl(

--- a/sidebar/session-group-section.test.ts
+++ b/sidebar/session-group-section.test.ts
@@ -296,6 +296,64 @@ describe("shouldShowProjectEditorDiffStats", () => {
   });
 });
 
+describe("project row Actions", () => {
+  test("renders Global Actions flagged for the project row, not only project ones", () => {
+    /*
+     * CDXC:GlobalActions 2026-08-07:
+     * Global Actions live in their own HUD list, so a row that reads only
+     * commandsByProject leaves the "Show on the project's sidebar row" toggle
+     * dead for every global. Merge both lists, globals first like Settings.
+     */
+    const rowCommandsStart = sessionGroupSectionSource.indexOf(
+      "const projectRowCommands = useMemo(",
+    );
+    const rowCommandsSource = sessionGroupSectionSource.slice(
+      rowCommandsStart,
+      rowCommandsStart + 600,
+    );
+
+    expect(rowCommandsStart).toBeGreaterThan(-1);
+    expect(sessionGroupSectionSource).toContain(
+      "const globalCommands = useSidebarStore((state) => state.hud.globalCommands);",
+    );
+    expect(rowCommandsSource).toContain(
+      '...(globalCommands ?? []).map((command) => ({ command, scope: "global" }) as const)',
+    );
+    expect(rowCommandsSource).toContain(
+      '...(projectCommands ?? []).map((command) => ({ command, scope: "project" }) as const)',
+    );
+    expect(rowCommandsSource).toContain(".filter((entry) => entry.command.showOnProjectRow)");
+    expect(rowCommandsSource.indexOf("globalCommands ?? []")).toBeLessThan(
+      rowCommandsSource.indexOf("projectCommands ?? []"),
+    );
+  });
+
+  test("keys and runs row Actions by scope so the two id spaces cannot collide", () => {
+    /*
+     * CDXC:GlobalActions 2026-08-07:
+     * Global and project Action ids are separate spaces, so the click must name
+     * the list to resolve against and the React key must stay unique when both
+     * lists hold the same id. The group id keeps naming the project to run in.
+     */
+    const runStart = sessionGroupSectionSource.indexOf(
+      "const requestRunProjectRowCommand = (",
+    );
+    const runSource = sessionGroupSectionSource.slice(runStart, runStart + 900);
+    const buttonStart = sessionGroupSectionSource.indexOf(
+      "projectRowCommands.map(({ command, scope }) => {",
+    );
+    const buttonSource = sessionGroupSectionSource.slice(buttonStart, buttonStart + 900);
+
+    expect(runStart).toBeGreaterThan(-1);
+    expect(buttonStart).toBeGreaterThan(-1);
+    expect(runSource).toContain("scope: SidebarCommandScope,");
+    expect(runSource).toContain("groupId: group.groupId,");
+    expect(runSource).toContain("scope,");
+    expect(buttonSource).toContain("key={`${scope}:${command.commandId}`}");
+    expect(buttonSource).toContain("requestRunProjectRowCommand(command, scope);");
+  });
+});
+
 describe("project diff stats refresh triggers", () => {
   test("does not refresh project git stats from header hover", () => {
     /*

--- a/sidebar/session-group-section.tsx
+++ b/sidebar/session-group-section.tsx
@@ -51,7 +51,7 @@ import {
 } from "../shared/session-grid-contract";
 import type { SidebarProjectDiffStats } from "../shared/project-diff-stats";
 import type { SidebarAgentButton } from "../shared/sidebar-agents";
-import type { SidebarCommandButton } from "../shared/sidebar-commands";
+import type { SidebarCommandButton, SidebarCommandScope } from "../shared/sidebar-commands";
 import { DEFAULT_SIDEBAR_COMMAND_ICON } from "../shared/sidebar-command-icons";
 import { SidebarCommandIconGlyph } from "./sidebar-command-icon";
 import {
@@ -716,9 +716,27 @@ export function SessionGroupSection({
     }
     return state.hud.commandsByProject?.[projectId];
   });
+  /*
+   * CDXC:GlobalActions 2026-08-07:
+   * Global Actions live in their own daemon-owned list, never in
+   * commandsByProject, so reading only the per-project block made the row
+   * toggle dead for them. Merge the two lists here and keep each button's
+   * scope beside it: the scopes are separate id spaces, so the click needs to
+   * say which list its id came from, and React needs a key that cannot
+   * collide when both lists happen to hold the same id.
+   *
+   * Globals render first, matching Settings > Actions, which also lists Global
+   * Actions above the project's own. That order also keeps a global button at
+   * the same spot on every row, since only the project part varies per row.
+   */
+  const globalCommands = useSidebarStore((state) => state.hud.globalCommands);
   const projectRowCommands = useMemo(
-    () => (projectCommands ?? []).filter((command) => command.showOnProjectRow),
-    [projectCommands],
+    () =>
+      [
+        ...(globalCommands ?? []).map((command) => ({ command, scope: "global" }) as const),
+        ...(projectCommands ?? []).map((command) => ({ command, scope: "project" }) as const),
+      ].filter((entry) => entry.command.showOnProjectRow),
+    [globalCommands, projectCommands],
   );
   const orderedSessionIds = orderedSessionIdsProp ?? storedSessionIds;
   const [contextMenuPosition, setContextMenuPosition] = useState<GroupContextMenuPosition>();
@@ -1569,7 +1587,10 @@ export function SessionGroupSection({
     });
   };
 
-  const requestRunProjectRowCommand = (command: SidebarCommandButton) => {
+  const requestRunProjectRowCommand = (
+    command: SidebarCommandButton,
+    scope: SidebarCommandScope,
+  ) => {
     if (!projectContext) {
       return;
     }
@@ -1578,10 +1599,16 @@ export function SessionGroupSection({
      * Row Action clicks stay selector-shaped like the Command Palette: command
      * id plus the row's group id. The host resolves launch metadata from its
      * trusted per-project HUD state and activates the project before running.
+     *
+     * CDXC:GlobalActions 2026-08-07:
+     * The scope names the list to resolve the id against; the group id keeps
+     * meaning the project to run in, so a Global Action clicked on a row runs
+     * in that row's project exactly like a project one.
      */
     vscode.postMessage({
       commandId: command.commandId,
       groupId: group.groupId,
+      scope,
       type: "runSidebarCommand",
     });
   };
@@ -2353,17 +2380,17 @@ export function SessionGroupSection({
                           />
                         </ProjectHeaderActionButton>
                         {projectHeaderActions === "all"
-                          ? projectRowCommands.map((command) => {
+                          ? projectRowCommands.map(({ command, scope }) => {
                               const commandLabel = command.name.trim() || "Run Action";
                               return (
                                 <ProjectHeaderActionButton
                                   aria-label={`Run ${commandLabel} in ${group.title}`}
                                   className="group-add-button group-project-row-command-button"
-                                  key={command.commandId}
+                                  key={`${scope}:${command.commandId}`}
                                   onClick={(event) => {
                                     event.preventDefault();
                                     event.stopPropagation();
-                                    requestRunProjectRowCommand(command);
+                                    requestRunProjectRowCommand(command, scope);
                                   }}
                                   tooltip={commandLabel}
                                   type="button"


### PR DESCRIPTION
From the Discord thread (BANOZZ): a Global Action with "Show on the project's sidebar row" enabled never appeared on any row. The bug had three layers, all fixed here — two in TS, one in the daemon.

## Root causes

1. **The row never read globals.** `session-group-section.tsx` built its row buttons only from `hud.commandsByProject[projectId]`; `hud.globalCommands` lives in a separate daemon table and was never consulted — structurally unreachable.
2. **The toggle never even persisted for globals.** The gpui host's `saveGlobalSidebarCommand` didn't forward `showOnProjectRow` into the mutation (the project save did), so every global save wrote the flag back as `false`. The Settings toggle was offered and silently inert.
3. **The daemon never announced global writes.** A project-Action write schedules a `projectUpdated` presentation delta and the sidebar refetches its HUD on it; a Global-Action write scheduled nothing — and there is no HUD poll (a code comment claimed one; it doesn't exist). The row only converged when some unrelated project event happened to fire. Proven by a red-check: with the broadcast disabled, the test observes the daemon emitting nothing at all for a global save.

## What changes

- The row merges `globalCommands` + per-project commands (each entry carrying its scope; collision-proof React keys; globals render first, matching Settings order).
- The run path gained an optional validated `scope` — unknown scope is an unsupported no-op, never a silent fallback that would run something the user didn't click. A global action clicked on a row runs **in that row's project** (scope picks the list, groupId picks the project); the tab strip's behavior is unchanged.
- `saveGlobalSidebarCommand` forwards `showOnProjectRow`.
- The daemon broadcasts `globalSidebarCommandsChanged` (signal-only, revision-bumped, same shape as the sidebar-collection events; `/api/readSidebarHud` stays the single projection) and the sidebar refreshes on it — Rust + protocol + one subscriber branch.

## Verification

- `cargo check` clean; new Rust test `global_sidebar_command_write_broadcasts_a_hud_change_event` passes (note: running the crate's tests requires the one-line fix in the companion cargo-test PR — `cargo test` doesn't compile at current HEAD without it)
- `bun run typecheck` → exit 0; `bunx vitest run shared/ sidebar/session-group-section.test.ts` → 701/701
- No duplicate rendering is possible: `commandsByProject` is built only from project `customCommands`; globals never appear there.

## To test

Settings → Actions → a Global Action → enable "Show on the project's sidebar row": it appears on every project row and runs in the clicked row's project. The instant appear/disappear needs a rebuilt gxserver (the broadcast is daemon-side); with an old daemon the rendering fix works but updates lag until the next project event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
