### PR TITLE
fix(gpui): resolve native CEF entries on the dev server

### DIFF
--- a/gpui/vite.config.ts
+++ b/gpui/vite.config.ts
@@ -314,6 +314,18 @@ export default defineConfig({
        * The GPUI CEF sidebar bundle imports app-owned sidebar and shadcn modules from the repository root. Keep the same @ alias as Storybook and Electron so this app exercises the production React component graph.
        */
       "@": repoRoot,
+      /*
+       * CDXC:GPUIDevNativeEntryUrls 2026-08-09:
+       * modal-host.html and titlebar-host.html point at ../native/sidebar/*.tsx,
+       * which the browser normalises to /native/sidebar/*.tsx against the dev
+       * root (gpui/). That URL escapes the root, so the dev server answered the
+       * SPA fallback HTML instead of the module and both windows rendered blank.
+       * Map the escaped prefix back to the real directory so dev serves the same
+       * entry the build resolves from disk. Build output is unaffected: Rollup
+       * resolves the relative src itself and no module specifier starts with
+       * /native.
+       */
+      "/native": path.resolve(repoRoot, "native"),
     },
   },
   server: {


### PR DESCRIPTION
## Symptom

Run the gpui webview surfaces against the Vite dev server (`GHOSTEX_GPUI_APP_MODAL_HOST_URL` pointed at it) and the **Settings window and the Add Worktree dialog open completely blank**. The titlebar Tips dropdown is dead the same way. Four of the six CEF entries work fine; only `modal-host.html` and `titlebar-host.html` are broken.

Production builds are **not** affected — this is dev-server-only.

## Root cause

`gpui/vite.config.ts` sets the dev root to `gpui/`. Four HTML entries reference their code with a path that stays inside that root:

```html
<script type="module" src="./sidebar/kanban-main.tsx"></script>
```

The other two reach up out of it, because their entries live in the shared `native/sidebar/` tree:

```html
<script type="module" src="../native/sidebar/modal-host.tsx"></script>
<script type="module" src="../native/sidebar/titlebar-host.tsx"></script>
```

The browser normalises `../native/sidebar/modal-host.tsx` to the URL `/native/sidebar/modal-host.tsx`. That is outside the dev root, so Vite cannot resolve it:

```
Pre-transform error: Failed to load url /native/sidebar/modal-host.tsx (resolved id: /native/sidebar/modal-host.tsx). Does the file exist?
Pre-transform error: Failed to load url /native/sidebar/titlebar-host.tsx (resolved id: /native/sidebar/titlebar-host.tsx). Does the file exist?
```

The failed transform then falls through to the SPA fallback, so the request **returns HTTP 200 with `Content-Type: text/html`** — the browser gets `index.html` where it asked for a JS module, the module never parses, and React never mounts. That 200 is why the failure looks silent: status alone does not reveal it, only the content type does.

Note this is *not* a `server.fs.allow` problem — `repoRoot` is already allowed. Only URL resolution was broken.

## The fix

One alias entry mapping the escaped prefix back to the real directory:

```ts
"/native": path.resolve(repoRoot, "native"),
```

### Why this one, and not editing the HTML

The alternative was changing the two HTML files to reference their entries some way that works in both dev and build. Rejected, because in this config the HTML `src` is load-bearing for the production build in three separate places:

- `cefHtmlEntryScripts` maps each HTML entry to an absolute entry path, and `buildInlineCefEntryScript` esbuild-bundles exactly that path into the single-file CEF output.
- `collectCefEntryCssFileNames` finds each entry chunk by matching `facadeModuleId` against those same paths, and **throws** if no chunk matches.
- `replaceCefEntryModuleScript` rewrites the module script in the original wrapper HTML.

Pointing the HTML at a different specifier (a re-export shim under `gpui/sidebar/`, for example) changes the facade module id Rollup emits, so it would also require updating the entry map — more moving parts, new files, and a real risk of changing what ships in the CEF bundle. Aliasing touches one config block, adds no files, and leaves every build input exactly as it was.

The alias is also the accurate inverse of what the browser did: the URL `/native/X` genuinely means `<repoRoot>/native/X`. It is dev-only in practice — no module specifier anywhere in the repository starts with `/native`, and during a build Rollup resolves the relative `src` from disk itself, so the alias never fires.

## Verification

Everything below was run on this branch. Dev server on port 5399: `bunx vite --config gpui/vite.config.ts --port 5399 --strictPort`.

### Before the fix

```
$ for p in /modal-host.html /titlebar-host.html /kanban.html /index.html \
           /native/sidebar/modal-host.tsx /native/sidebar/titlebar-host.tsx; do ... done

/native/sidebar/modal-host.tsx      200  Content-Type: text/html     <- SPA fallback, not the module
/native/sidebar/titlebar-host.tsx   200  Content-Type: text/html     <- SPA fallback, not the module

$ curl -s http://localhost:5399/native/sidebar/modal-host.tsx | head -4
<!doctype html>
<html lang="en">
  <head>
    <script type="module" src="/@vite/client"></script>
```

Vite log:

```
  VITE v8.0.10  ready in 215 ms
  ➜  Local:   http://localhost:5399/
5:26:55 PM [vite] (client) Pre-transform error: Failed to load url /native/sidebar/modal-host.tsx (resolved id: /native/sidebar/modal-host.tsx). Does the file exist?
5:26:55 PM [vite] (client) Pre-transform error: Failed to load url /native/sidebar/titlebar-host.tsx (resolved id: /native/sidebar/titlebar-host.tsx). Does the file exist?
```

### After the fix

All six entries, status and content type:

```
PATH                                       STATUS CONTENT-TYPE
/modal-host.html                           200 text/html
/titlebar-host.html                        200 text/html
/kanban.html                               200 text/html
/index.html                                200 text/html
/native/sidebar/modal-host.tsx             200 text/javascript
/native/sidebar/titlebar-host.tsx          200 text/javascript
```

The two entries now serve real transformed modules (341,498 bytes for the modal host) with their imports rewritten to `/@fs/` URLs:

```
$ curl -s http://localhost:5399/native/sidebar/modal-host.tsx | head -4
const createRoot = __vite__cjsImport0_reactDom_client["createRoot"]; ...
import __vite__cjsImport1_react from "/@fs/.../node_modules/.vite/deps/react.js?v=6357476a";
import { T3CODE_ENABLED } from "/@fs/.../shared/feature-flags.ts";
import { AddProjectModal } from "/@fs/.../sidebar/add-project-modal/add-project-modal.tsx";
```

Full Vite log after requesting all six — zero `Failed to load url`, zero errors, zero warnings:

```
  VITE v8.0.10  ready in 156 ms
  ➜  Local:   http://localhost:5399/
  ➜  Network: use --host to expose

=== 'Failed to load url' occurrences: 0 ===
```

### Production build is byte-for-byte unchanged

`vite build` was run twice — once with the alias, once with it stashed — and every emitted file hashed:

```
$ find . -type f | sort | xargs shasum -a 256 > dist-{baseline,with-fix}.sha256
$ diff dist-baseline.sha256 dist-with-fix.sha256
diff exit=0 (0 = identical)
files compared:      391 vs      391
```

391 emitted files, identical SHA-256 across both builds.

### Typecheck

```
$ bun run typecheck
$ tsc --noEmit --pretty false
EXIT=0
```

## Scope

One file, twelve added lines, all inside `resolve.alias` in `gpui/vite.config.ts`. No HTML, no source, no build inputs touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development-time loading for native modal and title bar components.
  * Added support for resolving native modules through the `/native` path without changing production build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->