### PR TITLE
fix(gxserver): repair the cargo test build

### DIFF
--- a/gxserver-rs/src/agents.rs
+++ b/gxserver-rs/src/agents.rs
@@ -6859,7 +6859,7 @@ mod tests {
         let (temp, db) = open_test_database();
         let repository = DomainRepository::new(&db, "test-server");
         let agent_session_id = "codex-zmx-status-title";
-        let (lifecycle, _session) = create_codex_agent_session(&repository, agent_session_id);
+        let (lifecycle, _session) = create_codex_agent_session(&repository, agent_session_id, temp.path());
         let codex_dir = temp.path().join(".codex");
         std::fs::create_dir_all(&codex_dir).expect("create codex dir");
         std::fs::write(


### PR DESCRIPTION
`cargo test` doesn't compile at current HEAD: one call site in `gxserver-rs/src/agents.rs` passes two arguments to the three-argument test helper `create_codex_agent_session`, while every sibling call passes `temp.path()`. This breaks the test target for the whole crate.

One line: pass `temp.path()` like the siblings.

Verified: `cargo check --tests` → clean (was: compile error).

Found while working on the Global Actions broadcast PR, whose new Rust test needs a compiling test target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
