### PR TITLE
feat(gxserver): board start-work dispatch endpoint and CLI verb

### DIFF
--- a/gxserver-rs/src/board_start_work.rs
+++ b/gxserver-rs/src/board_start_work.rs
@@ -1,0 +1,967 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::{json, Map, Value};
+
+use crate::agents::{
+    apply_created_session_identity, create_agent_session_params_for_project, read_agent_settings,
+};
+use crate::domain::{DomainRepository, DomainStateError};
+use crate::presentation::list_previous_sessions;
+use crate::sidebar_hud::sidebar_agent_buttons_from_projects;
+
+/*
+CDXC:BoardStartWork 2026-08-07:
+`ghostex board start-work <bead-id>` is the daemon-owned dispatch for a Project
+Board card: resolve the bead's board project, reuse any usable linked
+conversation, otherwise create the visible agent session with the canonical
+bead work prompt staged as the first user message and persist the conversation
+link. The endpoint is the dispatch — external orchestrators call it INSTEAD of
+launching a worker themselves, and repeated calls are idempotent
+(`created: false` returns the existing usable session). The caller in server.rs
+serializes calls behind a process-wide gate so two concurrent requests for the
+same bead cannot both observe "no link" and create two workers.
+*/
+
+#[derive(Debug)]
+pub struct StartBoardWorkOutcome {
+    pub created: bool,
+    /// `(projectId, sessionId)` of a newly created session so the caller can
+    /// schedule the presentation delta and start the zmx provider.
+    pub created_session: Option<(String, String)>,
+    pub result: Value,
+}
+
+pub fn start_board_work(
+    repository: &DomainRepository<'_>,
+    db: &rusqlite::Connection,
+    server_id: &str,
+    params: &Map<String, Value>,
+    bd_executable_path: &str,
+) -> Result<StartBoardWorkOutcome, DomainStateError> {
+    let bead_id = read_trimmed(params, "beadId").ok_or_else(|| {
+        DomainStateError::bad_request("startBoardWork requires a bead id.")
+    })?;
+    let projects = repository.list_projects()?;
+    let (board_project, bead) =
+        resolve_board_project_and_bead(&projects, params, &bead_id, bd_executable_path)?;
+    let board_project_id = project_id_of(&board_project)?;
+    let store_projects = select_link_store_projects(&board_project, &projects);
+
+    // Redline 2: any usable linked conversation — live, sleeping, or
+    // restorable — is an idempotent success, never a second worker.
+    if let Some(existing_session_id) =
+        find_usable_linked_session(repository, db, server_id, &store_projects, &bead_id)?
+    {
+        return Ok(StartBoardWorkOutcome {
+            created: false,
+            created_session: None,
+            result: json!({ "created": false, "sessionId": existing_session_id }),
+        });
+    }
+
+    let agent_buttons = board_prompt_agent_options(&projects);
+    let settings = read_agent_settings(db)?;
+    let default_agent_id = settings
+        .get("defaultPromptAgentId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let assignee = read_trimmed_value(&bead, "assignee");
+    let agent_id = resolve_start_work_agent(
+        read_trimmed(params, "agent").or_else(|| read_trimmed(params, "agentId")),
+        assignee.as_deref(),
+        &agent_buttons,
+        &default_agent_id,
+    );
+    let agent_button = agent_buttons.iter().find(|button| {
+        button.get("agentId").and_then(Value::as_str) == Some(agent_id.as_str())
+    });
+
+    let canonical_bead_id = read_trimmed_value(&bead, "id").unwrap_or_else(|| bead_id.clone());
+    let prompt = build_board_bead_work_prompt(
+        &canonical_bead_id,
+        &canonical_bead_id,
+        read_trimmed_value(&bead, "title").as_deref().unwrap_or(""),
+        read_trimmed_value(&bead, "description").as_deref(),
+    );
+
+    // Compose the create-agent path: the same parameter builder and repository
+    // insert `/api/createAgentSession` uses, with the work prompt staged as the
+    // gxserver first user message.
+    let mut create_params = Map::new();
+    create_params.insert("agentId".to_string(), Value::String(agent_id.clone()));
+    create_params.insert(
+        "projectId".to_string(),
+        Value::String(board_project_id.clone()),
+    );
+    create_params.insert("surface".to_string(), Value::String("workspace".to_string()));
+    create_params.insert("requireLaunchCommand".to_string(), Value::Bool(true));
+    let mut launch_settings = Map::new();
+    if let Some(command) = agent_button.and_then(|button| button.get("command")) {
+        launch_settings.insert("agentCommand".to_string(), command.clone());
+    }
+    if let Some(icon) = agent_button.and_then(|button| button.get("icon")) {
+        launch_settings.insert("icon".to_string(), icon.clone());
+    }
+    create_params.insert(
+        "launchSettings".to_string(),
+        Value::Object(launch_settings),
+    );
+    create_params.insert(
+        "runtimeSettings".to_string(),
+        json!({ "firstUserMessage": prompt }),
+    );
+    let normalized = create_agent_session_params_for_project(db, &board_project, &create_params)?;
+    let created_session = repository.create_session(&normalized, false)?;
+    let session = apply_created_session_identity(repository, &created_session, &normalized)?;
+    let session_project_id = read_trimmed_value(&session, "projectId")
+        .ok_or_else(|| DomainStateError::corrupt_state("Session missing projectId."))?;
+    let session_id = read_trimmed_value(&session, "sessionId")
+        .ok_or_else(|| DomainStateError::corrupt_state("Session missing sessionId."))?;
+
+    write_bead_conversation_link(
+        repository,
+        &store_projects,
+        &board_project_id,
+        &canonical_bead_id,
+        &session,
+        &session_project_id,
+        &session_id,
+        agent_button,
+        &agent_id,
+    )?;
+
+    Ok(StartBoardWorkOutcome {
+        created: true,
+        created_session: Some((session_project_id, session_id.clone())),
+        result: json!({ "created": true, "sessionId": session_id }),
+    })
+}
+
+/*
+Board-project resolution mirrors the shared-mount link-store contract in
+shared/bead-conversation-links.ts: rows that mount the same Beads directory
+(projectBoardConfig.beadsDirectory, else the project path) are one board. An
+explicit projectId wins; otherwise every distinct store is probed with
+`bd show` and the bead must live on exactly one of them.
+*/
+fn resolve_board_project_and_bead(
+    projects: &[Value],
+    params: &Map<String, Value>,
+    bead_id: &str,
+    bd_executable_path: &str,
+) -> Result<(Value, Value), DomainStateError> {
+    if let Some(project_id) = read_trimmed(params, "projectId") {
+        let project = projects
+            .iter()
+            .find(|candidate| {
+                candidate.get("projectId").and_then(Value::as_str) == Some(project_id.as_str())
+            })
+            .cloned()
+            .ok_or_else(|| {
+                DomainStateError::not_found(format!("Project {project_id} does not exist."))
+            })?;
+        let store = link_store_key(&project);
+        if store.is_empty() {
+            return Err(DomainStateError::bad_request(format!(
+                "Project {project_id} has no Beads directory."
+            )));
+        }
+        let bead = run_bd_show(bd_executable_path, &store, bead_id)?.ok_or_else(|| {
+            DomainStateError::not_found(format!(
+                "Bead {bead_id} was not found on the {project_id} project board."
+            ))
+        })?;
+        return Ok((project, bead));
+    }
+    let mut matches: Vec<(Value, Value)> = Vec::new();
+    let mut probed: HashMap<String, bool> = HashMap::new();
+    for project in projects {
+        let store = link_store_key(project);
+        if store.is_empty() || probed.contains_key(&store) {
+            continue;
+        }
+        if !Path::new(&store).join(".beads").is_dir() {
+            probed.insert(store, false);
+            continue;
+        }
+        let bead = run_bd_show(bd_executable_path, &store, bead_id)?;
+        let found = bead.is_some();
+        if let Some(bead) = bead {
+            matches.push((project.clone(), bead));
+        }
+        probed.insert(store, found);
+    }
+    match matches.len() {
+        0 => Err(DomainStateError::not_found(format!(
+            "Bead {bead_id} was not found on any project board."
+        ))),
+        1 => Ok(matches.remove(0)),
+        _ => Err(DomainStateError::bad_request(format!(
+            "Bead {bead_id} exists on multiple project boards. Pass --project-id to choose one."
+        ))),
+    }
+}
+
+fn run_bd_show(
+    bd_executable_path: &str,
+    cwd: &str,
+    bead_id: &str,
+) -> Result<Option<Value>, DomainStateError> {
+    let output = Command::new(bd_executable_path)
+        .args(["show", bead_id, "--json"])
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| DomainStateError {
+            code: "internalError",
+            message: format!("Could not run bd show: {error}"),
+        })?;
+    if !output.status.success() {
+        // bd exits nonzero for an unknown issue id; that is "not on this board".
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = match serde_json::from_str(stdout.trim()) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    // bd wraps some results as { data: ... }; unwrap to the issue object.
+    let issue = match parsed {
+        Value::Object(ref object) if object.contains_key("data") => {
+            object.get("data").cloned().unwrap_or(Value::Null)
+        }
+        other => other,
+    };
+    let issue = match issue {
+        Value::Array(items) => items.into_iter().next().unwrap_or(Value::Null),
+        other => other,
+    };
+    Ok(issue.is_object().then_some(issue))
+}
+
+/*
+CDXC:BoardStartWork 2026-08-07:
+Phase 3 agent resolution: an explicit --agent always wins; a bead assignee is
+honored only when it matches a configured board agent's id or name
+case-insensitively (a role-name assignee that matches nothing falls through);
+otherwise the saved default prompt agent runs the card.
+*/
+pub(crate) fn resolve_start_work_agent(
+    explicit_agent: Option<String>,
+    assignee: Option<&str>,
+    agent_buttons: &[Value],
+    default_agent_id: &str,
+) -> String {
+    if let Some(agent) = explicit_agent.filter(|value| !value.is_empty()) {
+        return agent;
+    }
+    if let Some(assignee) = assignee.map(str::trim).filter(|value| !value.is_empty()) {
+        for button in agent_buttons {
+            let agent_id = button.get("agentId").and_then(Value::as_str).unwrap_or("");
+            let name = button.get("name").and_then(Value::as_str).unwrap_or("");
+            if agent_id.eq_ignore_ascii_case(assignee) || name.eq_ignore_ascii_case(assignee) {
+                return agent_id.to_string();
+            }
+        }
+    }
+    default_agent_id.to_string()
+}
+
+/// The configured agents a board prompt can run: the sidebar HUD registry
+/// minus T3 and commandless entries, matching the board's agent dropdown.
+fn board_prompt_agent_options(projects: &[Value]) -> Vec<Value> {
+    sidebar_agent_buttons_from_projects(projects)
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|button| {
+            let agent_id = button.get("agentId").and_then(Value::as_str).unwrap_or("");
+            let command = button.get("command").and_then(Value::as_str).unwrap_or("");
+            agent_id != "t3" && !command.trim().is_empty()
+        })
+        .collect()
+}
+
+/*
+CDXC:BoardStartWork 2026-08-07:
+Rust port of `buildAgentWorkPrompt` in native/sidebar/project-board-shared.ts —
+the canonical bead work prompt. The endpoint owns this copy for the CLI path;
+`native/sidebar/board-start-work-prompt-parity.test.ts` asserts both templates
+stay line-identical so the Rust and TypeScript prompts cannot drift apart
+silently.
+*/
+pub(crate) fn build_board_bead_work_prompt(
+    bead_id: &str,
+    display_id: &str,
+    title: &str,
+    description: Option<&str>,
+) -> String {
+    let description = description
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("No prompt provided.");
+    [
+        format!("Work on bead {bead_id} ({display_id}): {title}"),
+        String::new(),
+        description.to_string(),
+        String::new(),
+        "After each turn where you made progress on this bead, add a bead comment summarizing what you did:".to_string(),
+        format!("- `gx bd comment {bead_id} \"<summary>\"`"),
+        "- Focus on user-facing requirements delivered and high-level technical approach.".to_string(),
+        "- Do not list specific files or line numbers.".to_string(),
+        "- End the comment with `Agent: <agent name>` and `Session: <saved agent CLI session id>` lines so the ticket view can show the agent after the user name and the resumable agent session id at the bottom.".to_string(),
+        String::new(),
+        "Status workflow for this project board:".to_string(),
+        format!("- Park for later: `gx bd update {bead_id} --status backlog`"),
+        format!("- When you start: `gx bd update {bead_id} --status in_progress`"),
+        format!("- When implementation is ready for test: `gx bd update {bead_id} --status test`"),
+        format!("- When ready for review: `gx bd update {bead_id} --status review`"),
+        format!("- When done: `gx bd close {bead_id}`"),
+    ]
+    .join("\n")
+}
+
+fn link_store_key(project: &Value) -> String {
+    let configured = project
+        .get("projectBoardConfig")
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("beadsDirectory"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let directory = configured.or_else(|| project.get("path").and_then(Value::as_str));
+    directory
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn select_link_store_projects(board_project: &Value, projects: &[Value]) -> Vec<Value> {
+    let board_store_key = link_store_key(board_project);
+    let board_project_id = board_project.get("projectId").and_then(Value::as_str);
+    let mut store_projects = vec![board_project.clone()];
+    if board_store_key.is_empty() {
+        return store_projects;
+    }
+    for candidate in projects {
+        if candidate.get("projectId").and_then(Value::as_str) != board_project_id
+            && link_store_key(candidate) == board_store_key
+        {
+            store_projects.push(candidate.clone());
+        }
+    }
+    store_projects
+}
+
+/// Trailing-suffix bead match key from shared/bead-conversation-links.ts:
+/// Beads prefix renames rewrite `zmux-95421485` to `ghostex-95421485`, so
+/// links match on the suffix after the last `-`.
+fn bead_link_match_key(bead_id: &str) -> String {
+    let normalized = bead_id.trim().to_lowercase();
+    match normalized.rfind('-') {
+        Some(index) if index > 0 && index + 1 < normalized.len() => {
+            normalized[index + 1..].to_string()
+        }
+        _ => normalized,
+    }
+}
+
+struct LinkedSessionReference {
+    project_id: String,
+    session_id: String,
+    updated_at: String,
+}
+
+fn read_active_bead_links(store_projects: &[Value], bead_id: &str) -> Vec<LinkedSessionReference> {
+    let match_key = bead_link_match_key(bead_id);
+    let mut references = Vec::new();
+    for project in store_projects {
+        let store_project_id = project
+            .get("projectId")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let links = project
+            .get("projectBoardConfig")
+            .and_then(Value::as_object)
+            .and_then(|config| config.get("beadConversationLinks"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for link in links {
+            let link_bead_id = link.get("beadId").and_then(Value::as_str).unwrap_or("");
+            let ghostex_session_id = link
+                .get("ghostexSessionId")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if link_bead_id.is_empty()
+                || ghostex_session_id.is_empty()
+                || bead_link_match_key(link_bead_id) != match_key
+                || link.get("status").and_then(Value::as_str) == Some("archived")
+            {
+                continue;
+            }
+            let (project_id, session_id) = resolve_link_session_reference(
+                &link,
+                ghostex_session_id,
+                store_project_id,
+            );
+            references.push(LinkedSessionReference {
+                project_id,
+                session_id,
+                updated_at: link
+                    .get("updatedAt")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            });
+        }
+    }
+    // Prefer the most recently updated conversation, like the board does.
+    references.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    references
+}
+
+/// Session-owner resolution order from shared/bead-conversation-links.ts:
+/// a `combined-session:` scoped id, then the explicit `sessionProjectId`
+/// written since PR #87, then the legacy zmx persistence name, then the
+/// storing row as the last resort.
+fn resolve_link_session_reference(
+    link: &Value,
+    ghostex_session_id: &str,
+    store_project_id: &str,
+) -> (String, String) {
+    if let Some((project_id, session_id)) = parse_scoped_session_id(ghostex_session_id) {
+        return (project_id, session_id);
+    }
+    if let Some(session_project_id) = read_trimmed_value(link, "sessionProjectId") {
+        return (session_project_id, ghostex_session_id.to_string());
+    }
+    if let Some(persistence_name) = read_trimmed_value(link, "sessionPersistenceName") {
+        let parts: Vec<&str> = persistence_name.split('-').collect();
+        if parts.len() == 3
+            && parts[0].starts_with('S')
+            && parts[1].starts_with('P')
+            && parts[2].starts_with('G')
+            && parts[2] == ghostex_session_id
+        {
+            return (parts[1].to_string(), parts[2].to_string());
+        }
+    }
+    let link_project_id = read_trimmed_value(link, "projectId")
+        .unwrap_or_else(|| store_project_id.to_string());
+    (link_project_id, ghostex_session_id.to_string())
+}
+
+fn parse_scoped_session_id(session_id: &str) -> Option<(String, String)> {
+    let payload = session_id.strip_prefix("combined-session:")?;
+    let separator = payload.find(':')?;
+    Some((
+        percent_decode(&payload[..separator]),
+        percent_decode(&payload[separator + 1..]),
+    ))
+}
+
+fn percent_decode(value: &str) -> String {
+    if !value.contains('%') {
+        return value.to_string();
+    }
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(&value[index + 1..index + 3], 16) {
+                decoded.push(byte);
+                index += 3;
+                continue;
+            }
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+/*
+Redline 2's "usable" definition, evaluated daemon-side: a linked conversation
+whose session row still exists (live or sleeping, in any project) is reused
+directly; a link whose row is gone is still usable when the daemon's
+previous-session history can restore it — the same restore contract the board's
+resumable-link affordance reads.
+*/
+fn find_usable_linked_session(
+    repository: &DomainRepository<'_>,
+    db: &rusqlite::Connection,
+    server_id: &str,
+    store_projects: &[Value],
+    bead_id: &str,
+) -> Result<Option<String>, DomainStateError> {
+    for reference in read_active_bead_links(store_projects, bead_id) {
+        if repository
+            .get_session(&reference.project_id, &reference.session_id)?
+            .is_some()
+        {
+            return Ok(Some(reference.session_id));
+        }
+        let mut previous_params = Map::new();
+        previous_params.insert(
+            "projectId".to_string(),
+            Value::String(reference.project_id.clone()),
+        );
+        previous_params.insert(
+            "query".to_string(),
+            Value::String(reference.session_id.clone()),
+        );
+        previous_params.insert("limit".to_string(), json!(20));
+        let previous = list_previous_sessions(db, server_id, &previous_params)?;
+        let restorable = previous
+            .get("results")
+            .and_then(Value::as_array)
+            .is_some_and(|results| {
+                results.iter().any(|row| {
+                    row.get("sessionId").and_then(Value::as_str)
+                        == Some(reference.session_id.as_str())
+                })
+            });
+        if restorable {
+            return Ok(Some(reference.session_id));
+        }
+    }
+    Ok(None)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_bead_conversation_link(
+    repository: &DomainRepository<'_>,
+    store_projects: &[Value],
+    board_project_id: &str,
+    bead_id: &str,
+    session: &Value,
+    session_project_id: &str,
+    session_id: &str,
+    agent_button: Option<&Value>,
+    agent_id: &str,
+) -> Result<(), DomainStateError> {
+    // Writes stay on the board's own row (shared-mount reads span the rows).
+    let link_project = store_projects
+        .iter()
+        .find(|project| {
+            project.get("projectId").and_then(Value::as_str) == Some(board_project_id)
+        })
+        .cloned()
+        .ok_or_else(|| DomainStateError::corrupt_state("Board project missing from store."))?;
+    let ghostex_session_id = if session_project_id == board_project_id {
+        session_id.to_string()
+    } else {
+        format!("combined-session:{session_project_id}:{session_id}")
+    };
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let link_id = [board_project_id, bead_id, &ghostex_session_id]
+        .iter()
+        .map(|part| sanitize_link_id_part(part))
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(":");
+    let mut link = Map::new();
+    link.insert("agentId".to_string(), Value::String(agent_id.to_string()));
+    if let Some(name) = agent_button.and_then(|button| button.get("name")).cloned() {
+        link.insert("agentName".to_string(), name);
+    }
+    if let Some(agent_session_id) = read_trimmed_value(session, "agentSessionId") {
+        link.insert("agentSessionId".to_string(), Value::String(agent_session_id));
+    }
+    if let Some(agent_session_path) = read_trimmed_value(session, "agentSessionPath") {
+        link.insert(
+            "agentSessionPath".to_string(),
+            Value::String(agent_session_path),
+        );
+    }
+    link.insert("beadDisplayId".to_string(), Value::String(bead_id.to_string()));
+    link.insert("beadId".to_string(), Value::String(bead_id.to_string()));
+    link.insert("createdAt".to_string(), Value::String(now.clone()));
+    link.insert(
+        "ghostexSessionId".to_string(),
+        Value::String(ghostex_session_id),
+    );
+    link.insert("id".to_string(), Value::String(link_id.clone()));
+    link.insert(
+        "projectId".to_string(),
+        Value::String(board_project_id.to_string()),
+    );
+    if let Some(zmx_name) = read_trimmed_value(session, "zmxName") {
+        link.insert("sessionPersistenceName".to_string(), Value::String(zmx_name));
+    }
+    link.insert(
+        "sessionPersistenceProvider".to_string(),
+        Value::String("zmx".to_string()),
+    );
+    link.insert(
+        "sessionProjectId".to_string(),
+        Value::String(session_project_id.to_string()),
+    );
+    link.insert("status".to_string(), Value::String("active".to_string()));
+    link.insert("updatedAt".to_string(), Value::String(now));
+
+    let mut board_config = link_project
+        .get("projectBoardConfig")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut links = board_config
+        .get("beadConversationLinks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(existing) = links.iter_mut().find(|existing| {
+        existing.get("id").and_then(Value::as_str) == Some(link_id.as_str())
+    }) {
+        let created_at = existing.get("createdAt").cloned();
+        let mut merged = existing.as_object().cloned().unwrap_or_default();
+        for (key, value) in &link {
+            merged.insert(key.clone(), value.clone());
+        }
+        if let Some(created_at) = created_at {
+            merged.insert("createdAt".to_string(), created_at);
+        }
+        *existing = Value::Object(merged);
+    } else {
+        links.push(Value::Object(link));
+    }
+    board_config.insert("beadConversationLinks".to_string(), Value::Array(links));
+    let mut update = Map::new();
+    update.insert(
+        "projectId".to_string(),
+        Value::String(board_project_id.to_string()),
+    );
+    update.insert(
+        "projectBoardConfig".to_string(),
+        Value::Object(board_config),
+    );
+    repository.update_project(&update)?;
+    Ok(())
+}
+
+fn sanitize_link_id_part(part: &str) -> String {
+    // Port of createBeadConversationLinkId's `[^a-z0-9_-]+` → `-` collapse.
+    let mut sanitized = String::with_capacity(part.len());
+    let mut previous_was_dash = false;
+    for character in part.trim().chars() {
+        if character.is_ascii_alphanumeric() || character == '_' || character == '-' {
+            sanitized.push(character);
+            previous_was_dash = false;
+        } else if !previous_was_dash {
+            sanitized.push('-');
+            previous_was_dash = true;
+        }
+    }
+    sanitized.trim_matches('-').to_string()
+}
+
+fn project_id_of(project: &Value) -> Result<String, DomainStateError> {
+    read_trimmed_value(project, "projectId")
+        .ok_or_else(|| DomainStateError::corrupt_state("Project missing projectId."))
+}
+
+fn read_trimmed(params: &Map<String, Value>, key: &str) -> Option<String> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn read_trimmed_value(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        paths::get_gxserver_paths,
+        storage::{initialize_gxserver_storage, open_gxserver_database},
+    };
+    use std::fs;
+    use std::sync::{Arc, Barrier, Mutex};
+
+    const TEST_SERVER_ID: &str = "S7k";
+    const TEST_BEAD_ID: &str = "gx-95421499";
+
+    struct TestBoard {
+        _temp: tempfile::TempDir,
+        paths: crate::paths::GxserverPaths,
+        bd_path: String,
+        project_id: String,
+    }
+
+    fn make_executable(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(path).expect("bd metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("bd permissions");
+    }
+
+    /// A board fixture: gxserver storage in a tempdir (explicit home, no HOME
+    /// override), one project whose beadsDirectory holds a fake `.beads`
+    /// workspace, and a fake `bd` that knows exactly one bead.
+    fn create_test_board(assignee: Option<&str>) -> TestBoard {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = get_gxserver_paths(Some(temp.path().to_path_buf()));
+        if let Some(config_dir) = paths.config_file.parent() {
+            fs::create_dir_all(config_dir).expect("config dir");
+        }
+        initialize_gxserver_storage(&paths).expect("storage init");
+
+        let board_dir = temp.path().join("board");
+        fs::create_dir_all(board_dir.join(".beads")).expect("board dir");
+        let repo_dir = temp.path().join("repo");
+        fs::create_dir_all(&repo_dir).expect("repo dir");
+
+        let assignee_field = assignee
+            .map(|value| format!("\"assignee\":\"{value}\","))
+            .unwrap_or_default();
+        let bd_path = temp.path().join("bd");
+        fs::write(
+            &bd_path,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = \"show\" ] && [ \"$2\" = \"{TEST_BEAD_ID}\" ]; then\n  echo '{{\"data\":{{\"id\":\"{TEST_BEAD_ID}\",\"title\":\"Fix the flux capacitor\",{assignee_field}\"description\":\"Reverse the polarity.\",\"status\":\"open\"}}}}'\n  exit 0\nfi\necho 'issue not found' >&2\nexit 1\n"
+            ),
+        )
+        .expect("write bd");
+        make_executable(&bd_path);
+
+        let db = open_gxserver_database(&paths).expect("open db");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+        let project = repository
+            .create_project(
+                json!({
+                    "name": "Board",
+                    "path": repo_dir.to_string_lossy(),
+                    "projectBoardConfig": { "beadsDirectory": board_dir.to_string_lossy() },
+                })
+                .as_object()
+                .expect("project params"),
+            )
+            .expect("project created");
+        let project_id = project
+            .get("projectId")
+            .and_then(Value::as_str)
+            .expect("projectId")
+            .to_string();
+        TestBoard {
+            _temp: temp,
+            paths,
+            bd_path: bd_path.to_string_lossy().to_string(),
+            project_id,
+        }
+    }
+
+    fn run_start_board_work(
+        board: &TestBoard,
+        params: &Map<String, Value>,
+    ) -> Result<StartBoardWorkOutcome, DomainStateError> {
+        let db = open_gxserver_database(&board.paths).expect("open db");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+        start_board_work(&repository, &db, TEST_SERVER_ID, params, &board.bd_path)
+    }
+
+    fn bead_params() -> Map<String, Value> {
+        let mut params = Map::new();
+        params.insert("beadId".to_string(), json!(TEST_BEAD_ID));
+        params
+    }
+
+    fn read_board_links(board: &TestBoard) -> Vec<Value> {
+        let db = open_gxserver_database(&board.paths).expect("open db");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+        let projects = repository.list_projects().expect("projects");
+        projects
+            .iter()
+            .find(|project| {
+                project.get("projectId").and_then(Value::as_str)
+                    == Some(board.project_id.as_str())
+            })
+            .and_then(|project| project.get("projectBoardConfig"))
+            .and_then(|config| config.get("beadConversationLinks"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn start_board_work_creates_session_link_and_prompt() {
+        let board = create_test_board(None);
+        let outcome = run_start_board_work(&board, &bead_params()).expect("start work");
+        assert!(outcome.created);
+        let session_id = outcome
+            .result
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .expect("sessionId")
+            .to_string();
+        assert_eq!(outcome.result.get("created"), Some(&json!(true)));
+
+        let db = open_gxserver_database(&board.paths).expect("open db");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+        let session = repository
+            .get_session(&board.project_id, &session_id)
+            .expect("session lookup")
+            .expect("session exists");
+        assert_eq!(session.get("kind"), Some(&json!("agent")));
+        let first_user_message = session
+            .get("runtimeSettings")
+            .and_then(|settings| settings.get("firstUserMessage"))
+            .and_then(Value::as_str)
+            .expect("staged prompt");
+        assert!(first_user_message
+            .starts_with(&format!("Work on bead {TEST_BEAD_ID} ({TEST_BEAD_ID}): Fix the flux capacitor")));
+        assert!(first_user_message.contains("Reverse the polarity."));
+        assert!(first_user_message.contains(&format!("`gx bd close {TEST_BEAD_ID}`")));
+
+        let links = read_board_links(&board);
+        assert_eq!(links.len(), 1);
+        let link = &links[0];
+        assert_eq!(link.get("beadId"), Some(&json!(TEST_BEAD_ID)));
+        assert_eq!(link.get("ghostexSessionId"), Some(&json!(session_id)));
+        assert_eq!(link.get("sessionProjectId"), Some(&json!(board.project_id)));
+        assert_eq!(link.get("status"), Some(&json!("active")));
+    }
+
+    #[test]
+    fn start_board_work_reuses_existing_usable_linked_session() {
+        let board = create_test_board(None);
+        let first = run_start_board_work(&board, &bead_params()).expect("first start");
+        let first_session_id = first
+            .result
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .expect("sessionId")
+            .to_string();
+
+        let second = run_start_board_work(&board, &bead_params()).expect("second start");
+        assert!(!second.created);
+        assert!(second.created_session.is_none());
+        assert_eq!(second.result.get("created"), Some(&json!(false)));
+        assert_eq!(
+            second.result.get("sessionId"),
+            Some(&json!(first_session_id))
+        );
+        assert_eq!(read_board_links(&board).len(), 1);
+    }
+
+    #[test]
+    fn start_board_work_serializes_concurrent_calls_into_one_session() {
+        // The endpoint-level race guard: both callers run the full
+        // check-then-create sequence, but behind the shared gate the second
+        // observes the first call's link and reuses its session.
+        let board = Arc::new(create_test_board(None));
+        let gate = Arc::new(Mutex::new(()));
+        let barrier = Arc::new(Barrier::new(2));
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let board = Arc::clone(&board);
+            let gate = Arc::clone(&gate);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                let _guard = gate.lock().expect("gate");
+                run_start_board_work(&board, &bead_params()).expect("start work")
+            }));
+        }
+        let outcomes: Vec<StartBoardWorkOutcome> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread"))
+            .collect();
+        let created_count = outcomes.iter().filter(|outcome| outcome.created).count();
+        assert_eq!(created_count, 1);
+        let session_ids: Vec<&str> = outcomes
+            .iter()
+            .map(|outcome| {
+                outcome
+                    .result
+                    .get("sessionId")
+                    .and_then(Value::as_str)
+                    .expect("sessionId")
+            })
+            .collect();
+        assert_eq!(session_ids[0], session_ids[1]);
+        assert_eq!(read_board_links(&board).len(), 1);
+    }
+
+    #[test]
+    fn start_board_work_rejects_unknown_bead() {
+        let board = create_test_board(None);
+        let mut params = Map::new();
+        params.insert("beadId".to_string(), json!("gx-does-not-exist"));
+        let error = run_start_board_work(&board, &params).expect_err("unknown bead");
+        assert_eq!(error.code, "notFound");
+        assert!(error.message.contains("gx-does-not-exist"));
+    }
+
+    #[test]
+    fn start_board_work_uses_matching_assignee_agent() {
+        let board = create_test_board(Some("Claude"));
+        let outcome = run_start_board_work(&board, &bead_params()).expect("start work");
+        let session_id = outcome
+            .result
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .expect("sessionId")
+            .to_string();
+        let db = open_gxserver_database(&board.paths).expect("open db");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+        let session = repository
+            .get_session(&board.project_id, &session_id)
+            .expect("session lookup")
+            .expect("session exists");
+        assert_eq!(session.get("agentId"), Some(&json!("claude")));
+    }
+
+    #[test]
+    fn resolve_start_work_agent_follows_documented_chain() {
+        let agents = vec![
+            json!({ "agentId": "claude", "command": "claude", "name": "Claude" }),
+            json!({ "agentId": "codex", "command": "codex", "name": "Codex" }),
+        ];
+        // 1. Explicit --agent always wins.
+        assert_eq!(
+            resolve_start_work_agent(Some("codex".to_string()), Some("Claude"), &agents, "claude"),
+            "codex"
+        );
+        // 2. Assignee matches a configured agent id or name case-insensitively.
+        assert_eq!(
+            resolve_start_work_agent(None, Some("CLAUDE"), &agents, "codex"),
+            "claude"
+        );
+        assert_eq!(
+            resolve_start_work_agent(None, Some("Codex"), &agents, "claude"),
+            "codex"
+        );
+        // 3. A role-name assignee that matches nothing falls through to the
+        //    project default.
+        assert_eq!(
+            resolve_start_work_agent(None, Some("Researcher"), &agents, "codex"),
+            "codex"
+        );
+        assert_eq!(resolve_start_work_agent(None, None, &agents, "codex"), "codex");
+    }
+
+    #[test]
+    fn board_bead_work_prompt_matches_the_board_template() {
+        let prompt = build_board_bead_work_prompt("gx-12", "gx-12", "Do the thing", None);
+        assert!(prompt.starts_with("Work on bead gx-12 (gx-12): Do the thing"));
+        assert!(prompt.contains("No prompt provided."));
+        assert!(prompt.contains("- `gx bd comment gx-12 \"<summary>\"`"));
+        assert!(prompt.contains("- When done: `gx bd close gx-12`"));
+    }
+}

--- a/gxserver-rs/src/board_start_work.rs
+++ b/gxserver-rs/src/board_start_work.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use rusqlite::{Transaction, TransactionBehavior};
 use serde_json::{json, Map, Value};
 
 use crate::agents::{
@@ -130,15 +131,27 @@ pub fn start_board_work(
         json!({ "firstUserMessage": prompt }),
     );
     let normalized = create_agent_session_params_for_project(db, &board_project, &create_params)?;
-    let created_session = repository.create_session(&normalized, false)?;
-    let session = apply_created_session_identity(repository, &created_session, &normalized)?;
+    // Session identity and its board link are one durable operation. If link
+    // persistence fails, rolling back the transaction prevents an unlinked
+    // worker from being left behind for the next retry to duplicate.
+    let transaction =
+        Transaction::new_unchecked(db, TransactionBehavior::Immediate).map_err(|error| {
+            DomainStateError {
+                code: "internalError",
+                message: format!("Could not start board-work transaction: {error}"),
+            }
+        })?;
+    let transaction_repository = DomainRepository::new(&transaction, server_id);
+    let created_session = transaction_repository.create_session(&normalized, false)?;
+    let session =
+        apply_created_session_identity(&transaction_repository, &created_session, &normalized)?;
     let session_project_id = read_trimmed_value(&session, "projectId")
         .ok_or_else(|| DomainStateError::corrupt_state("Session missing projectId."))?;
     let session_id = read_trimmed_value(&session, "sessionId")
         .ok_or_else(|| DomainStateError::corrupt_state("Session missing sessionId."))?;
 
     write_bead_conversation_link(
-        repository,
+        &transaction_repository,
         &board_project_id,
         &canonical_bead_id,
         &session,
@@ -147,6 +160,11 @@ pub fn start_board_work(
         agent_button,
         &agent_id,
     )?;
+    drop(transaction_repository);
+    transaction.commit().map_err(|error| DomainStateError {
+        code: "internalError",
+        message: format!("Could not commit board-work transaction: {error}"),
+    })?;
 
     Ok(StartBoardWorkOutcome {
         created: true,
@@ -936,6 +954,39 @@ mod tests {
         assert_eq!(link.get("ghostexSessionId"), Some(&json!(session_id)));
         assert_eq!(link.get("sessionProjectId"), Some(&json!(board.project_id)));
         assert_eq!(link.get("status"), Some(&json!("active")));
+    }
+
+    #[test]
+    fn start_board_work_rolls_back_session_when_link_persistence_fails() {
+        let board = create_test_board(None);
+        let db = open_gxserver_database(&board.paths).expect("open db");
+        db.execute_batch(
+            r#"
+            CREATE TEMP TRIGGER fail_board_link_update
+            BEFORE UPDATE OF projectBoardConfigJson ON projects
+            BEGIN
+              SELECT RAISE(ABORT, 'forced board-link persistence failure');
+            END;
+            "#,
+        )
+        .expect("install failure trigger");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+
+        let error = start_board_work(
+            &repository,
+            &db,
+            TEST_SERVER_ID,
+            &bead_params(),
+            &board.bd_path,
+        )
+        .expect_err("link persistence must fail");
+
+        assert_eq!(error.code, "internalError");
+        assert!(repository
+            .list_sessions(Some(&board.project_id))
+            .expect("sessions")
+            .is_empty());
+        assert!(read_board_links(&board).is_empty());
     }
 
     #[test]

--- a/gxserver-rs/src/board_start_work.rs
+++ b/gxserver-rs/src/board_start_work.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Map, Value};
 
@@ -24,15 +27,19 @@ serializes calls behind a process-wide gate so two concurrent requests for the
 same bead cannot both observe "no link" and create two workers.
 */
 
+/// Result of resolving and dispatching one Project Board bead.
 #[derive(Debug)]
 pub struct StartBoardWorkOutcome {
+    /// Whether this request created a new worker session.
     pub created: bool,
     /// `(projectId, sessionId)` of a newly created session so the caller can
     /// schedule the presentation delta and start the zmx provider.
     pub created_session: Option<(String, String)>,
+    /// RPC payload returned to the caller.
     pub result: Value,
 }
 
+/// Resolve a board bead and reuse or create its linked worker session.
 pub fn start_board_work(
     repository: &DomainRepository<'_>,
     db: &rusqlite::Connection,
@@ -51,13 +58,17 @@ pub fn start_board_work(
 
     // Redline 2: any usable linked conversation — live, sleeping, or
     // restorable — is an idempotent success, never a second worker.
-    if let Some(existing_session_id) =
+    if let Some((existing_project_id, existing_session_id)) =
         find_usable_linked_session(repository, db, server_id, &store_projects, &bead_id)?
     {
         return Ok(StartBoardWorkOutcome {
             created: false,
             created_session: None,
-            result: json!({ "created": false, "sessionId": existing_session_id }),
+            result: json!({
+                "created": false,
+                "projectId": existing_project_id,
+                "sessionId": existing_session_id,
+            }),
         });
     }
 
@@ -75,6 +86,11 @@ pub fn start_board_work(
         &agent_buttons,
         &default_agent_id,
     );
+    if agent_id.is_empty() {
+        return Err(DomainStateError::bad_request(
+            "No agent was resolved for this bead. Pass --agent or set a default prompt agent.",
+        ));
+    }
     let agent_button = agent_buttons.iter().find(|button| {
         button.get("agentId").and_then(Value::as_str) == Some(agent_id.as_str())
     });
@@ -123,7 +139,6 @@ pub fn start_board_work(
 
     write_bead_conversation_link(
         repository,
-        &store_projects,
         &board_project_id,
         &canonical_bead_id,
         &session,
@@ -135,8 +150,12 @@ pub fn start_board_work(
 
     Ok(StartBoardWorkOutcome {
         created: true,
-        created_session: Some((session_project_id, session_id.clone())),
-        result: json!({ "created": true, "sessionId": session_id }),
+        created_session: Some((session_project_id.clone(), session_id.clone())),
+        result: json!({
+            "created": true,
+            "projectId": session_project_id,
+            "sessionId": session_id,
+        }),
     })
 }
 
@@ -210,19 +229,75 @@ fn run_bd_show(
     cwd: &str,
     bead_id: &str,
 ) -> Result<Option<Value>, DomainStateError> {
-    let output = Command::new(bd_executable_path)
+    const BD_SHOW_TIMEOUT: Duration = Duration::from_secs(10);
+
+    let mut command = Command::new(bd_executable_path);
+    command
         .args(["show", bead_id, "--json"])
         .current_dir(cwd)
-        .output()
-        .map_err(|error| DomainStateError {
-            code: "internalError",
-            message: format!("Could not run bd show: {error}"),
-        })?;
-    if !output.status.success() {
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut child = command.spawn().map_err(|error| DomainStateError {
+        code: "internalError",
+        message: format!("Could not run bd show: {error}"),
+    })?;
+    let mut stdout_reader = child.stdout.take().map(|mut stdout| {
+        thread::spawn(move || {
+            let mut output = Vec::new();
+            stdout.read_to_end(&mut output).map(|_| output)
+        })
+    });
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() >= BD_SHOW_TIMEOUT => {
+                let _ = child.kill();
+                let _ = child.wait();
+                if let Some(reader) = stdout_reader.take() {
+                    let _ = reader.join();
+                }
+                return Err(DomainStateError {
+                    code: "internalError",
+                    message: format!(
+                        "bd show timed out after {} seconds.",
+                        BD_SHOW_TIMEOUT.as_secs()
+                    ),
+                });
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                if let Some(reader) = stdout_reader.take() {
+                    let _ = reader.join();
+                }
+                return Err(DomainStateError {
+                    code: "internalError",
+                    message: format!("Could not wait for bd show: {error}"),
+                });
+            }
+        }
+    };
+    let output = match stdout_reader {
+        Some(reader) => reader
+            .join()
+            .map_err(|_| DomainStateError {
+                code: "internalError",
+                message: "bd show output reader panicked.".to_string(),
+            })?
+            .map_err(|error| DomainStateError {
+                code: "internalError",
+                message: format!("Could not read bd show output: {error}"),
+            })?,
+        None => Vec::new(),
+    };
+    if !status.success() {
         // bd exits nonzero for an unknown issue id; that is "not on this board".
         return Ok(None);
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = String::from_utf8_lossy(&output);
     let parsed: Value = match serde_json::from_str(stdout.trim()) {
         Ok(value) => value,
         Err(_) => return Ok(None),
@@ -248,6 +323,7 @@ honored only when it matches a configured board agent's id or name
 case-insensitively (a role-name assignee that matches nothing falls through);
 otherwise the saved default prompt agent runs the card.
 */
+/// Choose the explicit, assignee-matched, or configured default agent.
 pub(crate) fn resolve_start_work_agent(
     explicit_agent: Option<String>,
     assignee: Option<&str>,
@@ -293,6 +369,7 @@ the canonical bead work prompt. The endpoint owns this copy for the CLI path;
 stay line-identical so the Rust and TypeScript prompts cannot drift apart
 silently.
 */
+/// Render the canonical Project Board worker prompt.
 pub(crate) fn build_board_bead_work_prompt(
     bead_id: &str,
     display_id: &str,
@@ -499,13 +576,13 @@ fn find_usable_linked_session(
     server_id: &str,
     store_projects: &[Value],
     bead_id: &str,
-) -> Result<Option<String>, DomainStateError> {
+) -> Result<Option<(String, String)>, DomainStateError> {
     for reference in read_active_bead_links(store_projects, bead_id) {
         if repository
             .get_session(&reference.project_id, &reference.session_id)?
             .is_some()
         {
-            return Ok(Some(reference.session_id));
+            return Ok(Some((reference.project_id, reference.session_id)));
         }
         let mut previous_params = Map::new();
         previous_params.insert(
@@ -528,7 +605,7 @@ fn find_usable_linked_session(
                 })
             });
         if restorable {
-            return Ok(Some(reference.session_id));
+            return Ok(Some((reference.project_id, reference.session_id)));
         }
     }
     Ok(None)
@@ -537,7 +614,6 @@ fn find_usable_linked_session(
 #[allow(clippy::too_many_arguments)]
 fn write_bead_conversation_link(
     repository: &DomainRepository<'_>,
-    store_projects: &[Value],
     board_project_id: &str,
     bead_id: &str,
     session: &Value,
@@ -547,12 +623,9 @@ fn write_bead_conversation_link(
     agent_id: &str,
 ) -> Result<(), DomainStateError> {
     // Writes stay on the board's own row (shared-mount reads span the rows).
-    let link_project = store_projects
-        .iter()
-        .find(|project| {
-            project.get("projectId").and_then(Value::as_str) == Some(board_project_id)
-        })
-        .cloned()
+    // Re-read the row so a concurrent projectBoardConfig write is not lost.
+    let link_project = repository
+        .get_project(board_project_id)?
         .ok_or_else(|| DomainStateError::corrupt_state("Board project missing from store."))?;
     let ghostex_session_id = if session_project_id == board_project_id {
         session_id.to_string()
@@ -781,6 +854,30 @@ mod tests {
         params
     }
 
+    fn add_board_project(board: &TestBoard, name: &str) -> String {
+        let board_dir = board._temp.path().join(format!("{name}-board"));
+        fs::create_dir_all(board_dir.join(".beads")).expect("second board dir");
+        let repo_dir = board._temp.path().join(format!("{name}-repo"));
+        fs::create_dir_all(&repo_dir).expect("second repo dir");
+        let db = open_gxserver_database(&board.paths).expect("open db");
+        let repository = DomainRepository::new(&db, TEST_SERVER_ID);
+        repository
+            .create_project(
+                json!({
+                    "name": name,
+                    "path": repo_dir.to_string_lossy(),
+                    "projectBoardConfig": { "beadsDirectory": board_dir.to_string_lossy() },
+                })
+                .as_object()
+                .expect("project params"),
+            )
+            .expect("second project created")
+            .get("projectId")
+            .and_then(Value::as_str)
+            .expect("second projectId")
+            .to_string()
+    }
+
     fn read_board_links(board: &TestBoard) -> Vec<Value> {
         let db = open_gxserver_database(&board.paths).expect("open db");
         let repository = DomainRepository::new(&db, TEST_SERVER_ID);
@@ -810,6 +907,10 @@ mod tests {
             .expect("sessionId")
             .to_string();
         assert_eq!(outcome.result.get("created"), Some(&json!(true)));
+        assert_eq!(
+            outcome.result.get("projectId"),
+            Some(&json!(board.project_id))
+        );
 
         let db = open_gxserver_database(&board.paths).expect("open db");
         let repository = DomainRepository::new(&db, TEST_SERVER_ID);
@@ -856,7 +957,34 @@ mod tests {
             second.result.get("sessionId"),
             Some(&json!(first_session_id))
         );
+        assert_eq!(
+            second.result.get("projectId"),
+            Some(&json!(board.project_id))
+        );
         assert_eq!(read_board_links(&board).len(), 1);
+    }
+
+    #[test]
+    fn start_board_work_uses_explicit_project_when_bead_exists_on_multiple_boards() {
+        let board = create_test_board(None);
+        let second_project_id = add_board_project(&board, "Second");
+        let mut params = bead_params();
+        params.insert("projectId".to_string(), json!(second_project_id));
+
+        let outcome = run_start_board_work(&board, &params).expect("explicit board start");
+
+        assert_eq!(outcome.result.get("projectId"), Some(&json!(second_project_id)));
+    }
+
+    #[test]
+    fn start_board_work_rejects_ambiguous_unqualified_bead() {
+        let board = create_test_board(None);
+        add_board_project(&board, "Second");
+
+        let error = run_start_board_work(&board, &bead_params()).expect_err("ambiguous bead");
+
+        assert_eq!(error.code, "badRequest");
+        assert!(error.message.contains("exists on multiple project boards"));
     }
 
     #[test]

--- a/gxserver-rs/src/ghostex_cli/board.rs
+++ b/gxserver-rs/src/ghostex_cli/board.rs
@@ -12,8 +12,9 @@ so external orchestrators dispatch a Project Board card through the daemon
 instead of launching a worker session themselves. The daemon owns bead
 resolution, the idempotent reuse guard, the canonical work prompt, and the
 conversation link; the CLI only ships the parameters and prints the JSON
-result (`{ sessionId, created }`).
+result (`{ projectId, sessionId, created }`).
 */
+/// Dispatch a Ghostex Project Board CLI subcommand.
 pub fn board_command(args: &[String]) -> CliResult<()> {
     match args.first().map(String::as_str) {
         Some("start-work") => start_work_command(&args[1..]),
@@ -72,11 +73,9 @@ fn start_work_command(args: &[String]) -> CliResult<()> {
         &Value::Object(payload),
         &parsed.flags,
     )?;
-    if is_failed_cli_result(&result) {
-        print_json(&result);
-        crate::ghostex_cli::set_exit_code(1);
-        return Ok(());
-    }
     print_json(&result);
+    if is_failed_cli_result(&result) {
+        crate::ghostex_cli::set_exit_code(1);
+    }
     Ok(())
 }

--- a/gxserver-rs/src/ghostex_cli/board.rs
+++ b/gxserver-rs/src/ghostex_cli/board.rs
@@ -1,0 +1,82 @@
+use serde_json::{Map, Value};
+
+use crate::ghostex_cli::args::parse_args;
+use crate::ghostex_cli::output::{is_failed_cli_result, print_json};
+use crate::ghostex_cli::rpc::{call_gxserver_rpc, CliError, CliResult};
+
+/*
+CDXC:BoardStartWork 2026-08-07:
+`ghostex board start-work <bead-id>` is the CLI face of gxserver's
+`/api/startBoardWork`: a thin wrapper like `run-action` and `create-agent`,
+so external orchestrators dispatch a Project Board card through the daemon
+instead of launching a worker session themselves. The daemon owns bead
+resolution, the idempotent reuse guard, the canonical work prompt, and the
+conversation link; the CLI only ships the parameters and prints the JSON
+result (`{ sessionId, created }`).
+*/
+pub fn board_command(args: &[String]) -> CliResult<()> {
+    match args.first().map(String::as_str) {
+        Some("start-work") => start_work_command(&args[1..]),
+        None | Some("help") | Some("-h") | Some("--help") => {
+            println!("{}", crate::ghostex_cli::usage::board_usage());
+            Ok(())
+        }
+        Some(other) => Err(CliError::Other(format!(
+            "Unknown board command: {other}\n\n{}",
+            crate::ghostex_cli::usage::board_usage()
+        ))),
+    }
+}
+
+fn start_work_command(args: &[String]) -> CliResult<()> {
+    if matches!(
+        args.first().map(String::as_str),
+        Some("help") | Some("-h") | Some("--help")
+    ) {
+        println!("{}", crate::ghostex_cli::usage::board_usage());
+        return Ok(());
+    }
+    let parsed = parse_args(args);
+    let bead_id = parsed
+        .flags
+        .text("beadId")
+        .or_else(|| parsed.rest.first().cloned())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if bead_id.is_empty() {
+        return Err(CliError::Other(
+            "board start-work requires a bead id.".to_string(),
+        ));
+    }
+    let mut payload = Map::new();
+    payload.insert("beadId".to_string(), Value::String(bead_id));
+    if let Some(agent) = parsed
+        .flags
+        .text("agent")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        payload.insert("agent".to_string(), Value::String(agent));
+    }
+    if let Some(project_id) = parsed
+        .flags
+        .text("projectId")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        payload.insert("projectId".to_string(), Value::String(project_id));
+    }
+    let result = call_gxserver_rpc(
+        "/api/startBoardWork",
+        &Value::Object(payload),
+        &parsed.flags,
+    )?;
+    if is_failed_cli_result(&result) {
+        print_json(&result);
+        crate::ghostex_cli::set_exit_code(1);
+        return Ok(());
+    }
+    print_json(&result);
+    Ok(())
+}

--- a/gxserver-rs/src/ghostex_cli/mod.rs
+++ b/gxserver-rs/src/ghostex_cli/mod.rs
@@ -2,6 +2,7 @@ pub mod actions;
 pub mod args;
 pub mod attach;
 pub mod automations;
+pub mod board;
 pub mod browser_mcp;
 pub mod diagnostics;
 pub mod editors;
@@ -55,6 +56,7 @@ const HELP_GATE_EXCLUDED: &[&str] = &[
     "agent-orchestration",
     "bd",
     "beads",
+    "board",
     "browser",
     "browser-use",
     "computer-use",
@@ -222,6 +224,7 @@ fn is_known_command(name: &str) -> bool {
         "browser-mcp",
         "bd",
         "beads",
+        "board",
         "server",
         "web",
         "install-browser-skill",
@@ -485,6 +488,7 @@ fn run_command(name: &str, args: &[String]) -> CliResult<()> {
         "browser-use" => skills::browser_use_command(args),
         "browser-devtools-mcp" | "browser-mcp" => browser_mcp::browser_devtools_mcp_command(args),
         "bd" | "beads" => launchers::beads_command(args),
+        "board" => board::board_command(args),
         "server" => server_command(args),
         "web" => web::web_command(args),
         "install-browser-skill" | "install-browser-mcp-skill" => {

--- a/gxserver-rs/src/ghostex_cli/usage.rs
+++ b/gxserver-rs/src/ghostex_cli/usage.rs
@@ -122,6 +122,10 @@ pub fn usage() -> String {
             "create-agent <agentId> --project-id id [--group-id id]",
             "Create and start a configured agent session",
         ),
+        format_help_command(
+            "board start-work <bead-id> [--agent id] [--project-id id] [--json]",
+            "Dispatch a Project Board bead: reuse its usable linked session or create the worker",
+        ),
         format_help_command("run-agent <agentId>", "Run a configured agent button"),
         format_help_command(
             "run-command <commandId>",
@@ -487,6 +491,36 @@ Behavior:
 Inspect:
   ghostex state
   ghostex state | jq '.projects[] | {{projectId, name, path, customCommands, customCommandOrder}}'
+"
+    )
+}
+
+pub fn board_usage() -> String {
+    let commands = [format_help_command(
+        "board start-work <bead-id> [--agent id] [--project-id id] [--json]",
+        "Dispatch a Project Board bead through gxserver",
+    )]
+    .join("\n");
+
+    format!(
+        "Ghostex Project Board - dispatch bead work through gxserver
+
+Usage:
+  ghostex board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]
+  gx board start-work <bead-id>
+
+Commands:
+{commands}
+
+Behavior:
+  start-work IS the dispatch: it creates and starts the visible worker session with the bead's
+  canonical work prompt and links the conversation to the card. Do not also launch a worker yourself.
+  Repeated calls are safe: an existing usable linked conversation (live, sleeping, or restorable)
+  is returned as {{ \"sessionId\": ..., \"created\": false }} instead of creating a second worker.
+  Without --agent, the bead assignee is matched case-insensitively against configured agents,
+  falling back to the default prompt agent.
+  Without --project-id, the bead is located across the registered project boards; pass --project-id
+  when the same bead id exists on more than one board.
 "
     )
 }

--- a/gxserver-rs/src/ghostex_cli/usage.rs
+++ b/gxserver-rs/src/ghostex_cli/usage.rs
@@ -495,6 +495,7 @@ Inspect:
     )
 }
 
+/// Render CLI help for Project Board worker dispatch.
 pub fn board_usage() -> String {
     let commands = [format_help_command(
         "board start-work <bead-id> [--agent id] [--project-id id] [--json]",
@@ -516,7 +517,7 @@ Behavior:
   start-work IS the dispatch: it creates and starts the visible worker session with the bead's
   canonical work prompt and links the conversation to the card. Do not also launch a worker yourself.
   Repeated calls are safe: an existing usable linked conversation (live, sleeping, or restorable)
-  is returned as {{ \"sessionId\": ..., \"created\": false }} instead of creating a second worker.
+  is returned as {{ \"projectId\": ..., \"sessionId\": ..., \"created\": false }} instead of creating a second worker.
   Without --agent, the bead assignee is matched case-insensitively against configured agents,
   falling back to the default prompt agent.
   Without --project-id, the bead is located across the registered project boards; pass --project-id

--- a/gxserver-rs/src/lib.rs
+++ b/gxserver-rs/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agent_transcripts;
 pub mod agents;
 pub mod auth;
 pub mod automations;
+pub mod board_start_work;
 pub mod cli;
 pub mod config;
 pub mod constants;

--- a/gxserver-rs/src/protocol.rs
+++ b/gxserver-rs/src/protocol.rs
@@ -458,6 +458,12 @@ pub fn endpoint_for(path: &str) -> Option<EndpointDescriptor> {
         | "/api/runProjectSetupCommand"
         | "/api/runBeadsAction"
         | "/api/runProjectDocsAction"
+        /*
+        CDXC:BoardStartWorkRemote 2026-08-08:
+        Remote board dispatch is allowed because it creates and starts the
+        worker on the selected daemon. beadId, projectId, and agent are opaque
+        selectors only; none is interpreted as a path or command.
+        */
         | "/api/startBoardWork"
         | "/api/previewRepositoryClone"
         | "/api/startRepositoryClone"

--- a/gxserver-rs/src/protocol.rs
+++ b/gxserver-rs/src/protocol.rs
@@ -458,6 +458,7 @@ pub fn endpoint_for(path: &str) -> Option<EndpointDescriptor> {
         | "/api/runProjectSetupCommand"
         | "/api/runBeadsAction"
         | "/api/runProjectDocsAction"
+        | "/api/startBoardWork"
         | "/api/previewRepositoryClone"
         | "/api/startRepositoryClone"
         | "/api/readRepositoryCloneJob"

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -2680,7 +2680,7 @@ async fn route_http(
             },
         ),
         "/api/startBoardWork" => {
-            handle_board_start_work_http(&state, endpoint.path, request_id, &body_json)
+            handle_board_start_work_http(&state, endpoint.path, request_id, &body_json).await
         }
         "/api/generateCommitMessage" => {
             handle_generate_commit_message_http(&state, endpoint.path, request_id, &body_json).await
@@ -3026,7 +3026,7 @@ creating a duplicate worker. The zmx provider start happens after the gate is
 released: the link is already durable, so a concurrent caller reuses the
 session whether or not its provider has finished materializing.
 */
-fn handle_board_start_work_http(
+async fn handle_board_start_work_http(
     state: &AppState,
     endpoint_path: String,
     request_id: String,
@@ -3049,6 +3049,40 @@ fn handle_board_start_work_http(
             );
         }
     };
+    let paths = state.paths.clone();
+    let server_id = state.metadata.server_id.clone();
+    let gate = Arc::clone(&state.board_start_work_gate);
+    let bd_executable_path = bd.executable_path;
+    let outcome = tokio::task::spawn_blocking(move || {
+        let _gate = gate.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let db = open_gxserver_database(&paths).map_err(|error| DomainStateError {
+            code: "internalError",
+            message: format!("SQLite gxserver state error: {error}"),
+        })?;
+        let repository = DomainRepository::new(&db, &server_id);
+        crate::board_start_work::start_board_work(
+            &repository,
+            &db,
+            &server_id,
+            &params,
+            &bd_executable_path,
+        )
+    })
+    .await;
+    let mut outcome = match outcome {
+        Ok(Ok(outcome)) => outcome,
+        Ok(Err(error)) => return domain_error_response(endpoint_path, request_id, error),
+        Err(error) => {
+            return domain_error_response(
+                endpoint_path,
+                request_id,
+                DomainStateError {
+                    code: "internalError",
+                    message: format!("Board start-work task failed: {error}"),
+                },
+            )
+        }
+    };
     let db = match open_gxserver_database(&state.paths) {
         Ok(db) => db,
         Err(error) => {
@@ -3059,31 +3093,13 @@ fn handle_board_start_work_http(
                     code: "internalError",
                     message: format!("SQLite gxserver state error: {error}"),
                 },
-            );
+            )
         }
     };
-    let server_id = state.metadata.server_id.as_str();
-    let repository = DomainRepository::new(&db, server_id);
-    let outcome = {
-        let _gate = state
-            .board_start_work_gate
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        crate::board_start_work::start_board_work(
-            &repository,
-            &db,
-            server_id,
-            &params,
-            &bd.executable_path,
-        )
-    };
-    let outcome = match outcome {
-        Ok(outcome) => outcome,
-        Err(error) => return domain_error_response(endpoint_path, request_id, error),
-    };
-    if let Some((project_id, session_id)) = outcome.created_session.as_ref() {
+    let repository = DomainRepository::new(&db, state.metadata.server_id.as_str());
+    if let Some((project_id, session_id)) = outcome.created_session.clone() {
         if let Err(error) =
-            schedule_presentation_session_delta(state, &db, &repository, project_id, session_id)
+            schedule_presentation_session_delta(state, &db, &repository, &project_id, &session_id)
         {
             return domain_error_response(endpoint_path, request_id, error);
         }
@@ -3101,18 +3117,45 @@ fn handle_board_start_work_http(
             Err(error) => return domain_error_response(endpoint_path, request_id, error),
         };
         let mut provider_params = Map::new();
-        provider_params.insert("projectId".to_string(), json!(project_id));
-        provider_params.insert("sessionId".to_string(), json!(session_id));
-        if let Err(error) = dispatch_zmx_lifecycle_endpoint(
+        provider_params.insert("projectId".to_string(), json!(&project_id));
+        provider_params.insert("sessionId".to_string(), json!(&session_id));
+        let provider_start = dispatch_zmx_lifecycle_endpoint(
             &repository,
             "/api/startSessionProvider",
             &provider_params,
             &context,
             &agent_settings,
-        ) {
-            return zmx_error_response(endpoint_path, request_id, error);
+        );
+        if let Some(result) = outcome.result.as_object_mut() {
+            match provider_start {
+                Ok(_) => {
+                    result.insert("providerStarted".to_string(), Value::Bool(true));
+                }
+                Err(error) => {
+                    let message = match error {
+                        ZmxEndpointError::DependencyUnavailable(message) => message,
+                        ZmxEndpointError::Domain(error) => error.message,
+                    };
+                    let _ = state.logger.log(GxserverLogInput {
+                        level: LogLevel::Warn,
+                        event: "boardStartWork.providerStartFailed".to_string(),
+                        server_id: Some(state.metadata.server_id.clone()),
+                        request_id: Some(request_id.clone()),
+                        client: None,
+                        duration_ms: None,
+                        error: Some(message.clone()),
+                        details: Some(json!({
+                            "projectId": project_id,
+                            "sessionId": session_id,
+                        })),
+                    });
+                    result.insert("providerStarted".to_string(), Value::Bool(false));
+                    result.insert("providerStartError".to_string(), Value::String(message));
+                }
+            }
         }
-        let _ = schedule_presentation_session_delta(state, &db, &repository, project_id, session_id);
+        let _ =
+            schedule_presentation_session_delta(state, &db, &repository, &project_id, &session_id);
     }
     routed_json(
         Some(endpoint_path),
@@ -3186,6 +3229,7 @@ fn domain_error_response(
         "notFound" => StatusCode::NOT_FOUND,
         "corruptState" => StatusCode::CONFLICT,
         "projectPathUnavailable" => StatusCode::CONFLICT,
+        "dependencyUnavailable" => StatusCode::SERVICE_UNAVAILABLE,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     };
     routed_json(

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -120,7 +120,7 @@ use crate::{
         T3RuntimeStatusPayload,
     },
     terminal_ws::{handle_terminal_socket, TerminalWsState},
-    toolchain::{get_gxserver_tool_statuses, require_bundled_zmx},
+    toolchain::{get_gxserver_tool_statuses, require_bundled_bd, require_bundled_zmx},
     typed_operations::{
         create_pull_request_for_project, dispatch_typed_operation_endpoint,
         dispatch_worktree_path_operation, typed_operation_log_details, typed_operation_log_level,
@@ -159,6 +159,9 @@ enum ExistingGxserverState {
 struct AppState {
     auth_token: String,
     automation_runtime: AutomationRuntime,
+    /// Serializes `/api/startBoardWork` so concurrent calls for one bead
+    /// cannot both observe "no usable link" and create two worker sessions.
+    board_start_work_gate: Arc<Mutex<()>>,
     build_identity: String,
     config: GxserverConfig,
     event_hub: GxserverEventHub,
@@ -352,6 +355,7 @@ pub async fn run_gxserver_foreground(
     let state = Arc::new(AppState {
         auth_token: auth.token,
         automation_runtime,
+        board_start_work_gate: Arc::new(Mutex::new(())),
         build_identity,
         config,
         event_hub,
@@ -2675,6 +2679,9 @@ async fn route_http(
                 ))
             },
         ),
+        "/api/startBoardWork" => {
+            handle_board_start_work_http(&state, endpoint.path, request_id, &body_json)
+        }
         "/api/generateCommitMessage" => {
             handle_generate_commit_message_http(&state, endpoint.path, request_id, &body_json).await
         }
@@ -3007,6 +3014,111 @@ where
         ),
         Err(error) => domain_error_response(endpoint_path, request_id, error),
     }
+}
+
+/*
+CDXC:BoardStartWork 2026-08-07:
+The daemon-owned Project Board "Start work" dispatch. The whole
+resolve → reuse-check → create → link sequence runs while holding the
+process-wide start-work gate, so two concurrent calls for one bead serialize
+and the second reuses the first call's link (`created: false`) instead of
+creating a duplicate worker. The zmx provider start happens after the gate is
+released: the link is already durable, so a concurrent caller reuses the
+session whether or not its provider has finished materializing.
+*/
+fn handle_board_start_work_http(
+    state: &AppState,
+    endpoint_path: String,
+    request_id: String,
+    body: &Value,
+) -> RoutedResponse {
+    let params = match read_domain_rpc_params(body) {
+        Ok(params) => params,
+        Err(error) => return domain_error_response(endpoint_path, request_id, error),
+    };
+    let bd = match require_bundled_bd() {
+        Ok(bd) => bd,
+        Err(message) => {
+            return domain_error_response(
+                endpoint_path,
+                request_id,
+                DomainStateError {
+                    code: "dependencyUnavailable",
+                    message,
+                },
+            );
+        }
+    };
+    let db = match open_gxserver_database(&state.paths) {
+        Ok(db) => db,
+        Err(error) => {
+            return domain_error_response(
+                endpoint_path,
+                request_id,
+                DomainStateError {
+                    code: "internalError",
+                    message: format!("SQLite gxserver state error: {error}"),
+                },
+            );
+        }
+    };
+    let server_id = state.metadata.server_id.as_str();
+    let repository = DomainRepository::new(&db, server_id);
+    let outcome = {
+        let _gate = state
+            .board_start_work_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::board_start_work::start_board_work(
+            &repository,
+            &db,
+            server_id,
+            &params,
+            &bd.executable_path,
+        )
+    };
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(error) => return domain_error_response(endpoint_path, request_id, error),
+    };
+    if let Some((project_id, session_id)) = outcome.created_session.as_ref() {
+        if let Err(error) =
+            schedule_presentation_session_delta(state, &db, &repository, project_id, session_id)
+        {
+            return domain_error_response(endpoint_path, request_id, error);
+        }
+        // Materialize the zmx provider like `ghostex create-agent`, so the
+        // staged bead prompt reaches a live agent instead of an inert row.
+        let context = ZmxServerContext {
+            auth_token_file: state.paths.auth_token_file.to_string_lossy().to_string(),
+            base_url: format!(
+                "http://{}:{}",
+                state.config.listeners.local.host, state.config.listeners.local.port
+            ),
+        };
+        let agent_settings = match read_agent_settings(&db) {
+            Ok(settings) => settings,
+            Err(error) => return domain_error_response(endpoint_path, request_id, error),
+        };
+        let mut provider_params = Map::new();
+        provider_params.insert("projectId".to_string(), json!(project_id));
+        provider_params.insert("sessionId".to_string(), json!(session_id));
+        if let Err(error) = dispatch_zmx_lifecycle_endpoint(
+            &repository,
+            "/api/startSessionProvider",
+            &provider_params,
+            &context,
+            &agent_settings,
+        ) {
+            return zmx_error_response(endpoint_path, request_id, error);
+        }
+        let _ = schedule_presentation_session_delta(state, &db, &repository, project_id, session_id);
+    }
+    routed_json(
+        Some(endpoint_path),
+        StatusCode::OK,
+        rpc_success(request_id, outcome.result),
+    )
 }
 
 fn create_quick_project_params(
@@ -15562,6 +15674,7 @@ mod tests {
         Arc::new(AppState {
             auth_token: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
             automation_runtime,
+            board_start_work_gate: Arc::new(Mutex::new(())),
             build_identity: "test-build".to_string(),
             config,
             event_hub: GxserverEventHub::new(metadata.server_id.clone()),

--- a/gxserver-rs/src/sidebar_hud.rs
+++ b/gxserver-rs/src/sidebar_hud.rs
@@ -863,7 +863,7 @@ pub fn read_sidebar_hud_global_commands(stored_definitions: &[Value]) -> Value {
     )
 }
 
-fn sidebar_agent_buttons_from_projects(projects: &[Value]) -> Value {
+pub(crate) fn sidebar_agent_buttons_from_projects(projects: &[Value]) -> Value {
     let (stored_agents, stored_order) = sidebar_agent_state_from_projects(projects);
     sidebar_agent_buttons_from_state(&stored_agents, &stored_order)
 }

--- a/native/sidebar/board-start-work-prompt-parity.test.ts
+++ b/native/sidebar/board-start-work-prompt-parity.test.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
 import { buildAgentWorkPrompt } from "./project-board-shared";
@@ -9,18 +8,46 @@ import { buildAgentWorkPrompt } from "./project-board-shared";
  * gxserver's /api/startBoardWork owns a Rust port of buildAgentWorkPrompt so
  * `ghostex board start-work` sends the same canonical bead work prompt the
  * board sends. There must be exactly one prompt shape: this test renders the
- * TypeScript template with Rust-style placeholders and asserts every line is
- * present verbatim in the Rust template, so the two copies cannot drift apart
- * silently.
+ * TypeScript template with Rust-style placeholders and compares it to the
+ * ordered Rust template sequence, so the two copies cannot drift silently.
+ * This shared module is active GPUI code: gpui/sidebar/kanban-main.tsx loads
+ * native/sidebar/tasks-placeholder.tsx, which imports project-board-shared.ts.
  */
 describe("board start-work prompt parity", () => {
   test("the Rust work-prompt template matches buildAgentWorkPrompt line for line", () => {
-    // Rust string literals escape double quotes, so unescape them before
-    // comparing raw prompt lines against the template source.
     const rustSource = readFileSync(
-      join(__dirname, "..", "..", "gxserver-rs", "src", "board_start_work.rs"),
+      new URL("../../gxserver-rs/src/board_start_work.rs", import.meta.url),
       "utf8",
-    ).replaceAll('\\"', '"');
+    );
+    const functionSource = rustSource.slice(
+      rustSource.indexOf("pub(crate) fn build_board_bead_work_prompt"),
+    );
+    const entries = functionSource.match(
+      /\n    \[\n(?<entries>[\s\S]*?)\n    \]\n    \.join\("\\n"\)/,
+    )?.groups?.entries;
+    if (!entries) {
+      throw new Error("Could not extract the Rust work-prompt array.");
+    }
+    const rustPrompt = entries
+      .trim()
+      .split("\n")
+      .map((line) => line.trim().replace(/,$/, ""))
+      .map((expression) => {
+        if (expression === "String::new()") {
+          return "";
+        }
+        if (expression === "description.to_string()") {
+          return "No prompt provided.";
+        }
+        const literal =
+          expression.match(/^format!\(("(?:\\.|[^"\\])*")\)$/)?.[1] ??
+          expression.match(/^("(?:\\.|[^"\\])*")\.to_string\(\)$/)?.[1];
+        if (!literal) {
+          throw new Error(`Unsupported Rust prompt expression: ${expression}`);
+        }
+        return JSON.parse(literal) as string;
+      })
+      .join("\n");
     const prompt = buildAgentWorkPrompt({
       boardStatus: "todo",
       displayId: "{display_id}",
@@ -28,14 +55,7 @@ describe("board start-work prompt parity", () => {
       status: "open",
       title: "{title}",
     });
-    for (const line of prompt.split("\n")) {
-      if (!line || line === "No prompt provided.") {
-        // The default-description line is asserted separately below; blank
-        // separator lines carry no template content.
-        continue;
-      }
-      expect(rustSource).toContain(line);
-    }
-    expect(rustSource).toContain("No prompt provided.");
+    expect(rustPrompt).toContain("No prompt provided.");
+    expect(rustPrompt).toBe(prompt);
   });
 });

--- a/native/sidebar/board-start-work-prompt-parity.test.ts
+++ b/native/sidebar/board-start-work-prompt-parity.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { buildAgentWorkPrompt } from "./project-board-shared";
+
+/*
+ * CDXC:BoardStartWork 2026-08-07:
+ * gxserver's /api/startBoardWork owns a Rust port of buildAgentWorkPrompt so
+ * `ghostex board start-work` sends the same canonical bead work prompt the
+ * board sends. There must be exactly one prompt shape: this test renders the
+ * TypeScript template with Rust-style placeholders and asserts every line is
+ * present verbatim in the Rust template, so the two copies cannot drift apart
+ * silently.
+ */
+describe("board start-work prompt parity", () => {
+  test("the Rust work-prompt template matches buildAgentWorkPrompt line for line", () => {
+    // Rust string literals escape double quotes, so unescape them before
+    // comparing raw prompt lines against the template source.
+    const rustSource = readFileSync(
+      join(__dirname, "..", "..", "gxserver-rs", "src", "board_start_work.rs"),
+      "utf8",
+    ).replaceAll('\\"', '"');
+    const prompt = buildAgentWorkPrompt({
+      boardStatus: "todo",
+      displayId: "{display_id}",
+      id: "{bead_id}",
+      status: "open",
+      title: "{title}",
+    });
+    for (const line of prompt.split("\n")) {
+      if (!line || line === "No prompt provided.") {
+        // The default-description line is asserted separately below; blank
+        // separator lines carry no template content.
+        continue;
+      }
+      expect(rustSource).toContain(line);
+    }
+    expect(rustSource).toContain("No prompt provided.");
+  });
+});

--- a/skills/ghostex-manage-beads/SKILL.md
+++ b/skills/ghostex-manage-beads/SKILL.md
@@ -55,6 +55,34 @@ Keep comments focused on user-facing requirements delivered and high-level
 technical approach. Do not require humans to read the agent transcript to know
 what changed.
 
+## Dispatch A Bead To A Worker Session (Orchestrators)
+
+This section is for orchestrators and dispatchers deciding who works a bead,
+not for an agent that is already doing the bead's work.
+
+To dispatch a bead through Ghostex, run:
+
+```bash
+ghostex board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]
+```
+
+- **The command is the dispatch.** It creates and starts the visible worker
+  session in the bead's board project, sends the canonical bead work prompt,
+  and links the conversation to the card. Call it *instead of* launching a
+  worker session yourself — it is not a preparation step before separately
+  starting another worker. Calling it and then starting your own worker puts
+  two workers on the same card.
+- **Already working the bead? Do not call it.** An agent that is itself doing
+  the bead's work must not run the command; that would create an additional
+  worker for work that is already underway.
+- **Repeated calls are safe.** If the bead already has a usable linked
+  conversation — live, sleeping, or restorable — the command returns it with
+  `{ "sessionId": ..., "created": false }` instead of creating another
+  worker, so automation can call it idempotently.
+- Without `--agent`, the bead's assignee is matched case-insensitively against
+  the configured agents' ids and names; an assignee that matches no configured
+  agent falls back to the default prompt agent.
+
 ## Create A Review Bead
 
 Use a review bead when the implementation is ready for another pass:

--- a/skills/ghostex-manage-beads/SKILL.md
+++ b/skills/ghostex-manage-beads/SKILL.md
@@ -63,7 +63,7 @@ not for an agent that is already doing the bead's work.
 To dispatch a bead through Ghostex, run:
 
 ```bash
-ghostex board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]
+gx board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]
 ```
 
 - **The command is the dispatch.** It creates and starts the visible worker
@@ -77,7 +77,7 @@ ghostex board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--js
   worker for work that is already underway.
 - **Repeated calls are safe.** If the bead already has a usable linked
   conversation — live, sleeping, or restorable — the command returns it with
-  `{ "sessionId": ..., "created": false }` instead of creating another
+  `{ "projectId": ..., "sessionId": ..., "created": false }` instead of creating another
   worker, so automation can call it idempotently.
 - Without `--agent`, the bead's assignee is matched case-insensitively against
   the configured agents' ids and names; an assignee that matches no configured


### PR DESCRIPTION
Implements the v1 we agreed in the design review (CLI-only, no modes, no mapping UI), with all four of your redlines built in.

## What it does

`ghostex board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]`

One daemon endpoint (`/api/startBoardWork`) that IS the dispatch: resolves the bead across shared board mounts, reuses any **usable** linked conversation idempotently, or creates the visible agent session via the existing `create-agent` path with the canonical work prompt staged, writes the conversation link (with `sessionProjectId`), and returns `{"sessionId", "created"}`. The CLI verb is a thin wrapper patterned on `run-action`/`create-agent`/`save-command` conventions.

## Your redlines → how they landed

1. **The command is the dispatch** — the new 28-line section in `skills/ghostex-manage-beads/SKILL.md` addresses orchestrators/dispatchers explicitly: call it *instead of* launching a worker; never as a prep step; an agent already working the bead must not call it; repeated calls are safe.
2. **Race-safe idempotent guard** — a process-wide mutex (`board_start_work_gate`, same pattern as `presentation_event_sequence`) held across resolve → usable-check → create → link-write. "Usable" = live, sleeping, **or restorable** via previous-session history, matching the board's resumable-link contract. Existing usable session returns `created: false`, never an error. Proven by a 2-thread barrier test and live concurrent CLI calls (one `true`, one `false`, same session id).
3. **One canonical prompt** — the endpoint owns the prompt; a parity test (`board-start-work-prompt-parity.test.ts`) renders the TS `buildAgentWorkPrompt` template and asserts every line exists verbatim in the Rust implementation, so the copies cannot drift silently.
4. **Isolation without HOME** — headless e2e uses `GHOSTEX_HOME` + `GHOSTEX_GXSERVER_DEV_PORT` (both supported), never overriding `HOME`, never touching a live daemon, never starting the app. A replayable demo script exercised all four behaviors (create / reuse / race / unknown-bead) against a throwaway daemon.

Agent resolution: explicit `--agent` → bead assignee matched case-insensitively against configured agent ids/names (the #84 logic) → default prompt agent.

## Verification

- `cargo test board_start_work` → 7/7 (happy path, reuse, concurrent serialization, unknown bead, assignee agent, resolution chain, prompt template)
- Full `cargo test --lib`: identical pass/fail set to base plus the 7 new tests — zero regressions (the 150 pre-existing environmental failures on temp-home fixtures are unchanged)
- `bun run typecheck` clean; vitest incl. the parity test green
- Headless e2e (twice, independently): first call `created: true` with staged prompt + link incl. `sessionProjectId`; second call `created: false` same id; concurrent calls serialize; unknown bead → clean JSON error, exit 1

## Two honest flags

- **Size**: Phase 1 came in around ~600 logic lines + ~370 test lines — above the ~150–250 estimate from the plan. The overage is the Rust port of #87's link-store/match-key/session-reference helpers (the daemon needs them to resolve links server-side) plus the four-scenario test harness you asked for. Nothing speculative was added.
- **Duplication**: that port means the link-matching logic now exists in both Rust and TS, with only the *prompt* parity-tested. Options if you want it hardened: parity tests for the match keys too, or migrating board link reads daemon-side later so TS stops owning a copy. Your call — happy to do either as a follow-up.

Rebased onto current main after you merged #84–#89, per your "land the dependencies first" note — the diff is only the new work.

- **Third flag, found while demo-testing**: a gxserver booted under `GHOSTEX_HOME` isolation still installs its Claude hooks into the user's *real* `~/.claude/settings.json`, pointing all six hook events at the throwaway home (which then vanishes). Any second daemon instance corrupts the user's global Claude config this way. The hook installer should probably derive its target from `GHOSTEX_HOME` or skip installation when isolated — happy to file/fix as a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Project Board work dispatch through the `board start-work` command and API.
  * Creates or reuses linked work sessions for beads, with optional agent and project selection.
  * Selects agents by assignee, with fallback to a default agent.
  * Prevents duplicate sessions and safely handles concurrent requests.
  * Added structured JSON results, session linking, and clear error reporting.

* **Documentation**
  * Added CLI help and workflow guidance for bead dispatching and duplicate-work prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->