### PR TITLE
feat(worktree): rename a worktree's folder and branch from the sidebar

### DIFF
--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -16625,6 +16625,18 @@ guards the shape instead: single line, no backslashes, bounded length.
 */
 function gpuiWorktreeRenameUserVisibleErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message.trim() : "";
+  /*
+  CDXC:WorktreeRename 2026-08-09-18:40:
+  A daemon older than this feature answers the rename endpoint with
+  `notFound: "/api/renameWorktreeProject is not a gxserver HTTP endpoint."`.
+  That sentence is true and completely useless to the person who just clicked
+  Rename, so translate the one condition they can actually act on. This happens
+  for real whenever a freshly built app attaches to a gxserver left running by
+  the previously installed one.
+  */
+  if (message.includes("is not a gxserver HTTP endpoint")) {
+    return "This Ghostex build's background service is out of date. Quit Ghostex fully, reopen it, and try again.";
+  }
   if (message && !message.includes("\\") && !message.includes("\n") && message.length <= 200) {
     return message;
   }

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -16627,14 +16627,18 @@ function gpuiWorktreeRenameUserVisibleErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message.trim() : "";
   /*
   CDXC:WorktreeRename 2026-08-09-18:40:
-  A daemon older than this feature answers the rename endpoint with
-  `notFound: "/api/renameWorktreeProject is not a gxserver HTTP endpoint."`.
-  That sentence is true and completely useless to the person who just clicked
-  Rename, so translate the one condition they can actually act on. This happens
-  for real whenever a freshly built app attaches to a gxserver left running by
-  the previously installed one.
+  A daemon older than this feature cannot route the rename endpoint at all, and
+  says so by naming the path back at the user — verified live as
+  `notFound: "No gxserver endpoint for POST /api/renameWorktreeProject."`, though
+  gxserver has more than one phrasing for it. Match on the endpoint path instead
+  of on any one sentence: an error that names this route is always the daemon
+  being older than the app, never anything the user did to their worktree.
+
+  This is not hypothetical. A freshly built app attaches to whatever gxserver is
+  already listening on 127.0.0.1:58744, which is normally the daemon the
+  installed app started — so the very first run of a new build hits it.
   */
-  if (message.includes("is not a gxserver HTTP endpoint")) {
+  if (message.includes("/api/renameWorktreeProject")) {
     return "This Ghostex build's background service is out of date. Quit Ghostex fully, reopen it, and try again.";
   }
   if (message && !message.includes("\\") && !message.includes("\n") && message.length <= 200) {

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -5042,6 +5042,9 @@ class GpuiSidebarRuntime {
       case "confirmDeleteWorktree":
         void this.confirmDeleteWorktree(message);
         return;
+      case "confirmRenameWorktree":
+        void this.confirmRenameWorktree(message);
+        return;
       case "commitWorktreeBeforeDelete":
         void this.runSidebarGitAction({
           action: "commit",
@@ -6271,6 +6274,12 @@ class GpuiSidebarRuntime {
         return;
       case "confirmDeleteWorktree":
         await this.confirmDeleteWorktree(message);
+        return;
+      case "promptRenameWorktreeForGroup":
+        await this.promptRenameWorktreeForGroup(message.groupId);
+        return;
+      case "confirmRenameWorktree":
+        await this.confirmRenameWorktree(message);
         return;
       case "updateSettingsPatch":
         this.saveSidebarSettingsPatch(message);
@@ -11684,6 +11693,204 @@ class GpuiSidebarRuntime {
     }
   }
 
+  /*
+  CDXC:WorktreeRename 2026-08-09-18:40:
+  Everything the modal needs to decide whether a rename can happen is gathered
+  HERE, before the native child window opens, because that window has no channel
+  to ask gxserver anything once it is up. The split is deliberate:
+
+  - answers that do not depend on the typed name (submodules, lock, pushed
+    branch, uncommitted changes, live sessions, agent history) ride the draft;
+  - answers that are pure computation over draft data (a folder that collides
+    with the main checkout or with another registered project) are recomputed
+    live in the modal as the user types;
+  - answers that need git or the filesystem for a name nobody has typed yet (the
+    destination already existing, the branch already existing, a ref-namespace
+    collision) are enforced by gxserver at submit and surface as the error toast.
+
+  Remote worktrees are out: the rename endpoint is remote-allowed, but the
+  presentation-project indirection the remote delete flow needs has no rename
+  counterpart yet, so a remote row gets an honest refusal instead of a modal that
+  cannot submit.
+  */
+  private async promptRenameWorktreeForGroup(groupId: string): Promise<void> {
+    if (parseGpuiRemotePresentationGroupId(groupId)) {
+      this.postWorktreeToast("warning", "Not available for remote worktrees", {
+        description: "Rename a remote worktree from the machine that owns it.",
+      });
+      return;
+    }
+    const projectId = parseGxserverPresentationProjectGroupId(groupId);
+    const project = projectId ? this.domainProjectById(projectId) : undefined;
+    const worktree = normalizeGpuiWorktreeMetadata(project?.worktree);
+    const projectPath = normalizeGpuiProjectPath(project?.path);
+    if (!project || !worktree || !projectPath) {
+      this.postWorktreeToast("warning", "Not a worktree", {
+        description: "Only worktree projects can be renamed.",
+      });
+      return;
+    }
+    const parentProject = this.domainProjectById(worktree.parentProjectId);
+    const parentProjectPath = normalizeGpuiProjectPath(parentProject?.path);
+    if (!parentProject || !parentProjectPath) {
+      this.postWorktreeToast("warning", "Parent project unavailable", {
+        description: "The worktree's parent project is not registered.",
+      });
+      return;
+    }
+
+    try {
+      const [branch, status, submodules] = await Promise.all([
+        this.runGitAction(project, { action: "branch" }),
+        this.runGitAction(project, { action: "status" }),
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        The submodule probe is an early warning, not the guard. A daemon that
+        does not know the action rejects it, and that must not cost the user the
+        whole dialog — gxserver re-checks submodules inside the rename itself and
+        refuses with the same sentence. Degrade to that refusal instead.
+        */
+        this.runWorktreeAction(parentProject, {
+          action: "hasPopulatedSubmodules",
+          worktreePath: projectPath,
+        }).catch(() => undefined),
+      ]);
+      if (branch.exitCode !== 0 || status.exitCode !== 0) {
+        throw new Error("Could not read worktree status.");
+      }
+      const branchName = normalizeGpuiWorktreeDeleteBranchName(branch.stdout, worktree.branch);
+      const branchMetadata = await resolveGpuiWorktreeDeleteBranchMetadata(
+        branchName,
+        (remoteName, remoteBranchName) =>
+          this.runGitAction(project, {
+            action: "remoteBranchExists",
+            branch: remoteBranchName,
+            remoteName,
+          }),
+      );
+      const parentFolderName = gpuiProjectNameFromPath(parentProjectPath);
+      const currentFolderName = gpuiProjectNameFromPath(projectPath);
+      const sessions = (this.presentation?.sessions ?? []).filter(
+        (session) => session.projectId === project.projectId,
+      );
+      const runningSessionCount = sessions.filter(
+        (session) => session.lifecycleState === "running",
+      ).length;
+      const warnings: string[] = [];
+      if (branchMetadata.remoteBranchExists && branchName) {
+        warnings.push(
+          `Renaming here only renames the local branch. ${branchMetadata.remoteName}/${branchName} keeps its old name, and your next push will be rejected until you set a new upstream.`,
+        );
+      }
+      if (hasGpuiGitShortStatusChanges(status.stdout)) {
+        warnings.push(
+          "This worktree has uncommitted changes. They move with the folder and are not touched.",
+        );
+      }
+      if (runningSessionCount > 0) {
+        warnings.push(
+          `${runningSessionCount} running session(s) will keep working, but their shell still thinks it is in the old folder until you cd or restart them.`,
+        );
+      }
+      if (sessions.some((session) => Boolean(session.agentId))) {
+        warnings.push(
+          "Agent history (Claude/Cursor) is filed under the old folder path and will not follow the rename.",
+        );
+      }
+
+      postAppModalHostMessage(
+        {
+          modal: "renameWorktree",
+          type: "open",
+          worktreeRenameDraft: {
+            ...(submodules?.exitCode === 0
+              ? {
+                  blockingReason:
+                    "This worktree has initialised submodules, and git cannot move those. Remove them (git submodule deinit --all) or move the folder yourself.",
+                }
+              : {}),
+            ...(branchName ? { branch: branchName } : {}),
+            currentName: gpuiWorktreeFolderSuffix(currentFolderName, parentFolderName),
+            currentPath: projectPath,
+            parentFolderName,
+            parentProjectPath,
+            projectId: project.projectId,
+            registeredProjectPaths: this.domainProjects
+              .filter((candidate) => candidate.projectId !== project.projectId)
+              .map((candidate) => normalizeGpuiProjectPath(candidate.path))
+              .filter((path): path is string => Boolean(path)),
+            renameBranchDefault: isGpuiManagedWorktreeBranch(branchName),
+            warnings,
+            worktreeName: project.name || worktree.name || currentFolderName,
+          },
+        },
+        "AppModals:gpuiRenameWorktree",
+      );
+    } catch (error) {
+      this.postWorktreeToast("error", "Could not inspect worktree", {
+        description: error instanceof Error ? error.message : "git status failed.",
+      });
+    }
+  }
+
+  private async confirmRenameWorktree(
+    message: Extract<SidebarToExtensionMessage, { type: "confirmRenameWorktree" }>,
+  ): Promise<void> {
+    const project = this.domainProjectById(message.projectId);
+    const worktree = normalizeGpuiWorktreeMetadata(project?.worktree);
+    if (!project || !worktree || !this.client) {
+      this.postWorktreeToast("warning", "Worktree unavailable", {
+        description: "The selected worktree no longer exists.",
+      });
+      return;
+    }
+    const parentProject = this.domainProjectById(worktree.parentProjectId);
+    const toastId = createGpuiWorktreeToastId();
+    this.postWorktreeToast("info", "Renaming worktree", {
+      description: project.name,
+      persistent: true,
+      toastId,
+    });
+    /*
+    CDXC:SidebarGitMemo 2026-07-29 (extended for rename):
+    Same reasoning as `confirmDeleteWorktree`: the rename is a git write that
+    does not go through the `runGitAction` chokepoint — gxserver moves the
+    checkout and can rename the branch in the parent repo — so a memoized state
+    taken before the write would otherwise be republished for the rest of the
+    TTL, describing a branch and a path that no longer exist.
+    */
+    if (parentProject) {
+      this.gitStateMemoByProjectId.delete(parentProject.projectId);
+    }
+    this.gitStateMemoByProjectId.delete(project.projectId);
+    this.gitHubStateMemoByProjectId.delete(project.projectId);
+    try {
+      const result = await this.client.rpc<{ project?: GxserverProjectDomainState }>(
+        "/api/renameWorktreeProject",
+        {
+          name: message.name,
+          projectId: project.projectId,
+          renameBranch: message.renameBranch === true,
+        },
+      );
+      if (result.project) {
+        this.upsertDomainProject(result.project);
+      }
+      await this.refreshDomainPresentationFromClient("patch").catch(() => {
+        this.publishHudPatch();
+      });
+      this.postWorktreeToast("success", "Worktree renamed", {
+        description: result.project?.name ?? project.name,
+        toastId,
+      });
+    } catch (error) {
+      this.postWorktreeToast("error", "Could not rename worktree", {
+        description: gpuiWorktreeRenameUserVisibleErrorMessage(error),
+        toastId,
+      });
+    }
+  }
+
   private async promptDeleteRemoteWorktreeForGroup(groupId: string): Promise<boolean> {
     if (!parseGpuiRemotePresentationGroupId(groupId)) {
       return false;
@@ -12975,6 +13182,27 @@ class GpuiSidebarRuntime {
         projectId: remoteScope.projectId,
       },
     );
+  }
+
+  /*
+  CDXC:WorktreeRename 2026-08-09-18:40:
+  Worktree actions scope to the PARENT project, not the worktree's own row: the
+  typed operation derives the worktree family root from the parent of its cwd and
+  then refuses a path equal to that cwd, so passing the worktree's id makes the
+  operation refuse to act on itself. `createProjectWorktree` already sends the
+  parent for the same reason.
+  */
+  private async runWorktreeAction(
+    parentProject: GxserverProjectDomainState,
+    params: Record<string, unknown>,
+  ): Promise<GxserverTypedOperationResult> {
+    if (!this.client) {
+      throw new Error("gxserver is unavailable.");
+    }
+    return this.client.rpc<GxserverTypedOperationResult>("/api/runWorktreeAction", {
+      ...params,
+      projectId: parentProject.projectId,
+    });
   }
 
   private async runGitHubAction(
@@ -16356,6 +16584,53 @@ async function resolveGpuiWorktreeDeleteBranchMetadata(
   };
 }
 
+/**
+ * The field's prefill: the folder's own name with the `<ParentFolder>-` prefix
+ * stripped, because that prefix is re-applied on submit and showing it would
+ * invite the user to type it twice.
+ */
+function gpuiWorktreeFolderSuffix(folderName: string, parentFolderName: string): string {
+  const prefix = `${parentFolderName}-`;
+  return parentFolderName && folderName.startsWith(prefix)
+    ? folderName.slice(prefix.length)
+    : folderName;
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+The branch checkbox defaults on only for a branch gxserver minted or manages —
+`ghostex/<8hex>` or `ghostex/<slug>`, mirroring `is_worktree_temp_branch` and
+`is_managed_worktree_branch` in `gxserver-rs/src/worktree_sessions.rs`. A branch
+the user named is theirs and stays put unless they say otherwise; a branch
+Ghostex named is Ghostex's to keep in step with the folder. Getting this backwards
+would silently rename branches people had pushed.
+*/
+function isGpuiManagedWorktreeBranch(branch: string | undefined): boolean {
+  const slug = branch?.startsWith("ghostex/") ? branch.slice("ghostex/".length) : undefined;
+  return Boolean(
+    slug &&
+      slug !== "automation" &&
+      !slug.startsWith("automation/") &&
+      /^[a-z0-9-]+$/.test(slug),
+  );
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+`gpuiWorktreeUserVisibleErrorMessage` drops any message containing `/`, which
+would swallow every rename refusal that names a branch — `Branch "feat/x" already
+exists.` is exactly the sentence the user needs. gxserver's rename errors are
+bounded strings by contract (never git stderr), so this keeps the slash and
+guards the shape instead: single line, no backslashes, bounded length.
+*/
+function gpuiWorktreeRenameUserVisibleErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message.trim() : "";
+  if (message && !message.includes("\\") && !message.includes("\n") && message.length <= 200) {
+    return message;
+  }
+  return "The gxserver worktree rename failed.";
+}
+
 function hasGpuiGitShortStatusChanges(stdout: string): boolean {
   return stdout.split("\n").some((line) => {
     const trimmed = line.trim();
@@ -16367,6 +16642,7 @@ type GpuiWorktreeModalCommand =
   | Extract<SidebarToExtensionMessage, { type: "requestProjectWorktrees" }>
   | Extract<SidebarToExtensionMessage, { type: "createProjectWorktree" }>
   | Extract<SidebarToExtensionMessage, { type: "confirmDeleteWorktree" }>
+  | Extract<SidebarToExtensionMessage, { type: "confirmRenameWorktree" }>
   | Extract<SidebarToExtensionMessage, { type: "commitWorktreeBeforeDelete" }>;
 
 type GpuiGitCommitModalCommand =
@@ -16482,6 +16758,26 @@ function parseGpuiWorktreeModalCommand(payload: unknown): GpuiWorktreeModalComma
         deleteRemoteBranch: record.deleteRemoteBranch === true,
         projectId,
         type: "confirmDeleteWorktree",
+      };
+    }
+    case "confirmRenameWorktree": {
+      /*
+      CDXC:WorktreeRename 2026-08-09-18:40:
+      `name` crosses this boundary as bounded text, never as a path: gxserver
+      derives the destination folder from it and re-validates it against the
+      daemon's own ref policy, so nothing here can name a directory. The 200-char
+      cap matches the shared validator's.
+      */
+      const projectId = stringField("projectId", 300);
+      const name = stringField("name", 200);
+      if (!projectId || !name) {
+        return undefined;
+      }
+      return {
+        name,
+        projectId,
+        renameBranch: record.renameBranch === true,
+        type: "confirmRenameWorktree",
       };
     }
     case "commitWorktreeBeforeDelete": {

--- a/gpui/src/main.rs
+++ b/gpui/src/main.rs
@@ -2913,6 +2913,7 @@ enum GpuiAppModalKind {
     RemoteProjectPicker,
     Worktree,
     DeleteWorktree,
+    RenameWorktree,
     GitCommit,
     GitFileDiff,
     PortlessSetup,
@@ -2947,6 +2948,7 @@ impl GpuiAppModalKind {
             "remoteProjectPicker" => Some(Self::RemoteProjectPicker),
             "worktree" => Some(Self::Worktree),
             "deleteWorktree" => Some(Self::DeleteWorktree),
+            "renameWorktree" => Some(Self::RenameWorktree),
             "gitCommit" => Some(Self::GitCommit),
             "gitFileDiff" => Some(Self::GitFileDiff),
             "portlessSetup" => Some(Self::PortlessSetup),
@@ -2982,6 +2984,7 @@ impl GpuiAppModalKind {
             Self::RemoteProjectPicker => "remoteProjectPicker",
             Self::Worktree => "worktree",
             Self::DeleteWorktree => "deleteWorktree",
+            Self::RenameWorktree => "renameWorktree",
             Self::GitCommit => "gitCommit",
             Self::GitFileDiff => "gitFileDiff",
             Self::PortlessSetup => "portlessSetup",
@@ -3016,6 +3019,7 @@ impl GpuiAppModalKind {
             Self::RemoteProjectPicker => "Ghostex Remote Project",
             Self::Worktree => "Ghostex Add Worktree",
             Self::DeleteWorktree => "Ghostex Delete Worktree",
+            Self::RenameWorktree => "Ghostex Rename Worktree",
             Self::GitCommit => "Ghostex Commit Changes",
             Self::GitFileDiff => "Ghostex File Diff",
             Self::PortlessSetup => "Ghostex Portless Setup",
@@ -3096,6 +3100,17 @@ impl GpuiAppModalKind {
                 px(APP_MODAL_HOST_COMPACT_WINDOW_WIDTH),
                 px(APP_MODAL_HOST_DELETE_WORKTREE_WINDOW_HEIGHT),
             ),
+            /*
+            CDXC:WorktreeRename 2026-08-09-18:40:
+            Rename Worktree is one field, a preview, a checkbox, and however many
+            warnings the checkout has, so it opens on the same compact frame as
+            Delete Worktree and the one-shot fit-height pass sizes it down to
+            whatever it actually rendered.
+            */
+            Self::RenameWorktree => size(
+                px(APP_MODAL_HOST_COMPACT_WINDOW_WIDTH),
+                px(APP_MODAL_HOST_DELETE_WORKTREE_WINDOW_HEIGHT),
+            ),
             Self::PortlessSetup => size(
                 px(APP_MODAL_HOST_PORTLESS_SETUP_WINDOW_WIDTH),
                 px(APP_MODAL_HOST_PORTLESS_SETUP_WINDOW_HEIGHT),
@@ -3156,6 +3171,7 @@ impl GpuiAppModalKind {
                 | Self::RenameSession
                 | Self::Worktree
                 | Self::DeleteWorktree
+                | Self::RenameWorktree
                 | Self::GitCommit
                 | Self::GitFileDiff
                 | Self::PortlessSetup
@@ -3225,6 +3241,7 @@ impl GpuiAppModalKind {
             // open message is the menu-path shape.
             Self::Worktree
             | Self::DeleteWorktree
+            | Self::RenameWorktree
             | Self::GitCommit
             | Self::GitFileDiff
             | Self::PortlessSetup
@@ -27452,6 +27469,16 @@ impl GhostexGpuiApp {
                 "remoteMachineId",
             ],
             "confirmDeleteWorktree" => &["projectId"],
+            /*
+            CDXC:WorktreeRename 2026-08-09-18:40:
+            The rename confirmation carries the typed name across the modal
+            boundary. It is NOT a path: the runtime revalidates the project and
+            gxserver derives the destination folder from the name itself, so this
+            forward can never point a move at a directory of the caller's
+            choosing. `renameBranch` is a boolean and needs the explicit block
+            below — the string loop would drop it silently.
+            */
+            "confirmRenameWorktree" => &["projectId", "name"],
             "commitWorktreeBeforeDelete" => &["groupId"],
             _ => return false,
         };
@@ -27467,6 +27494,14 @@ impl GhostexGpuiApp {
                 if let Some(value) = command.get(field).and_then(serde_json::Value::as_bool) {
                     message.insert(field.to_string(), serde_json::json!(value));
                 }
+            }
+        }
+        if command_type == "confirmRenameWorktree" {
+            if let Some(value) = command
+                .get("renameBranch")
+                .and_then(serde_json::Value::as_bool)
+            {
+                message.insert("renameBranch".to_string(), serde_json::json!(value));
             }
         }
         let Some(sidebar) = self.sidebar.clone() else {
@@ -40155,6 +40190,7 @@ impl GhostexGpuiApp {
             "requestProjectWorktrees"
             | "createProjectWorktree"
             | "confirmDeleteWorktree"
+            | "confirmRenameWorktree"
             | "commitWorktreeBeforeDelete" => {
                 self.forward_gpui_worktree_modal_command_to_sidebar(command_type, command, cx);
             }

--- a/gxserver-rs/src/domain.rs
+++ b/gxserver-rs/src/domain.rs
@@ -1428,7 +1428,7 @@ fn run_git_worktree_topology_probe(project_path: &str) -> Option<GitWorktreeTopo
     })
 }
 
-fn detect_registered_git_worktree_metadata(
+pub(crate) fn detect_registered_git_worktree_metadata(
     projects: &[Value],
     project_path: &str,
     project_name: &str,

--- a/gxserver-rs/src/protocol.rs
+++ b/gxserver-rs/src/protocol.rs
@@ -424,6 +424,15 @@ pub fn endpoint_for(path: &str) -> Option<EndpointDescriptor> {
         | "/api/removeProject"
         | "/api/deleteWorktreeProject"
         /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        Renaming a worktree is remote-allowed for the same reason deleting one
+        is: a GPUI sidebar showing a remote machine's projects has to be able to
+        rename a worktree there. `projectId` is an opaque selector and `name` is
+        validated against the daemon's own ref policy before it reaches git; the
+        destination folder is computed by the daemon, never named by the caller.
+        */
+        | "/api/renameWorktreeProject"
+        /*
         CDXC:SidebarV2Worktrees 2026-07-29-00:00:
         Worktree sessions are remote-allowed for the same reason the other
         worktree RPCs are: a GPUI sidebar showing a remote machine's projects has

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -8384,6 +8384,21 @@ async fn rename_worktree_project_from_plan(
     plan: RenameWorktreeProjectPlan,
 ) -> std::result::Result<Value, RenameWorktreeProjectError> {
     let current_branch = resolve_renamed_worktree_branch_name(&plan).await?;
+    /*
+    CDXC:WorktreeRename 2026-08-10:
+    "Nothing to rename" cannot be decided from the checkbox alone. Asking to
+    rename the branch to the name it already has, on a folder that is already
+    correct, is a request to change nothing — and reporting success for that
+    tells the user something happened when it did not. The plan-time check
+    catches the checkbox-off case; this catches the one that needs git.
+    */
+    if !plan.moves_folder
+        && current_branch
+            .as_deref()
+            .is_some_and(|branch| branch == plan.params.name)
+    {
+        return Err(DomainStateError::bad_request("Nothing to rename.").into());
+    }
     let renamed_branch = rename_worktree_project_branch(&plan, current_branch.as_deref()).await?;
     if plan.moves_folder {
         if let Err(error) = move_worktree_project_checkout(&plan).await {
@@ -15228,7 +15243,7 @@ mod tests {
         );
 
         let nothing = route_http(
-            state,
+            state.clone(),
             rpc_request(
                 "/api/renameWorktreeProject",
                 &token,
@@ -15244,6 +15259,34 @@ mod tests {
         .await;
         assert_eq!(nothing.response.status(), StatusCode::BAD_REQUEST);
         let body = response_json(nothing.response).await;
+        assert_eq!(body["message"], json!("Nothing to rename."));
+
+        /*
+        CDXC:WorktreeRename 2026-08-10:
+        Asking to rename the branch to the name it already carries, on a folder
+        that is already correct, changes nothing — and reporting success for it
+        tells the user something happened. The checkbox being ticked is not
+        enough to call it a rename.
+        */
+        run_git_for_server_test(&parent, &["branch", "-m", "ghostex/0123abcd", "old"]);
+        let no_op_branch = route_http(
+            state,
+            rpc_request(
+                "/api/renameWorktreeProject",
+                &token,
+                json!({
+                    "params": {
+                        "name": "old",
+                        "projectId": worktree_project["projectId"],
+                        "renameBranch": true
+                    }
+                }),
+            ),
+            "request-rename-noop-branch".to_string(),
+        )
+        .await;
+        assert_eq!(no_op_branch.response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(no_op_branch.response).await;
         assert_eq!(body["message"], json!("Nothing to rename."));
     }
 

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -2003,6 +2003,9 @@ async fn route_http(
         "/api/deleteWorktreeProject" => {
             handle_delete_worktree_project_http(&state, endpoint.path, request_id, &body_json).await
         }
+        "/api/renameWorktreeProject" => {
+            handle_rename_worktree_project_http(&state, endpoint.path, request_id, &body_json).await
+        }
         /*
         CDXC:SidebarV2Worktrees 2026-07-29-00:00:
         Sidebar V2's worktree flow. Unlike `createProjectWorktree`, these
@@ -8071,6 +8074,654 @@ fn delete_worktree_project_error_response(
             project_path_error_response(endpoint_path, request_id, error)
         }
         DeleteWorktreeProjectError::Typed(error) => {
+            typed_operation_error_response(endpoint_path, request_id, error)
+        }
+    }
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+Renaming a worktree is a multi-step git + database mutation, so it lives behind
+ONE endpoint for exactly the reason `deleteWorktreeProject` does: the rollback
+must not depend on a renderer that may not survive the operation. The order is
+pre-flight, branch, folder, database, delta — every step checked, and everything
+reversible until the folder actually moves. If the branch rename lands and the
+move then fails, this rolls the branch back before returning, so a failed rename
+leaves nothing half-applied.
+
+The caller sends a NAME, never a path. The daemon slugs it into
+`<ParentFolder>-<slug>` next to the parent checkout itself, which is what keeps a
+renderer from pointing the move at a directory the user never named, and what
+keeps the typed operation's family-root guard meaningful.
+*/
+#[derive(Clone)]
+struct RenameWorktreeProjectParams {
+    name: String,
+    project_id: String,
+    rename_branch: bool,
+}
+
+struct RenameWorktreeProjectPlan {
+    destination_path: String,
+    moves_folder: bool,
+    params: RenameWorktreeProjectParams,
+    parent_path: String,
+    parent_project_name: String,
+    projects: Vec<Value>,
+    worktree_branch: Option<String>,
+    worktree_path: String,
+}
+
+enum RenameWorktreeProjectError {
+    Domain(DomainStateError),
+    ProjectPath(ProjectPathHttpError),
+    Typed(TypedOperationError),
+}
+
+impl From<DomainStateError> for RenameWorktreeProjectError {
+    fn from(error: DomainStateError) -> Self {
+        Self::Domain(error)
+    }
+}
+
+impl From<ProjectPathHttpError> for RenameWorktreeProjectError {
+    fn from(error: ProjectPathHttpError) -> Self {
+        Self::ProjectPath(error)
+    }
+}
+
+impl From<TypedOperationError> for RenameWorktreeProjectError {
+    fn from(error: TypedOperationError) -> Self {
+        Self::Typed(error)
+    }
+}
+
+async fn handle_rename_worktree_project_http(
+    state: &AppState,
+    endpoint_path: String,
+    request_id: String,
+    body: &Value,
+) -> RoutedResponse {
+    let params = match read_domain_rpc_params(body) {
+        Ok(params) => params,
+        Err(error) => return domain_error_response(endpoint_path, request_id, error),
+    };
+    let result = match prepare_rename_worktree_project_plan(state, &params) {
+        Ok(plan) => rename_worktree_project_from_plan(state, plan).await,
+        Err(error) => Err(error),
+    };
+    match result {
+        Ok(result) => routed_json(
+            Some(endpoint_path),
+            StatusCode::OK,
+            rpc_success(request_id, result),
+        ),
+        Err(error) => rename_worktree_project_error_response(endpoint_path, request_id, error),
+    }
+}
+
+fn normalize_rename_worktree_project_params(
+    params: &Map<String, Value>,
+) -> std::result::Result<RenameWorktreeProjectParams, DomainStateError> {
+    let project_id = read_project_id(params)?;
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string();
+    if let Some(error) = worktree_rename_name_error(&name) {
+        return Err(DomainStateError::bad_request(error));
+    }
+    Ok(RenameWorktreeProjectParams {
+        name,
+        project_id,
+        rename_branch: params.get("renameBranch").and_then(Value::as_bool) == Some(true),
+    })
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+The daemon re-validates the typed name with the same nine rules the sidebar field
+enforces (`shared/worktree-rename-name.ts`), because the field is a courtesy and
+this is the boundary. Rules 1-6 are gxserver's existing ref policy; 7-9 are the
+shapes git refuses that the character allowlist alone would let through.
+*/
+fn worktree_rename_name_error(name: &str) -> Option<&'static str> {
+    const CHARACTER_ERROR: &str =
+        "Use letters, numbers, and . _ / - only, starting with a letter or number.";
+    const SEPARATOR_ERROR: &str = "Names cannot contain \"..\", \"//\", or end with \"/\".";
+    if name.chars().count() > 200 {
+        return Some("Name is too long (200 characters max).");
+    }
+    if !name
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_alphanumeric())
+        || !name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '/' | '-'))
+        || name.ends_with('.')
+        || name
+            .split('/')
+            .any(|component| component.starts_with('.') || component.ends_with(".lock"))
+    {
+        return Some(CHARACTER_ERROR);
+    }
+    if name.contains("..") || name.contains("//") || name.ends_with('/') {
+        return Some(SEPARATOR_ERROR);
+    }
+    None
+}
+
+fn prepare_rename_worktree_project_plan(
+    state: &AppState,
+    params: &Map<String, Value>,
+) -> std::result::Result<RenameWorktreeProjectPlan, RenameWorktreeProjectError> {
+    let params = normalize_rename_worktree_project_params(params)?;
+    let db = open_gxserver_database(&state.paths).map_err(|error| DomainStateError {
+        code: "internalError",
+        message: format!("SQLite gxserver state error: {error}"),
+    })?;
+    let repository = DomainRepository::new(&db, state.metadata.server_id.as_str());
+    let projects = repository.list_projects()?;
+    let worktree_project = repository.get_project(&params.project_id)?.ok_or_else(|| {
+        DomainStateError::not_found(format!("Project {} does not exist.", params.project_id))
+    })?;
+    let worktree_project_path = worktree_project
+        .get("path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| DomainStateError::bad_request("Worktree project has no filesystem path."))?;
+    let worktree = normalize_worktree_metadata(worktree_project.get("worktree"))
+        .ok_or_else(|| DomainStateError::bad_request("Only worktree projects can be renamed."))?;
+    let parent_project = resolve_worktree_parent_project(&projects, &worktree)?;
+    let parent_project_path = parent_project
+        .get("path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| {
+            DomainStateError::not_found(format!(
+                "Parent project {} does not exist.",
+                worktree.parent_project_id
+            ))
+        })?;
+    let parent_project_name = parent_project
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let worktree_path_value = Value::String(worktree_project_path.to_string());
+    let parent_path_value = Value::String(parent_project_path.to_string());
+    let worktree_path = normalize_existing_directory_path(
+        Some(&worktree_path_value),
+        "project.path",
+        &state.paths.home_dir,
+    )?;
+    let parent_path = normalize_existing_directory_path(
+        Some(&parent_path_value),
+        "parentProject.path",
+        &state.paths.home_dir,
+    )?;
+
+    let destination_path = worktree_rename_destination_path(&parent_path, &params.name)
+        .ok_or_else(|| {
+            DomainStateError::bad_request(
+                "Use letters, numbers, and . _ / - only, starting with a letter or number.",
+            )
+        })?;
+    let moves_folder = destination_path != worktree_path;
+    if !moves_folder && !params.rename_branch {
+        return Err(DomainStateError::bad_request("Nothing to rename.").into());
+    }
+    if moves_folder {
+        if destination_path == parent_path {
+            return Err(
+                DomainStateError::bad_request("That name would collide with the main checkout.")
+                    .into(),
+            );
+        }
+        if Path::new(&destination_path).exists() {
+            return Err(DomainStateError::bad_request(format!(
+                "A folder named \"{}\" already exists next to the project.",
+                path_file_name_for_rename(&destination_path)
+            ))
+            .into());
+        }
+        if projects.iter().any(|project| {
+            project.get("projectId").and_then(Value::as_str) != Some(params.project_id.as_str())
+                && project
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .map(|path| {
+                        path_to_string(&resolve_path_syntax(PathBuf::from(path)))
+                            == destination_path
+                    })
+                    .unwrap_or(false)
+        }) {
+            return Err(DomainStateError::bad_request(
+                "Another project is already registered at that folder.",
+            )
+            .into());
+        }
+        if worktree_sessions::worktree_has_populated_submodules(&worktree_path) {
+            return Err(DomainStateError::bad_request(
+                "This worktree has initialised submodules, and git cannot move those. Remove them (git submodule deinit --all) or move the folder yourself.",
+            )
+            .into());
+        }
+        if worktree_sessions::worktree_is_locked(&parent_path, &worktree_path) {
+            return Err(DomainStateError::bad_request(
+                "This worktree is locked. Unlock it before renaming.",
+            )
+            .into());
+        }
+    }
+
+    Ok(RenameWorktreeProjectPlan {
+        destination_path,
+        moves_folder,
+        params,
+        parent_path,
+        parent_project_name,
+        projects,
+        worktree_branch: worktree.branch,
+        worktree_path,
+    })
+}
+
+/// `<dirname(parent)>/<basename(parent)>-<slug(name)>`. Worktrees stay siblings
+/// of the parent checkout because the typed operation's family-root guard is
+/// written in those terms; a destination anywhere else could not pass it.
+fn worktree_rename_destination_path(parent_path: &str, name: &str) -> Option<String> {
+    let slug = worktree_sessions::worktree_rename_folder_slug(name);
+    if slug.is_empty() {
+        return None;
+    }
+    let parent = Path::new(parent_path);
+    let folder = parent.file_name()?.to_string_lossy().to_string();
+    let family_root = parent.parent()?;
+    Some(path_to_string(
+        &family_root.join(format!("{folder}-{slug}")),
+    ))
+}
+
+fn path_file_name_for_rename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string())
+}
+
+async fn rename_worktree_project_from_plan(
+    state: &AppState,
+    plan: RenameWorktreeProjectPlan,
+) -> std::result::Result<Value, RenameWorktreeProjectError> {
+    let current_branch = resolve_renamed_worktree_branch_name(&plan).await?;
+    let renamed_branch = rename_worktree_project_branch(&plan, current_branch.as_deref()).await?;
+    if plan.moves_folder {
+        if let Err(error) = move_worktree_project_checkout(&plan).await {
+            /*
+            CDXC:WorktreeRename 2026-08-09-18:40:
+            The branch rename is the only step that already landed, and it is
+            trivially reversible, so undo it before reporting the move failure.
+            A user who sees "could not rename" must not then discover their
+            branch was renamed anyway.
+            */
+            if let (Some(from), Some(to)) = (current_branch.as_deref(), renamed_branch.as_deref()) {
+                let _ = run_rename_worktree_action(
+                    &plan.projects,
+                    "renameBranch",
+                    &plan.parent_path,
+                    rename_branch_params(to, from),
+                )
+                .await;
+            }
+            return Err(error);
+        }
+    }
+    let project = apply_renamed_worktree_project_state(state, &plan, renamed_branch.as_deref())?;
+    Ok(json!({
+        "movedFolder": plan.moves_folder,
+        "project": project,
+        "renamedBranch": renamed_branch,
+    }))
+}
+
+async fn resolve_renamed_worktree_branch_name(
+    plan: &RenameWorktreeProjectPlan,
+) -> std::result::Result<Option<String>, RenameWorktreeProjectError> {
+    let mut extra = Map::new();
+    extra.insert("action".to_string(), Value::String("branch".to_string()));
+    extra.insert(
+        "projectPath".to_string(),
+        Value::String(plan.worktree_path.clone()),
+    );
+    let branch = dispatch_typed_operation_endpoint("/api/runGitAction", &extra, plan.projects.clone())
+        .await?;
+    if exit_code(&branch) == 0 {
+        if let Some(branch_name) = branch
+            .get("stdout")
+            .and_then(Value::as_str)
+            .and_then(normalize_branch_name)
+        {
+            return Ok(Some(branch_name));
+        }
+    }
+    Ok(plan.worktree_branch.clone())
+}
+
+async fn rename_worktree_project_branch(
+    plan: &RenameWorktreeProjectPlan,
+    current_branch: Option<&str>,
+) -> std::result::Result<Option<String>, RenameWorktreeProjectError> {
+    if !plan.params.rename_branch {
+        return Ok(None);
+    }
+    let Some(current_branch) = current_branch else {
+        return Err(DomainStateError::bad_request(
+            "This worktree has no branch checked out, so there is no branch to rename.",
+        )
+        .into());
+    };
+    if current_branch == plan.params.name {
+        return Ok(None);
+    }
+    if worktree_sessions::worktree_branch_exists(&plan.parent_path, &plan.params.name) {
+        return Err(DomainStateError::bad_request(format!(
+            "Branch \"{}\" already exists.",
+            plan.params.name
+        ))
+        .into());
+    }
+    let result = run_rename_worktree_action(
+        &plan.projects,
+        "renameBranch",
+        &plan.parent_path,
+        rename_branch_params(current_branch, &plan.params.name),
+    )
+    .await?;
+    if exit_code(&result) != 0 {
+        return Err(DomainStateError::bad_request("Could not rename the branch.").into());
+    }
+    Ok(Some(plan.params.name.clone()))
+}
+
+fn rename_branch_params(branch: &str, new_branch: &str) -> Map<String, Value> {
+    let mut params = Map::new();
+    params.insert("branch".to_string(), Value::String(branch.to_string()));
+    params.insert(
+        "newBranch".to_string(),
+        Value::String(new_branch.to_string()),
+    );
+    params
+}
+
+async fn move_worktree_project_checkout(
+    plan: &RenameWorktreeProjectPlan,
+) -> std::result::Result<(), RenameWorktreeProjectError> {
+    let mut extra = Map::new();
+    extra.insert(
+        "worktreePath".to_string(),
+        Value::String(plan.worktree_path.clone()),
+    );
+    extra.insert(
+        "destinationPath".to_string(),
+        Value::String(plan.destination_path.clone()),
+    );
+    let result =
+        run_rename_worktree_action(&plan.projects, "move", &plan.parent_path, extra).await?;
+    if exit_code(&result) == 0 {
+        return Ok(());
+    }
+    /*
+    CDXC:WorktreeRename 2026-08-09-18:40:
+    git's stderr never reaches the user (typed-operation results are bounded by
+    contract), so translate the two refusals that are actionable and fall back to
+    a plain sentence for everything else. Submodules are re-checked here as well
+    as in the pre-flight because one can be initialised between the two.
+    */
+    if is_submodule_removal_refusal(&result) {
+        return Err(DomainStateError::bad_request(
+            "This worktree has initialised submodules, and git cannot move those. Remove them (git submodule deinit --all) or move the folder yourself.",
+        )
+        .into());
+    }
+    if is_locked_worktree_refusal(&result) {
+        return Err(DomainStateError::bad_request(
+            "This worktree is locked. Unlock it before renaming.",
+        )
+        .into());
+    }
+    Err(DomainStateError::bad_request("Could not move the worktree folder.").into())
+}
+
+async fn run_rename_worktree_action(
+    projects: &[Value],
+    action: &str,
+    project_path: &str,
+    mut extra_params: Map<String, Value>,
+) -> std::result::Result<Value, RenameWorktreeProjectError> {
+    extra_params.insert("action".to_string(), Value::String(action.to_string()));
+    extra_params.insert(
+        "projectPath".to_string(),
+        Value::String(project_path.to_string()),
+    );
+    dispatch_typed_operation_endpoint("/api/runWorktreeAction", &extra_params, projects.to_vec())
+        .await
+        .map_err(Into::into)
+}
+
+fn is_locked_worktree_refusal(result: &Value) -> bool {
+    let text = format!(
+        "{}\n{}",
+        result
+            .get("stderr")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        result
+            .get("stdout")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+    );
+    text.to_lowercase()
+        .contains("cannot move a locked working tree")
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+Everything that mirrors the worktree's location has to move with it in one pass,
+because the alternative is a sidebar row pointing at a folder that no longer
+exists — worse than not having the feature. The full list, each traced rather
+than guessed:
+
+- `projects.path`, through `relocate_project` so the destination is validated and
+  a collision with another registered project is still refused;
+- `projects.name`, the derived `<ParentProjectName>-<slug>` label;
+- `projects.worktreeJson`, re-detected from git at the new path (its `name` and
+  `branch` are stamped once at registration and never recomputed otherwise);
+- every `sessions.cwd` under the old folder — V2 worktree sessions store an
+  absolute cwd, and `start_session_provider` bakes that cwd into the generated
+  run script, so a stale one breaks the next cold start;
+- the V2 worktree session marker's `path`, which is the only authority the
+  branch auto-rename trusts and silently no-ops when it points nowhere;
+- `projectBoardConfig.beadsDirectory`, but only when it is an absolute path
+  inside the worktree; it defaults to the project path, which the relocate fixes.
+
+Caches are deliberately absent: the git-status cache, the worktree-topology probe
+(60s TTL), and the project-icon cache are all keyed by path and self-heal.
+*/
+fn apply_renamed_worktree_project_state(
+    state: &AppState,
+    plan: &RenameWorktreeProjectPlan,
+    renamed_branch: Option<&str>,
+) -> std::result::Result<Value, RenameWorktreeProjectError> {
+    let db = open_gxserver_database(&state.paths).map_err(|error| DomainStateError {
+        code: "internalError",
+        message: format!("SQLite gxserver state error: {error}"),
+    })?;
+    let repository = DomainRepository::new(&db, state.metadata.server_id.as_str());
+    let project_id = plan.params.project_id.as_str();
+
+    if plan.moves_folder {
+        let mut relocate = Map::new();
+        relocate.insert("projectId".to_string(), json!(project_id));
+        relocate.insert("path".to_string(), json!(plan.destination_path.clone()));
+        repository.relocate_project(&relocate)?;
+    }
+
+    let projects = repository.list_projects()?;
+    let project_name = renamed_worktree_project_name(plan);
+    let mut update = Map::new();
+    update.insert("projectId".to_string(), json!(project_id));
+    update.insert("name".to_string(), json!(project_name.clone()));
+    if let Some(worktree) = crate::domain::detect_registered_git_worktree_metadata(
+        &projects,
+        &plan.destination_path,
+        &project_name,
+    ) {
+        let mut worktree = worktree;
+        /*
+        The worktree's `createdAt` records when the checkout was made, so keep
+        the registered value instead of stamping the rename as a creation.
+        */
+        if let Some(created_at) = projects
+            .iter()
+            .find(|candidate| candidate.get("projectId").and_then(Value::as_str) == Some(project_id))
+            .and_then(|candidate| candidate.get("worktree"))
+            .and_then(Value::as_object)
+            .and_then(|current| current.get("createdAt"))
+            .cloned()
+        {
+            worktree.insert("createdAt".to_string(), created_at);
+        }
+        update.insert("worktree".to_string(), Value::Object(worktree));
+    }
+    if let Some(board_config) = renamed_worktree_board_config(&projects, plan) {
+        update.insert("projectBoardConfig".to_string(), Value::Object(board_config));
+    }
+    let project = repository.update_project(&update)?;
+
+    if plan.moves_folder {
+        for session in repository.list_sessions(Some(project_id))? {
+            let Some(session_id) = session.get("sessionId").and_then(Value::as_str) else {
+                continue;
+            };
+            let mut session_update = Map::new();
+            let moved_cwd = session
+                .get("cwd")
+                .and_then(Value::as_str)
+                .and_then(|cwd| rebase_renamed_worktree_path(cwd, plan));
+            if let Some(cwd) = moved_cwd {
+                session_update.insert("cwd".to_string(), json!(cwd));
+            }
+            if let Some(runtime_settings) =
+                worktree_sessions::runtime_settings_with_moved_worktree_path(
+                    &session,
+                    &plan.destination_path,
+                    renamed_branch,
+                )
+            {
+                session_update.insert(
+                    "runtimeSettings".to_string(),
+                    Value::Object(runtime_settings),
+                );
+            }
+            if session_update.is_empty() {
+                continue;
+            }
+            session_update.insert("projectId".to_string(), json!(project_id));
+            session_update.insert("sessionId".to_string(), json!(session_id));
+            repository.update_session(&session_update)?;
+        }
+    } else if let Some(branch) = renamed_branch {
+        for session in repository.list_sessions(Some(project_id))? {
+            let Some(session_id) = session.get("sessionId").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(runtime_settings) = worktree_sessions::runtime_settings_with_moved_worktree_path(
+                &session,
+                &plan.worktree_path,
+                Some(branch),
+            ) else {
+                continue;
+            };
+            let mut session_update = Map::new();
+            session_update.insert("projectId".to_string(), json!(project_id));
+            session_update.insert("sessionId".to_string(), json!(session_id));
+            session_update.insert(
+                "runtimeSettings".to_string(),
+                Value::Object(runtime_settings),
+            );
+            repository.update_session(&session_update)?;
+        }
+    }
+
+    schedule_presentation_project_delta(state, &db, &repository, project_id, "projectUpdated")?;
+    Ok(project)
+}
+
+fn renamed_worktree_project_name(plan: &RenameWorktreeProjectPlan) -> String {
+    let suffix = path_file_name_for_rename(&plan.destination_path);
+    let parent_folder = path_file_name_for_rename(&plan.parent_path);
+    let slug = suffix
+        .strip_prefix(&format!("{parent_folder}-"))
+        .unwrap_or(&suffix);
+    let parent_label = if plan.parent_project_name.trim().is_empty() {
+        parent_folder.as_str()
+    } else {
+        plan.parent_project_name.trim()
+    };
+    format!("{parent_label}-{slug}")
+}
+
+fn renamed_worktree_board_config(
+    projects: &[Value],
+    plan: &RenameWorktreeProjectPlan,
+) -> Option<Map<String, Value>> {
+    if !plan.moves_folder {
+        return None;
+    }
+    let mut board_config = projects
+        .iter()
+        .find(|candidate| {
+            candidate.get("projectId").and_then(Value::as_str)
+                == Some(plan.params.project_id.as_str())
+        })?
+        .get("projectBoardConfig")
+        .and_then(Value::as_object)
+        .cloned()?;
+    let directory = board_config.get("beadsDirectory").and_then(Value::as_str)?;
+    let moved = rebase_renamed_worktree_path(directory, plan)?;
+    board_config.insert("beadsDirectory".to_string(), json!(moved));
+    Some(board_config)
+}
+
+/// `<old worktree>/x` becomes `<new worktree>/x`; anything outside the moved
+/// folder is left exactly as it is.
+fn rebase_renamed_worktree_path(path: &str, plan: &RenameWorktreeProjectPlan) -> Option<String> {
+    let normalized = path_to_string(&resolve_path_syntax(PathBuf::from(path)));
+    if normalized == plan.worktree_path {
+        return Some(plan.destination_path.clone());
+    }
+    let prefix = format!("{}/", plan.worktree_path);
+    let rest = normalized.strip_prefix(&prefix)?;
+    Some(format!("{}/{rest}", plan.destination_path))
+}
+
+fn rename_worktree_project_error_response(
+    endpoint_path: String,
+    request_id: String,
+    error: RenameWorktreeProjectError,
+) -> RoutedResponse {
+    match error {
+        RenameWorktreeProjectError::Domain(error) => {
+            domain_error_response(endpoint_path, request_id, error)
+        }
+        RenameWorktreeProjectError::ProjectPath(error) => {
+            project_path_error_response(endpoint_path, request_id, error)
+        }
+        RenameWorktreeProjectError::Typed(error) => {
             typed_operation_error_response(endpoint_path, request_id, error)
         }
     }
@@ -14305,6 +14956,269 @@ mod tests {
             .unwrap()
             .iter()
             .any(|project| project["projectId"] == worktree_project["projectId"]));
+    }
+
+    #[tokio::test]
+    async fn renaming_a_worktree_updates_the_project_path_and_every_session_cwd() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        The lockstep contract. A rename that moves the folder but leaves the
+        database describing the old one is worse than no feature: the sidebar row
+        points at a dead path, `start_session_provider` refuses to start anything
+        there, and the V2 worktree marker silently stops being renameable. Assert
+        the whole set in one pass — project path, derived label, re-detected
+        worktree metadata, every session cwd, and the marker path — because they
+        only have value together.
+        */
+        if !git_available() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = get_gxserver_paths(Some(temp.path().to_path_buf()));
+        let state = test_app_state(paths.clone());
+        let token = state.auth_token.clone();
+        let parent = paths.root_dir.join("rename-worktree-parent");
+        let worktree = paths.root_dir.join("rename-worktree-parent-old");
+        create_git_repository_for_server_test(&parent);
+        run_git_for_server_test(&parent, &["branch", "ghostex/0123abcd"]);
+        run_git_for_server_test(
+            &parent,
+            &[
+                "worktree",
+                "add",
+                path_to_string(&worktree).as_str(),
+                "ghostex/0123abcd",
+            ],
+        );
+
+        let parent_project =
+            add_project_path_for_server_test(state.clone(), &token, &parent, Some("Parent")).await;
+        let worktree_project =
+            add_project_path_for_server_test(state.clone(), &token, &worktree, None).await;
+        assert_eq!(
+            worktree_project["worktree"]["parentProjectId"],
+            parent_project["projectId"]
+        );
+
+        let marker = worktree_sessions::worktree_session_marker_value(
+            "ghostex/0123abcd",
+            &path_to_string(&worktree),
+            "Codex Session",
+            "2026-07-29T00:00:00.000Z",
+        );
+        let created = route_http(
+            state.clone(),
+            rpc_request(
+                "/api/createSession",
+                &token,
+                json!({
+                    "params": {
+                        "cwd": path_to_string(&worktree.join("packages/app")),
+                        "kind": "terminal",
+                        "projectId": worktree_project["projectId"],
+                        "runtimeSettings": {
+                            worktree_sessions::WORKTREE_SESSION_RUNTIME_KEY: marker,
+                        },
+                        "title": "Codex Session",
+                    }
+                }),
+            ),
+            "request-create-rename-session".to_string(),
+        )
+        .await;
+        assert_eq!(created.response.status(), StatusCode::OK);
+        let session = response_json(created.response).await["result"]["session"].clone();
+
+        let response = route_http(
+            state.clone(),
+            rpc_request(
+                "/api/renameWorktreeProject",
+                &token,
+                json!({
+                    "params": {
+                        "name": "feat/kanban-assignee",
+                        "projectId": worktree_project["projectId"],
+                        "renameBranch": true
+                    }
+                }),
+            ),
+            "request-rename-worktree".to_string(),
+        )
+        .await;
+        assert_eq!(response.response.status(), StatusCode::OK);
+        let body = response_json(response.response).await;
+        let renamed = paths
+            .root_dir
+            .join("rename-worktree-parent-feat-kanban-assignee");
+
+        assert_eq!(body["result"]["movedFolder"], json!(true));
+        assert_eq!(body["result"]["renamedBranch"], json!("feat/kanban-assignee"));
+        assert_eq!(body["result"]["project"]["path"], json!(path_to_string(&renamed)));
+        assert_eq!(
+            body["result"]["project"]["name"],
+            json!("Parent-feat-kanban-assignee")
+        );
+        assert_eq!(
+            body["result"]["project"]["worktree"]["name"],
+            json!("rename-worktree-parent-feat-kanban-assignee")
+        );
+        assert_eq!(
+            body["result"]["project"]["worktree"]["branch"],
+            json!("feat/kanban-assignee")
+        );
+        assert_eq!(
+            body["result"]["project"]["worktree"]["createdAt"],
+            worktree_project["worktree"]["createdAt"],
+            "a rename is not a new checkout"
+        );
+        assert!(renamed.is_dir());
+        assert!(!worktree.exists());
+        assert_eq!(
+            run_git_for_server_test(&renamed, &["branch", "--show-current"]).trim(),
+            "feat/kanban-assignee"
+        );
+
+        let sessions = route_http(
+            state,
+            rpc_request(
+                "/api/listSessions",
+                &token,
+                json!({ "params": { "projectId": worktree_project["projectId"] } }),
+            ),
+            "request-list-renamed-sessions".to_string(),
+        )
+        .await;
+        let sessions = response_json(sessions.response).await;
+        let moved = sessions["result"]["sessions"]
+            .as_array()
+            .expect("sessions")
+            .iter()
+            .find(|candidate| candidate["sessionId"] == session["sessionId"])
+            .cloned()
+            .expect("renamed session");
+        assert_eq!(
+            moved["cwd"],
+            json!(path_to_string(&renamed.join("packages/app"))),
+            "a cwd inside the moved folder follows it"
+        );
+        let moved_marker =
+            &moved["runtimeSettings"][worktree_sessions::WORKTREE_SESSION_RUNTIME_KEY];
+        assert_eq!(moved_marker["path"], json!(path_to_string(&renamed)));
+        assert_eq!(moved_marker["branch"], json!("feat/kanban-assignee"));
+        assert_eq!(moved_marker["initialTitle"], json!("Codex Session"));
+    }
+
+    #[tokio::test]
+    async fn renaming_a_worktree_refuses_a_taken_folder_and_a_taken_branch() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        Both refusals must land BEFORE anything is touched, and both must say
+        which name is in the way. The folder case is the important one: with the
+        destination already present, `git worktree move` exits 0 and nests the
+        checkout one level deeper, so "no error" would otherwise mean "the folder
+        is somewhere nobody asked for".
+        */
+        if !git_available() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = get_gxserver_paths(Some(temp.path().to_path_buf()));
+        let state = test_app_state(paths.clone());
+        let token = state.auth_token.clone();
+        let parent = paths.root_dir.join("rename-guard-parent");
+        let worktree = paths.root_dir.join("rename-guard-parent-old");
+        create_git_repository_for_server_test(&parent);
+        run_git_for_server_test(&parent, &["branch", "ghostex/0123abcd"]);
+        run_git_for_server_test(&parent, &["branch", "feat/taken"]);
+        run_git_for_server_test(
+            &parent,
+            &[
+                "worktree",
+                "add",
+                path_to_string(&worktree).as_str(),
+                "ghostex/0123abcd",
+            ],
+        );
+        fs::create_dir_all(paths.root_dir.join("rename-guard-parent-busy")).expect("busy dir");
+
+        add_project_path_for_server_test(state.clone(), &token, &parent, Some("Parent")).await;
+        let worktree_project =
+            add_project_path_for_server_test(state.clone(), &token, &worktree, None).await;
+
+        let taken_folder = route_http(
+            state.clone(),
+            rpc_request(
+                "/api/renameWorktreeProject",
+                &token,
+                json!({
+                    "params": {
+                        "name": "busy",
+                        "projectId": worktree_project["projectId"]
+                    }
+                }),
+            ),
+            "request-rename-taken-folder".to_string(),
+        )
+        .await;
+        assert_eq!(taken_folder.response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(taken_folder.response).await;
+        assert_eq!(
+            body["message"],
+            json!("A folder named \"rename-guard-parent-busy\" already exists next to the project.")
+        );
+        assert!(worktree.is_dir(), "the worktree never moved");
+
+        let taken_branch = route_http(
+            state.clone(),
+            rpc_request(
+                "/api/renameWorktreeProject",
+                &token,
+                json!({
+                    "params": {
+                        "name": "feat/taken",
+                        "projectId": worktree_project["projectId"],
+                        "renameBranch": true
+                    }
+                }),
+            ),
+            "request-rename-taken-branch".to_string(),
+        )
+        .await;
+        assert_eq!(taken_branch.response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(taken_branch.response).await;
+        assert_eq!(
+            body["message"],
+            json!("Branch \"feat/taken\" already exists.")
+        );
+        assert!(
+            worktree.is_dir(),
+            "a refused branch rename never moves the folder"
+        );
+        assert_eq!(
+            run_git_for_server_test(&worktree, &["branch", "--show-current"]).trim(),
+            "ghostex/0123abcd"
+        );
+
+        let nothing = route_http(
+            state,
+            rpc_request(
+                "/api/renameWorktreeProject",
+                &token,
+                json!({
+                    "params": {
+                        "name": "old",
+                        "projectId": worktree_project["projectId"]
+                    }
+                }),
+            ),
+            "request-rename-nothing".to_string(),
+        )
+        .await;
+        assert_eq!(nothing.response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(nothing.response).await;
+        assert_eq!(body["message"], json!("Nothing to rename."));
     }
 
     #[tokio::test]

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -7917,7 +7917,7 @@ async fn remove_worktree_checkout(
     let mut remove =
         run_delete_worktree_action(&plan.projects, "remove", &plan.parent_path, extra).await?;
     let mut retried_for_submodules = false;
-    if exit_code(&remove) != 0 && !force_initial_remove && is_submodule_removal_refusal(&remove) {
+    if exit_code(&remove) != 0 && !force_initial_remove && is_submodule_worktree_refusal(&remove) {
         retried_for_submodules = true;
         let mut retry_extra = Map::new();
         retry_extra.insert(
@@ -8110,6 +8110,20 @@ struct RenameWorktreeProjectPlan {
     projects: Vec<Value>,
     worktree_branch: Option<String>,
     worktree_path: String,
+    /*
+    CDXC:WorktreeRename 2026-08-10:
+    The same folder can be spelled two ways on macOS — `/tmp/rt-old` and
+    `/private/tmp/rt-old` — and nothing forces a session's stored `cwd` to use
+    the spelling the project row happens to carry. Rebasing compares strings, so
+    a session recorded through the other spelling matched no prefix, kept an
+    absolute path into a folder that had just moved, and broke on its next cold
+    start (`start_session_provider` bakes the cwd into the run script).
+
+    Resolve the alias here, at plan time, because it is the last moment the old
+    folder still exists to resolve. `None` when it cannot be resolved or adds
+    nothing, so the lexical comparison stays the only one that runs.
+    */
+    worktree_path_resolved: Option<String>,
 }
 
 enum RenameWorktreeProjectError {
@@ -8330,6 +8344,19 @@ fn prepare_rename_worktree_project_plan(
             )
             .into());
         }
+        /*
+        CDXC:WorktreeRename 2026-08-10:
+        These two probes exist to refuse early, with a sentence the user can act
+        on, and they are not authoritative. `worktree_is_locked` matches
+        `worktree_path` against what `git worktree list --porcelain` prints, and
+        git prints the symlink-resolved path while `normalize_existing_directory_path`
+        deliberately does not resolve one — a worktree registered through an
+        alias that still sits lexically inside the family root passes the guard
+        above and then reads as "not locked" here. A submodule can also be
+        initialised between this check and the move. `move_worktree_project_checkout`
+        re-classifies both refusals off git's own output and produces the same
+        sentences, so it, not this, is what actually enforces them.
+        */
         if worktree_sessions::worktree_has_populated_submodules(&worktree_path) {
             return Err(DomainStateError::bad_request(
                 "This worktree has initialised submodules, and git cannot move those. Remove them (git submodule deinit --all) or move the folder yourself.",
@@ -8344,6 +8371,11 @@ fn prepare_rename_worktree_project_plan(
         }
     }
 
+    let worktree_path_resolved = std::fs::canonicalize(&worktree_path)
+        .ok()
+        .map(|path| path_to_string(&path))
+        .filter(|resolved| resolved != &worktree_path);
+
     Ok(RenameWorktreeProjectPlan {
         destination_path,
         moves_folder,
@@ -8353,6 +8385,7 @@ fn prepare_rename_worktree_project_plan(
         projects,
         worktree_branch: worktree.branch,
         worktree_path,
+        worktree_path_resolved,
     })
 }
 
@@ -8410,13 +8443,41 @@ async fn rename_worktree_project_from_plan(
             branch was renamed anyway.
             */
             if let (Some(from), Some(to)) = (current_branch.as_deref(), renamed_branch.as_deref()) {
-                let _ = run_rename_worktree_action(
+                /*
+                CDXC:WorktreeRename 2026-08-10:
+                The undo is the only thing standing between the user and the
+                state the comment above forbids, so a failed undo is exactly the
+                case worth recording. Dropping it left the branch renamed, the
+                request reporting the move error, and nothing anywhere saying
+                the two had diverged. The user still gets the move error — the
+                rename genuinely did not happen — but support can now see it.
+                */
+                let rollback = run_rename_worktree_action(
                     &plan.projects,
                     "renameBranch",
                     &plan.parent_path,
                     rename_branch_params(to, from),
                 )
                 .await;
+                let rollback_failure = match &rollback {
+                    Err(_) => Some("branch rollback dispatch failed".to_string()),
+                    Ok(result) if exit_code(result) != 0 => {
+                        Some(format!("git exited {}", exit_code(result)))
+                    }
+                    Ok(_) => None,
+                };
+                if let Some(reason) = rollback_failure {
+                    let _ = state.logger.log(GxserverLogInput {
+                        level: LogLevel::Warn,
+                        event: "worktreeRenameBranchRollbackFailed".to_string(),
+                        server_id: Some(state.metadata.server_id.clone()),
+                        request_id: None,
+                        client: None,
+                        duration_ms: None,
+                        error: Some(reason),
+                        details: Some(json!({ "projectId": plan.params.project_id })),
+                    });
+                }
             }
             return Err(error);
         }
@@ -8522,7 +8583,7 @@ async fn move_worktree_project_checkout(
     a plain sentence for everything else. Submodules are re-checked here as well
     as in the pre-flight because one can be initialised between the two.
     */
-    if is_submodule_removal_refusal(&result) {
+    if is_submodule_worktree_refusal(&result) {
         return Err(DomainStateError::bad_request(
             "This worktree has initialised submodules, and git cannot move those. Remove them (git submodule deinit --all) or move the folder yourself.",
         )
@@ -8597,11 +8658,83 @@ fn apply_renamed_worktree_project_state(
     plan: &RenameWorktreeProjectPlan,
     renamed_branch: Option<&str>,
 ) -> std::result::Result<Value, RenameWorktreeProjectError> {
-    let db = open_gxserver_database(&state.paths).map_err(|error| DomainStateError {
-        code: "internalError",
-        message: format!("SQLite gxserver state error: {error}"),
-    })?;
+    /*
+    The busy handler is the point of this entry point: the transaction below
+    reserves the writer, and the daemon has other writers (lifecycle sweeps,
+    session updates). Without lock waiting, a concurrent write would fail this
+    one outright — after the folder has already moved, which is the one moment
+    there is nothing to retry.
+    */
+    let db = open_gxserver_database_with_busy_timeout(&state.paths, Duration::from_secs(10))
+        .map_err(|error| DomainStateError {
+            code: "internalError",
+            message: format!("SQLite gxserver state error: {error}"),
+        })?;
+    let project_id = plan.params.project_id.as_str();
+    /*
+    CDXC:WorktreeRename 2026-08-10:
+    The folder has already moved by the time any of this runs, so these rows are
+    the only remaining description of where it went — and the list above only has
+    value whole. Written one statement at a time, a session write that failed
+    halfway left the project row pointing at the new folder while the sessions
+    behind it still named the old one: a state no later request can tell apart
+    from a rename that worked. One transaction makes the failure mean "the
+    database still describes the old folder", which the returned error then says.
+    Following `create_session_transactional`: IMMEDIATE so the writer reservation
+    is held before the first read the writes depend on.
+    */
+    let transaction =
+        rusqlite::Transaction::new_unchecked(&db, rusqlite::TransactionBehavior::Immediate)
+            .map_err(|error| DomainStateError {
+                code: "internalError",
+                message: format!("SQLite gxserver state error: {error}"),
+            })?;
+    let project = {
+        let repository = DomainRepository::new(&transaction, state.metadata.server_id.as_str());
+        write_renamed_worktree_project_state(&repository, plan, renamed_branch)
+            .map_err(|error| unrecorded_worktree_rename_error(plan, error))?
+    };
+    transaction
+        .commit()
+        .map_err(|error| DomainStateError {
+            code: "internalError",
+            message: format!("SQLite gxserver state error: {error}"),
+        })
+        .map_err(|error| unrecorded_worktree_rename_error(plan, error.into()))?;
+
     let repository = DomainRepository::new(&db, state.metadata.server_id.as_str());
+    schedule_presentation_project_delta(state, &db, &repository, project_id, "projectUpdated")?;
+    Ok(project)
+}
+
+/// The transaction rolled back, so the database still describes the old folder
+/// while the filesystem no longer has one there. Say both halves: without the
+/// paths, "SQLite error" gives nobody enough to put the two back in step.
+fn unrecorded_worktree_rename_error(
+    plan: &RenameWorktreeProjectPlan,
+    error: RenameWorktreeProjectError,
+) -> RenameWorktreeProjectError {
+    if !plan.moves_folder {
+        return error;
+    }
+    let RenameWorktreeProjectError::Domain(domain) = error else {
+        return error;
+    };
+    DomainStateError {
+        code: domain.code,
+        message: format!(
+            "The worktree folder moved to \"{}\", but Ghostex could not record it and still points at \"{}\". Nothing else was changed. ({})",
+            plan.destination_path, plan.worktree_path, domain.message
+        ),
+    }
+    .into()
+}
+
+fn write_renamed_worktree_project_state(
+    repository: &DomainRepository<'_>,
+    plan: &RenameWorktreeProjectPlan,
+    renamed_branch: Option<&str>,
+) -> std::result::Result<Value, RenameWorktreeProjectError> {
     let project_id = plan.params.project_id.as_str();
 
     if plan.moves_folder {
@@ -8698,7 +8831,6 @@ fn apply_renamed_worktree_project_state(
         }
     }
 
-    schedule_presentation_project_delta(state, &db, &repository, project_id, "projectUpdated")?;
     Ok(project)
 }
 
@@ -8739,15 +8871,21 @@ fn renamed_worktree_board_config(
 }
 
 /// `<old worktree>/x` becomes `<new worktree>/x`; anything outside the moved
-/// folder is left exactly as it is.
+/// folder is left exactly as it is. The old folder is recognised through either
+/// spelling it had before the move — see `worktree_path_resolved`.
 fn rebase_renamed_worktree_path(path: &str, plan: &RenameWorktreeProjectPlan) -> Option<String> {
     let normalized = path_to_string(&resolve_path_syntax(PathBuf::from(path)));
-    if normalized == plan.worktree_path {
-        return Some(plan.destination_path.clone());
+    let roots =
+        std::iter::once(plan.worktree_path.as_str()).chain(plan.worktree_path_resolved.as_deref());
+    for root in roots {
+        if normalized == root {
+            return Some(plan.destination_path.clone());
+        }
+        if let Some(rest) = normalized.strip_prefix(&format!("{root}/")) {
+            return Some(format!("{}/{rest}", plan.destination_path));
+        }
     }
-    let prefix = format!("{}/", plan.worktree_path);
-    let rest = normalized.strip_prefix(&prefix)?;
-    Some(format!("{}/{rest}", plan.destination_path))
+    None
 }
 
 fn rename_worktree_project_error_response(
@@ -8791,7 +8929,9 @@ fn has_porcelain_status_changes(stdout: &str) -> bool {
     })
 }
 
-fn is_submodule_removal_refusal(result: &Value) -> bool {
+/// git refuses `worktree remove` and `worktree move` on a checkout with
+/// initialised submodules through the same message, so both verbs classify here.
+fn is_submodule_worktree_refusal(result: &Value) -> bool {
     let text = format!(
         "{}\n{}",
         result
@@ -15150,6 +15290,61 @@ mod tests {
         assert_eq!(moved_marker["initialTitle"], json!("Codex Session"));
     }
 
+    #[test]
+    fn a_session_cwd_recorded_through_the_resolved_path_form_still_follows_the_move() {
+        /*
+        CDXC:WorktreeRename 2026-08-10:
+        Nothing forces a session's stored `cwd` to use the same spelling of a
+        folder that the project row happens to carry, and on macOS every path
+        under `/tmp` or `/var` has two: `/tmp/rt-old` and `/private/tmp/rt-old`.
+        Compared lexically against the project row's spelling alone, a cwd
+        recorded through the other one matched no prefix, was left untouched, and
+        pointed into a folder that had just moved — which breaks that session's
+        next cold start, because `start_session_provider` bakes the cwd into the
+        generated run script. Both spellings of the old folder rebase; anything
+        genuinely outside it still does not.
+        */
+        let plan = RenameWorktreeProjectPlan {
+            destination_path: "/tmp/rt-new".to_string(),
+            moves_folder: true,
+            params: RenameWorktreeProjectParams {
+                name: "new".to_string(),
+                project_id: "project-1".to_string(),
+                rename_branch: false,
+            },
+            parent_path: "/tmp/rt".to_string(),
+            parent_project_name: "Parent".to_string(),
+            projects: Vec::new(),
+            worktree_branch: None,
+            worktree_path: "/tmp/rt-old".to_string(),
+            worktree_path_resolved: Some("/private/tmp/rt-old".to_string()),
+        };
+
+        assert_eq!(
+            rebase_renamed_worktree_path("/tmp/rt-old/packages/app", &plan).as_deref(),
+            Some("/tmp/rt-new/packages/app"),
+            "the spelling the project row carries"
+        );
+        assert_eq!(
+            rebase_renamed_worktree_path("/private/tmp/rt-old/packages/app", &plan).as_deref(),
+            Some("/tmp/rt-new/packages/app"),
+            "the spelling the filesystem resolves to"
+        );
+        assert_eq!(
+            rebase_renamed_worktree_path("/private/tmp/rt-old", &plan).as_deref(),
+            Some("/tmp/rt-new")
+        );
+        assert_eq!(
+            rebase_renamed_worktree_path("/private/tmp/rt-older/src", &plan),
+            None,
+            "a sibling that merely shares a prefix is not inside the moved folder"
+        );
+        assert_eq!(
+            rebase_renamed_worktree_path("/tmp/somewhere-else", &plan),
+            None
+        );
+    }
+
     #[tokio::test]
     async fn renaming_a_worktree_refuses_a_taken_folder_and_a_taken_branch() {
         /*
@@ -15290,6 +15485,9 @@ mod tests {
         assert_eq!(body["message"], json!("Nothing to rename."));
     }
 
+    // Symlinks are the whole subject of this test, and `std::os::unix::fs` does
+    // not exist off unix — without the gate the module stops compiling there.
+    #[cfg(unix)]
     #[tokio::test]
     async fn renaming_explains_a_worktree_registered_through_a_different_path_form() {
         /*

--- a/gxserver-rs/src/server.rs
+++ b/gxserver-rs/src/server.rs
@@ -8264,6 +8264,32 @@ fn prepare_rename_worktree_project_plan(
         &state.paths.home_dir,
     )?;
 
+    /*
+    CDXC:WorktreeRename 2026-08-09-18:40:
+    The typed operation scopes every worktree command to "inside the parent's
+    family directory" and compares paths LEXICALLY, by design — it collapses
+    `.`/`..` but deliberately does not resolve symlinks. So two rows that
+    describe the same folder through different symlink forms fail that guard
+    with a sentence about `worktreePath`, which means nothing to whoever just
+    clicked Rename. It happens for real on macOS: register a project as
+    `/tmp/rt` and its worktree resolves to `/private/tmp/rt-old`, because
+    `git worktree list` reports the resolved path while the project kept the
+    typed one.
+
+    Catch it here, where both paths are known, and say which two disagree. The
+    typed-operation guard stays the backstop; this only replaces the message.
+    */
+    let family_root = Path::new(&parent_path)
+        .parent()
+        .map(path_to_string)
+        .unwrap_or_else(|| parent_path.clone());
+    if !worktree_path.starts_with(&format!("{family_root}/")) {
+        return Err(DomainStateError::bad_request(
+            "This worktree and its project are registered under different paths, so Ghostex cannot tell they are siblings. This usually means one path goes through a symlink. Re-add the project using the same path form as the worktree.",
+        )
+        .into());
+    }
+
     let destination_path = worktree_rename_destination_path(&parent_path, &params.name)
         .ok_or_else(|| {
             DomainStateError::bad_request(
@@ -15219,6 +15245,83 @@ mod tests {
         assert_eq!(nothing.response.status(), StatusCode::BAD_REQUEST);
         let body = response_json(nothing.response).await;
         assert_eq!(body["message"], json!("Nothing to rename."));
+    }
+
+    #[tokio::test]
+    async fn renaming_explains_a_worktree_registered_through_a_different_path_form() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        Reproduces a real failure from manual testing on macOS: the project was
+        registered as `/tmp/rt` while its worktree resolved to
+        `/private/tmp/rt-old`, because `git worktree list` reports the symlink-
+        resolved path and the project kept the typed one. The typed operation
+        compares paths lexically by design, so it refused with a sentence about
+        `worktreePath` that meant nothing to the user. The rename must explain
+        which two things disagree instead of forwarding that.
+        */
+        if !git_available() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = get_gxserver_paths(Some(temp.path().to_path_buf()));
+        let state = test_app_state(paths.clone());
+        let token = state.auth_token.clone();
+        let real_root = paths.root_dir.join("symlink-family");
+        fs::create_dir_all(&real_root).expect("real root");
+        let parent = real_root.join("rt");
+        let worktree = real_root.join("rt-old");
+        create_git_repository_for_server_test(&parent);
+        run_git_for_server_test(&parent, &["branch", "feat/old"]);
+        run_git_for_server_test(
+            &parent,
+            &[
+                "worktree",
+                "add",
+                path_to_string(&worktree).as_str(),
+                "feat/old",
+            ],
+        );
+
+        // The parent is registered through a symlinked alias of the same folder,
+        // exactly as `/tmp/rt` aliases `/private/tmp/rt`.
+        let alias_root = paths.root_dir.join("symlink-alias");
+        std::os::unix::fs::symlink(&real_root, &alias_root).expect("symlink");
+        let aliased_parent = alias_root.join("rt");
+
+        add_project_path_for_server_test(state.clone(), &token, &aliased_parent, Some("Parent"))
+            .await;
+        let worktree_project =
+            add_project_path_for_server_test(state.clone(), &token, &worktree, None).await;
+
+        let response = route_http(
+            state,
+            rpc_request(
+                "/api/renameWorktreeProject",
+                &token,
+                json!({
+                    "params": {
+                        "name": "renamed",
+                        "projectId": worktree_project["projectId"]
+                    }
+                }),
+            ),
+            "request-rename-symlinked-family".to_string(),
+        )
+        .await;
+
+        assert_eq!(response.response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response.response).await;
+        let message = body["message"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("registered under different paths"),
+            "expected the mismatch explained, got: {message}"
+        );
+        assert!(
+            !message.contains("worktreePath"),
+            "the internal typed-operation sentence must not reach the user: {message}"
+        );
+        assert!(worktree.is_dir(), "nothing was touched");
     }
 
     #[tokio::test]

--- a/gxserver-rs/src/typed_operations.rs
+++ b/gxserver-rs/src/typed_operations.rs
@@ -470,6 +470,43 @@ async fn run_worktree_action(
     if action == "ensureBeadsHooks" {
         return ensure_beads_git_hooks(context).await;
     }
+    if action == "hasPopulatedSubmodules" {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        `git worktree move` hard-refuses a worktree with populated submodules,
+        and the only honest answer is to say so before the user names a folder.
+        This probe stays worktree-scoped (it only ever inspects a path already
+        proven to be inside the caller's worktree family) instead of widening
+        the git action list with a general `submodule` primitive. It follows
+        `pathExists`'s convention: exit code 0 means "yes".
+        */
+        let worktree_path = normalize_existing_worktree_path(params.get("worktreePath"), context)?;
+        let populated = crate::worktree_sessions::worktree_has_populated_submodules(&worktree_path);
+        return Ok(json!({
+            "action": action,
+            "exitCode": if populated { 0 } else { 1 },
+            "stderr": "",
+            "stdout": if populated { "true" } else { "false" },
+        }));
+    }
+    if action == "renameBranch" {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        `refs/heads/<x>` cannot exist while `refs/heads/<x>/…` does, in either
+        direction, and `git branch -m` reports that as a bare
+        `fatal: branch rename failed`. Probe both directions here, before the
+        command is built, so the caller gets a sentence naming the ref that is
+        in the way instead of a raw git failure.
+        */
+        let new_branch = normalize_git_ref(params.get("newBranch"), "newBranch")?;
+        if let Some(blocker) =
+            crate::worktree_sessions::worktree_branch_namespace_blocker(&context.cwd, &new_branch)
+        {
+            return Err(TypedOperationError::bad_request(format!(
+                "Git cannot use that branch name: \"{blocker}\" already exists."
+            )));
+        }
+    }
     let command = build_worktree_command(&action, params, context)?;
     let output = run_process_command(&command, context).await?;
     let mut result = typed_result(&action, &command, output);
@@ -1129,6 +1166,23 @@ fn build_worktree_command(
             ProcessCommand::new("git", args, cwd)
         }
         "list" => ProcessCommand::new("git", vec!["worktree", "list", "--porcelain"], cwd),
+        "move" => {
+            let worktree_path =
+                normalize_existing_worktree_path(params.get("worktreePath"), context)?;
+            let destination_path =
+                normalize_worktree_destination_path(params.get("destinationPath"), context)?;
+            ProcessCommand::new(
+                "git",
+                vec![
+                    "worktree".to_string(),
+                    "move".to_string(),
+                    "--".to_string(),
+                    worktree_path,
+                    destination_path,
+                ],
+                cwd,
+            )
+        }
         "prune" => ProcessCommand::new("git", vec!["worktree", "prune"], cwd),
         "remove" => {
             let worktree_path =
@@ -1139,6 +1193,28 @@ fn build_worktree_command(
             }
             args.extend(["--".to_string(), worktree_path]);
             ProcessCommand::new("git", args, cwd)
+        }
+        "renameBranch" => {
+            /*
+            CDXC:WorktreeRename 2026-08-09-18:40:
+            `-m`, never `-M`. Force does not help with the ref-namespace
+            collision this operation actually hits, and it would let a rename
+            silently clobber an existing branch — losing commits, not saving a
+            click.
+            */
+            let branch = normalize_git_ref(params.get("branch"), "branch")?;
+            let new_branch = normalize_git_ref(params.get("newBranch"), "newBranch")?;
+            ProcessCommand::new(
+                "git",
+                vec![
+                    "branch".to_string(),
+                    "-m".to_string(),
+                    "--".to_string(),
+                    branch,
+                    new_branch,
+                ],
+                cwd,
+            )
         }
         "switch" => ProcessCommand::new(
             "git",
@@ -2189,25 +2265,55 @@ fn normalize_worktree_target_path(
     input: Option<&Value>,
     context: &TypedOperationContext,
 ) -> Result<String, TypedOperationError> {
-    let worktree_path = normalize_absolute_path(input, "worktreePath")?;
+    normalize_worktree_family_path(input, "worktreePath", context)
+}
+
+fn normalize_worktree_family_path(
+    input: Option<&Value>,
+    field: &str,
+    context: &TypedOperationContext,
+) -> Result<String, TypedOperationError> {
+    let worktree_path = normalize_absolute_path(input, field)?;
     let family_root = Path::new(&context.cwd)
         .parent()
         .unwrap_or_else(|| Path::new(&context.cwd))
         .to_string_lossy()
         .to_string();
     if !is_path_inside(&family_root, &worktree_path) {
-        return Err(TypedOperationError::forbidden(
-            "worktreePath must stay inside the source project worktree family directory.",
-        ));
+        return Err(TypedOperationError::forbidden(format!(
+            "{field} must stay inside the source project worktree family directory."
+        )));
     }
     if normalize_path_string(PathBuf::from(&worktree_path))
         == normalize_path_string(PathBuf::from(&context.cwd))
     {
-        return Err(TypedOperationError::forbidden(
-            "worktreePath cannot be the source project directory.",
-        ));
+        return Err(TypedOperationError::forbidden(format!(
+            "{field} cannot be the source project directory."
+        )));
     }
     Ok(worktree_path)
+}
+
+fn normalize_worktree_destination_path(
+    input: Option<&Value>,
+    context: &TypedOperationContext,
+) -> Result<String, TypedOperationError> {
+    let destination_path = normalize_worktree_family_path(input, "destinationPath", context)?;
+    /*
+    CDXC:WorktreeRename 2026-08-09-18:40:
+    `git worktree move A B` with B already present is NOT an error: git moves the
+    worktree to B/A and exits 0, so the checkout silently lands one level deeper
+    than anyone asked for and the registered project path becomes wrong — a
+    "successful" rename that leaves the sidebar pointing at a directory that is
+    not a worktree. Refusing an existing destination outright is the only way to
+    keep "exit 0" meaning "the worktree is exactly where we said".
+    */
+    if Path::new(&destination_path).exists() {
+        return Err(TypedOperationError::bad_request(
+            "destinationPath already exists.",
+        ));
+    }
+    Ok(destination_path)
 }
 
 fn normalize_existing_worktree_path(
@@ -2421,9 +2527,16 @@ fn normalize_github_action(input: Option<&Value>) -> Result<String, TypedOperati
 fn normalize_worktree_action(input: Option<&Value>) -> Result<String, TypedOperationError> {
     let action = input.and_then(Value::as_str).unwrap_or("undefined");
     match action {
-        "create" | "ensureBeadsHooks" | "list" | "pathExists" | "prune" | "remove" | "switch" => {
-            Ok(action.to_string())
-        }
+        "create"
+        | "ensureBeadsHooks"
+        | "hasPopulatedSubmodules"
+        | "list"
+        | "move"
+        | "pathExists"
+        | "prune"
+        | "remove"
+        | "renameBranch"
+        | "switch" => Ok(action.to_string()),
         _ => Err(TypedOperationError::bad_request(format!(
             "Unsupported worktree action: {}",
             display_unknown_value(input)
@@ -3406,6 +3519,157 @@ bad branch\trefs/heads/bad branch\t\n",
                 .code,
             "forbidden"
         );
+    }
+
+    #[test]
+    fn worktree_move_builds_a_git_worktree_move_command() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("repo");
+        let worktree = dir.path().join("repo-old");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&worktree).unwrap();
+        let destination = dir.path().join("repo-new");
+        let ctx = context(&source);
+        let mut params = Map::new();
+        params.insert("worktreePath".to_string(), json!(worktree.to_string_lossy()));
+        params.insert(
+            "destinationPath".to_string(),
+            json!(destination.to_string_lossy()),
+        );
+
+        let command = build_worktree_command("move", &params, &ctx).unwrap();
+
+        assert_eq!(command.executable, "git");
+        assert_eq!(
+            command.args,
+            vec![
+                "worktree".to_string(),
+                "move".to_string(),
+                "--".to_string(),
+                normalize_path_string(worktree.clone()),
+                normalize_path_string(destination),
+            ]
+        );
+        assert_eq!(command.cwd, source.to_string_lossy());
+    }
+
+    #[test]
+    fn worktree_move_rejects_an_existing_destination() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        This is the regression test for the worst failure mode in the rename
+        feature. `git worktree move A B` with B already present exits 0 and
+        nests the worktree at B/A, so the operation "succeeds" while the folder
+        lands somewhere nobody asked for and the registered project path becomes
+        wrong. The guard has to refuse before git runs; reading the result back
+        is too late.
+        */
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("repo");
+        let worktree = dir.path().join("repo-old");
+        let destination = dir.path().join("repo-taken");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&worktree).unwrap();
+        fs::create_dir(&destination).unwrap();
+        let ctx = context(&source);
+        let mut params = Map::new();
+        params.insert("worktreePath".to_string(), json!(worktree.to_string_lossy()));
+        params.insert(
+            "destinationPath".to_string(),
+            json!(destination.to_string_lossy()),
+        );
+
+        let error = build_worktree_command("move", &params, &ctx).unwrap_err();
+
+        assert_eq!(error.code, "badRequest");
+        assert_eq!(error.message, "destinationPath already exists.");
+    }
+
+    #[test]
+    fn worktree_move_rejects_a_destination_outside_the_family_directory() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("repo");
+        let worktree = dir.path().join("repo-old");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&worktree).unwrap();
+        let ctx = context(&source);
+        let mut params = Map::new();
+        params.insert("worktreePath".to_string(), json!(worktree.to_string_lossy()));
+        params.insert(
+            "destinationPath".to_string(),
+            json!("/tmp/outside-worktree-family-rename"),
+        );
+
+        let error = build_worktree_command("move", &params, &ctx).unwrap_err();
+
+        assert_eq!(error.code, "forbidden");
+        assert!(error.message.contains("destinationPath"));
+
+        params.insert(
+            "destinationPath".to_string(),
+            json!(source.to_string_lossy()),
+        );
+        assert_eq!(
+            build_worktree_command("move", &params, &ctx)
+                .unwrap_err()
+                .code,
+            "forbidden",
+            "the main checkout is never a destination"
+        );
+    }
+
+    #[test]
+    fn worktree_rename_branch_builds_a_git_branch_dash_m_command() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("repo");
+        fs::create_dir(&source).unwrap();
+        let ctx = context(&source);
+        let mut params = Map::new();
+        params.insert("branch".to_string(), json!("ghostex/0123abcd"));
+        params.insert("newBranch".to_string(), json!("feat/kanban-assignee"));
+
+        let command = build_worktree_command("renameBranch", &params, &ctx).unwrap();
+
+        assert_eq!(command.executable, "git");
+        assert_eq!(
+            command.args,
+            vec![
+                "branch".to_string(),
+                "-m".to_string(),
+                "--".to_string(),
+                "ghostex/0123abcd".to_string(),
+                "feat/kanban-assignee".to_string(),
+            ]
+        );
+        assert!(
+            !command.args.iter().any(|arg| arg == "-M"),
+            "force rename would clobber an existing branch and does not help with namespace collisions"
+        );
+    }
+
+    #[test]
+    fn unsupported_worktree_actions_are_still_rejected() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        The rename feature widened the worktree allowlist. Prove it is still an
+        allowlist and did not become a wildcard.
+        */
+        for action in ["remove-branch", "moveAll", "renameBranchForce", "submodule"] {
+            let error = normalize_worktree_action(Some(&json!(action))).unwrap_err();
+            assert_eq!(error.code, "badRequest", "{action}");
+        }
+        for action in [
+            "create",
+            "hasPopulatedSubmodules",
+            "move",
+            "renameBranch",
+            "remove",
+        ] {
+            assert_eq!(
+                normalize_worktree_action(Some(&json!(action))).unwrap(),
+                action
+            );
+        }
     }
 
     #[test]

--- a/gxserver-rs/src/worktree_sessions.rs
+++ b/gxserver-rs/src/worktree_sessions.rs
@@ -111,6 +111,39 @@ pub fn worktree_directory_name(project_folder_name: &str, suffix: &str) -> Strin
     }
 }
 
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+Renaming a worktree types ONE name that becomes two things: the branch keeps it
+verbatim (so `feat/kanban-assignee` is possible) while the folder gets this slug,
+because `/` cannot be part of a directory name. This mirrors
+`worktreeRenameFolderSlug` in `shared/worktree-rename-name.ts` — the daemon slugs
+the name itself rather than accepting a destination path from a renderer, so a
+client can never point the move at a directory the user did not name. Case is
+preserved on purpose: `slugify_branch_title` above lowercases because it slugs a
+sentence, and lowercasing a name the user typed would rename their folder to
+something they did not ask for.
+*/
+pub fn worktree_rename_folder_slug(name: &str) -> String {
+    let mut slug = String::new();
+    for character in name.trim().chars() {
+        if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+            slug.push(character);
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    let slug = slug.trim_matches('-').to_string();
+    if slug.len() <= RENAMED_BRANCH_SLUG_MAX_CHARS {
+        return slug;
+    }
+    let cut = &slug[..RENAMED_BRANCH_SLUG_MAX_CHARS];
+    let truncated = match cut.rfind('-') {
+        Some(boundary) if boundary > 0 => &cut[..boundary],
+        _ => cut,
+    };
+    truncated.trim_end_matches('-').to_string()
+}
+
 /// `origin/main`, `refs/remotes/origin/main` and `main` all name the same branch
 /// on the remote; `startFromOrigin` needs the bare name to look it up.
 pub fn base_branch_short_name(base_ref: &str) -> String {
@@ -315,6 +348,41 @@ pub fn runtime_settings_with_renamed_worktree_branch(
     Some(runtime_settings)
 }
 
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+A moved worktree leaves the marker's `path` pointing at a folder that no longer
+exists, and `run_worktree_git` no-ops on a non-directory cwd — so a stale marker
+silently disables that session's auto-rename forever, and `remove_session_worktree`
+rejects the published path and strands the checkout. Rewrite `path` (and `branch`
+in the same pass when the rename covered the branch too, so the caller writes one
+`update_session` per session instead of two) and leave every other marker field
+alone: `initialTitle`, `createdAt`, and `renamedAt` still mean what they meant.
+*/
+pub fn runtime_settings_with_moved_worktree_path(
+    session: &Value,
+    path: &str,
+    branch: Option<&str>,
+) -> Option<Map<String, Value>> {
+    let mut runtime_settings = session
+        .get("runtimeSettings")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut marker = runtime_settings
+        .get(WORKTREE_SESSION_RUNTIME_KEY)
+        .and_then(Value::as_object)
+        .cloned()?;
+    marker.insert("path".to_string(), json!(path));
+    if let Some(branch) = branch {
+        marker.insert("branch".to_string(), json!(branch));
+    }
+    runtime_settings.insert(
+        WORKTREE_SESSION_RUNTIME_KEY.to_string(),
+        Value::Object(marker),
+    );
+    Some(runtime_settings)
+}
+
 // ---------------------------------------------------------------------------
 // git plumbing
 // ---------------------------------------------------------------------------
@@ -396,6 +464,126 @@ pub fn worktree_branch_exists(repository_path: &str, branch: &str) -> bool {
     )
     .map(|value| !value.trim().is_empty())
     .unwrap_or(false)
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+`refs/heads/<x>` cannot be a ref while `refs/heads/<x>/…` holds refs, and vice
+versa: with `test/board-batch` present, `git branch -m test/other test` fails with
+`error: 'refs/heads/test/board-batch' exists; cannot create 'refs/heads/test'`
+even though `git check-ref-format` passes `test` and no branch called `test`
+exists. `-M` does not help — force cannot dissolve a ref namespace. So the only
+way to give the user a sentence instead of a raw git failure is to probe both
+directions before running the rename: does the target name have refs *under* it,
+and is any *ancestor* of the target already a leaf ref. Returns the first
+blocking refname with `refs/heads/` stripped.
+
+The probe deliberately lives here rather than as a new `for-each-ref` git action:
+that would be a general ref-listing primitive on the typed-operation surface, and
+this needs exactly two bounded lookups.
+*/
+pub fn worktree_branch_namespace_blocker(repository_path: &str, branch: &str) -> Option<String> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return None;
+    }
+    if let Some(found) = run_worktree_git(
+        repository_path,
+        &[
+            "for-each-ref",
+            "--count=1",
+            "--format=%(refname)",
+            &format!("refs/heads/{branch}/**"),
+        ],
+        WORKTREE_GIT_COMMAND_TIMEOUT,
+    ) {
+        let found = found.trim();
+        if !found.is_empty() {
+            return Some(
+                found
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(found)
+                    .to_string(),
+            );
+        }
+    }
+    /*
+    The ancestor direction cannot reuse `for-each-ref`: git matches a pattern
+    "completely or from the beginning up to a slash", so `refs/heads/test`
+    happily returns `refs/heads/test/board-batch` and every namespaced name
+    would report itself as its own blocker. Resolve each ancestor exactly.
+    */
+    let mut prefix = String::new();
+    for component in branch.split('/').filter(|component| !component.is_empty()) {
+        if prefix.is_empty() {
+            prefix = component.to_string();
+        } else {
+            prefix = format!("{prefix}/{component}");
+        }
+        if prefix == branch {
+            break;
+        }
+        if worktree_branch_exists(repository_path, &prefix) {
+            return Some(prefix);
+        }
+    }
+    None
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+`git worktree move` hard-refuses a worktree with POPULATED submodules
+(`fatal: working trees containing submodules cannot be moved or removed`); an
+uninitialised gitlink is fine. `mv` plus `git worktree repair` is not a
+workaround — the top level repairs and the submodules do not, leaving a checkout
+whose `git status` fails in a way the user will not notice for days. So detect
+the condition and refuse with a sentence naming the fix. `submodule status`
+prints one line per gitlink and prefixes uninitialised ones with `-`, which is
+exactly the populated/not-populated split git itself refuses on.
+*/
+pub fn worktree_has_populated_submodules(worktree_path: &str) -> bool {
+    let Some(status) = run_worktree_git(
+        worktree_path,
+        &["submodule", "status", "--recursive"],
+        WORKTREE_GIT_COMMAND_TIMEOUT,
+    ) else {
+        return false;
+    };
+    status
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .any(|line| !line.starts_with('-'))
+}
+
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+`git worktree move` refuses a locked worktree with
+`fatal: cannot move a locked working tree`, and the override is `move -f -f`,
+which this feature deliberately does not offer — a lock is someone saying "do not
+touch this checkout". Read the lock straight off `worktree list --porcelain`,
+whose per-worktree block carries a bare `locked` line (or `locked <reason>`), so
+the refusal can name the actual reason instead of forwarding git's stderr.
+*/
+pub fn worktree_is_locked(repository_path: &str, worktree_path: &str) -> bool {
+    let Some(listing) = run_worktree_git(
+        repository_path,
+        &["worktree", "list", "--porcelain"],
+        WORKTREE_GIT_COMMAND_TIMEOUT,
+    ) else {
+        return false;
+    };
+    let target = worktree_path.trim_end_matches('/');
+    let mut in_target_block = false;
+    for line in listing.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            in_target_block = path.trim().trim_end_matches('/') == target;
+            continue;
+        }
+        if in_target_block && (line == "locked" || line.starts_with("locked ")) {
+            return true;
+        }
+    }
+    false
 }
 
 pub fn current_worktree_branch(worktree_path: &str) -> Option<String> {
@@ -499,6 +687,29 @@ mod tests {
             worktree_directory_name("  ", "0123abcd"),
             "worktree-0123abcd"
         );
+    }
+
+    #[test]
+    fn rename_folder_slugs_fold_separators_without_lowercasing() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        Same table as `shared/worktree-rename-name.test.ts`. The daemon computes
+        the destination folder itself, so if these two rules ever drift the
+        modal's live preview stops describing the folder the user actually gets.
+        */
+        assert_eq!(
+            worktree_rename_folder_slug("feat/kanban-assignee"),
+            "feat-kanban-assignee"
+        );
+        assert_eq!(worktree_rename_folder_slug("feat/UI-Polish"), "feat-UI-Polish");
+        assert_eq!(worktree_rename_folder_slug("a-b_c.d"), "a-b_c.d");
+        assert_eq!(worktree_rename_folder_slug("  feat/x  "), "feat-x");
+        let long = worktree_rename_folder_slug(
+            "rewrite-the-entire-presentation-snapshot-projection-pipeline-for-sidebar",
+        );
+        assert!(long.len() <= RENAMED_BRANCH_SLUG_MAX_CHARS);
+        assert!(!long.ends_with('-'));
+        assert!(long.starts_with("rewrite-the-entire-presentation-snapshot"));
     }
 
     #[test]
@@ -679,6 +890,107 @@ mod tests {
         );
     }
 
+    #[test]
+    fn moving_a_worktree_marker_keeps_every_other_field() {
+        let session = worktree_session("Fix login", temp_marker(), "generated");
+        let runtime_settings =
+            runtime_settings_with_moved_worktree_path(&session, "/repos/project-renamed", None)
+                .expect("runtime settings");
+        let marker = runtime_settings
+            .get(WORKTREE_SESSION_RUNTIME_KEY)
+            .and_then(Value::as_object)
+            .expect("marker");
+        assert_eq!(marker.get("path"), Some(&json!("/repos/project-renamed")));
+        assert_eq!(marker.get("branch"), Some(&json!("ghostex/0123abcd")));
+        assert_eq!(marker.get("initialTitle"), Some(&json!("Codex Session")));
+        assert_eq!(
+            marker.get("createdAt"),
+            Some(&json!("2026-07-29T00:00:00.000Z"))
+        );
+        assert_eq!(
+            runtime_settings.get("titleSource"),
+            Some(&json!("generated")),
+            "unrelated runtime settings survive"
+        );
+        assert_eq!(
+            runtime_settings_with_moved_worktree_path(
+                &json!({ "runtimeSettings": { "titleSource": "generated" } }),
+                "/repos/project-renamed",
+                None
+            ),
+            None,
+            "a session without the marker has nothing to move"
+        );
+    }
+
+    #[test]
+    fn moving_a_marker_can_carry_the_branch_rename_in_the_same_pass() {
+        let session = worktree_session("Fix login", temp_marker(), "generated");
+        let runtime_settings = runtime_settings_with_moved_worktree_path(
+            &session,
+            "/repos/project-renamed",
+            Some("feat/login"),
+        )
+        .expect("runtime settings");
+        let marker = runtime_settings
+            .get(WORKTREE_SESSION_RUNTIME_KEY)
+            .and_then(Value::as_object)
+            .expect("marker");
+        assert_eq!(marker.get("path"), Some(&json!("/repos/project-renamed")));
+        assert_eq!(marker.get("branch"), Some(&json!("feat/login")));
+        assert_eq!(marker.get("initialTitle"), Some(&json!("Codex Session")));
+    }
+
+    #[test]
+    fn a_moved_marker_still_plans_no_rename_for_a_human_branch() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        Moving a worktree must not hand the auto-rename sweep a branch it never
+        minted. A marker whose branch the user renamed by hand stays finished
+        business after the move, and a marker moved onto a temp branch is still
+        only due a rename because of the title, never because it moved.
+        */
+        let human_branch = worktree_session_marker_value(
+            "feature/login",
+            "/repos/project-0123abcd",
+            "Codex Session",
+            "2026-07-29T00:00:00.000Z",
+        );
+        let session = worktree_session("Fix login", human_branch, "generated");
+        let runtime_settings =
+            runtime_settings_with_moved_worktree_path(&session, "/repos/project-renamed", None)
+                .expect("runtime settings");
+        assert_eq!(
+            plan_worktree_branch_rename(&json!({
+                "projectId": "P1ab",
+                "runtimeSettings": Value::Object(runtime_settings),
+                "sessionId": "G1ab",
+                "title": "Fix login",
+            })),
+            None,
+            "only branches gxserver minted are renamed"
+        );
+
+        let temp_session = worktree_session("Fix login", temp_marker(), "generated");
+        let moved = runtime_settings_with_moved_worktree_path(
+            &temp_session,
+            "/repos/project-renamed",
+            None,
+        )
+        .expect("runtime settings");
+        let plan = plan_worktree_branch_rename(&json!({
+            "projectId": "P1ab",
+            "runtimeSettings": Value::Object(moved),
+            "sessionId": "G1ab",
+            "title": "Fix login",
+        }))
+        .expect("plan");
+        assert_eq!(
+            plan.worktree_path, "/repos/project-renamed",
+            "the sweep follows the worktree to its new folder"
+        );
+    }
+
     fn git_available() -> bool {
         Command::new("git")
             .arg("--version")
@@ -753,6 +1065,58 @@ mod tests {
                 WORKTREE_GIT_COMMAND_TIMEOUT
             ),
             None
+        );
+    }
+
+    #[test]
+    fn ref_namespace_collisions_are_detected_in_both_directions() {
+        /*
+        CDXC:WorktreeRename 2026-08-09-18:40:
+        This is the failure that produces a raw `fatal: branch rename failed`
+        with no explanation: `test` is a legal ref name and no branch called
+        `test` exists, yet git still refuses while `test/board-batch` does,
+        because a ref cannot be both a leaf and a namespace. Both directions are
+        checked here because both happen in practice.
+        */
+        if !git_available() {
+            return;
+        }
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("repo");
+        std::fs::create_dir_all(&root).expect("repo dir");
+        git(&root, &["init", "--quiet", "-b", "main"]);
+        git(&root, &["config", "user.email", "tests@example.invalid"]);
+        git(&root, &["config", "user.name", "Ghostex Tests"]);
+        std::fs::write(root.join("README.md"), "hello\n").expect("readme");
+        git(&root, &["add", "README.md"]);
+        git(&root, &["commit", "--quiet", "-m", "initial"]);
+        git(&root, &["branch", "test/board-batch"]);
+        git(&root, &["branch", "leaf"]);
+
+        let root_path = root.to_string_lossy().to_string();
+        assert_eq!(
+            worktree_branch_namespace_blocker(&root_path, "test").as_deref(),
+            Some("test/board-batch"),
+            "an existing ref under the target name blocks it"
+        );
+        assert_eq!(
+            worktree_branch_namespace_blocker(&root_path, "leaf/child").as_deref(),
+            Some("leaf"),
+            "an ancestor that is already a leaf ref blocks it"
+        );
+        assert_eq!(
+            worktree_branch_namespace_blocker(&root_path, "feat/login"),
+            None,
+            "an unrelated name is not blocked"
+        );
+        assert_eq!(
+            worktree_branch_namespace_blocker(&root_path, "test/board-batch"),
+            None,
+            "the branch's own name is not its own blocker"
+        );
+        assert!(
+            !worktree_has_populated_submodules(&root_path),
+            "a repository with no gitlinks has nothing populated"
         );
     }
 }

--- a/gxserver-rs/src/worktree_sessions.rs
+++ b/gxserver-rs/src/worktree_sessions.rs
@@ -323,12 +323,13 @@ pub fn plan_worktree_branch_rename(session: &Value) -> Option<WorktreeBranchRena
     })
 }
 
-/// The session's runtime settings with the marker's branch replaced and the
-/// rename stamped, ready to hand to `update_session`.
-pub fn runtime_settings_with_renamed_worktree_branch(
+/// The session's runtime settings with `mutate` applied to its V2 worktree
+/// marker, ready to hand to `update_session`. `None` when the session carries no
+/// marker, which is the signal that it is not a worktree session at all — the
+/// one shape both marker rewrites below share.
+fn runtime_settings_with_mutated_worktree_marker(
     session: &Value,
-    branch: &str,
-    renamed_at: &str,
+    mutate: impl FnOnce(&mut Map<String, Value>),
 ) -> Option<Map<String, Value>> {
     let mut runtime_settings = session
         .get("runtimeSettings")
@@ -339,13 +340,25 @@ pub fn runtime_settings_with_renamed_worktree_branch(
         .get(WORKTREE_SESSION_RUNTIME_KEY)
         .and_then(Value::as_object)
         .cloned()?;
-    marker.insert("branch".to_string(), json!(branch));
-    marker.insert("renamedAt".to_string(), json!(renamed_at));
+    mutate(&mut marker);
     runtime_settings.insert(
         WORKTREE_SESSION_RUNTIME_KEY.to_string(),
         Value::Object(marker),
     );
     Some(runtime_settings)
+}
+
+/// The session's runtime settings with the marker's branch replaced and the
+/// rename stamped, ready to hand to `update_session`.
+pub fn runtime_settings_with_renamed_worktree_branch(
+    session: &Value,
+    branch: &str,
+    renamed_at: &str,
+) -> Option<Map<String, Value>> {
+    runtime_settings_with_mutated_worktree_marker(session, |marker| {
+        marker.insert("branch".to_string(), json!(branch));
+        marker.insert("renamedAt".to_string(), json!(renamed_at));
+    })
 }
 
 /*
@@ -363,24 +376,12 @@ pub fn runtime_settings_with_moved_worktree_path(
     path: &str,
     branch: Option<&str>,
 ) -> Option<Map<String, Value>> {
-    let mut runtime_settings = session
-        .get("runtimeSettings")
-        .and_then(Value::as_object)
-        .cloned()
-        .unwrap_or_default();
-    let mut marker = runtime_settings
-        .get(WORKTREE_SESSION_RUNTIME_KEY)
-        .and_then(Value::as_object)
-        .cloned()?;
-    marker.insert("path".to_string(), json!(path));
-    if let Some(branch) = branch {
-        marker.insert("branch".to_string(), json!(branch));
-    }
-    runtime_settings.insert(
-        WORKTREE_SESSION_RUNTIME_KEY.to_string(),
-        Value::Object(marker),
-    );
-    Some(runtime_settings)
+    runtime_settings_with_mutated_worktree_marker(session, |marker| {
+        marker.insert("path".to_string(), json!(path));
+        if let Some(branch) = branch {
+            marker.insert("branch".to_string(), json!(branch));
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -561,8 +562,10 @@ CDXC:WorktreeRename 2026-08-09-18:40:
 `fatal: cannot move a locked working tree`, and the override is `move -f -f`,
 which this feature deliberately does not offer — a lock is someone saying "do not
 touch this checkout". Read the lock straight off `worktree list --porcelain`,
-whose per-worktree block carries a bare `locked` line (or `locked <reason>`), so
-the refusal can name the actual reason instead of forwarding git's stderr.
+whose per-worktree block carries a bare `locked` line (or `locked <reason>`),
+rather than forwarding git's stderr — which typed-operation results do not carry
+to the user anyway. The reason itself is deliberately dropped: the caller's
+refusal is a fixed sentence, so this answers only whether a lock is there.
 */
 pub fn worktree_is_locked(repository_path: &str, worktree_path: &str) -> bool {
     let Some(listing) = run_worktree_git(
@@ -704,6 +707,9 @@ mod tests {
         assert_eq!(worktree_rename_folder_slug("feat/UI-Polish"), "feat-UI-Polish");
         assert_eq!(worktree_rename_folder_slug("a-b_c.d"), "a-b_c.d");
         assert_eq!(worktree_rename_folder_slug("  feat/x  "), "feat-x");
+        // The empty result is load-bearing: `worktree_rename_destination_path`
+        // reads it as "this name cannot become a folder" and refuses the rename.
+        assert_eq!(worktree_rename_folder_slug("🎉🎉"), "");
         let long = worktree_rename_folder_slug(
             "rewrite-the-entire-presentation-snapshot-projection-pipeline-for-sidebar",
         );

--- a/native/sidebar/gxserver-client.ts
+++ b/native/sidebar/gxserver-client.ts
@@ -1420,6 +1420,8 @@ function describeGxserverOperation(path: GxserverEndpointPath): string {
       return "remove the project";
     case "/api/deleteWorktreeProject":
       return "delete the worktree project";
+    case "/api/renameWorktreeProject":
+      return "rename the worktree project";
     case "/api/updateSession":
       return "update the session";
     case "/api/updateSessionOrder":

--- a/native/sidebar/modal-host.tsx
+++ b/native/sidebar/modal-host.tsx
@@ -49,6 +49,10 @@ import {
   WorktreeDeleteModal,
   type WorktreeDeleteModalDraft,
 } from "../../sidebar/worktree-delete-modal";
+import {
+  WorktreeRenameModal,
+  type WorktreeRenameModalDraft,
+} from "../../sidebar/worktree-rename-modal";
 import { WorktreeCreateModal } from "../../sidebar/worktree-create-modal";
 import {
   normalizeAppToastDescription,
@@ -108,6 +112,7 @@ type AppModalKind =
   | "gitCommit"
   | "gitFileDiff"
   | "deleteWorktree"
+  | "renameWorktree"
   | "openTargets"
   | "pinnedPrompts"
   | "portlessSetup"
@@ -154,6 +159,7 @@ const ONE_SHOT_NATIVE_FIT_HEIGHT_MODAL_SELECTORS: Partial<Record<AppModalKind, s
   remoteGxserverInstall: ".remote-gxserver-install-modal",
   remoteProjectPicker: ".remote-project-picker-dialog",
   renameSession: ".session-rename-modal-shadcn",
+  renameWorktree: ".worktree-rename-modal-shadcn",
   worktree: ".worktree-create-modal-shadcn",
   updateAvailable: ".update-available-modal",
 };
@@ -231,6 +237,7 @@ type AppModalHostMessage =
       gitCommitDraft?: GitCommitModalDraft;
       gitFileDiff?: GitFileDiffModalDraft;
       worktreeDeleteDraft?: WorktreeDeleteModalDraft;
+      worktreeRenameDraft?: WorktreeRenameModalDraft;
       initialRemoteMachineId?: string;
       initialSection?: MainSettingsInitialSectionId;
       initialSearchQuery?: string;
@@ -932,6 +939,7 @@ function AppModalHost() {
     gitCommit,
     gitFileDiff,
     worktreeDelete,
+    worktreeRename,
     missingProjectFolder,
     commandPaletteInitialQuery,
     commandPaletteOpenRequestSequence,
@@ -1043,6 +1051,7 @@ function AppModalHost() {
     gitCommit,
     gitFileDiff,
     worktreeDelete,
+    worktreeRename,
     missingProjectFolder,
     remoteGxserverInstall,
     remoteProjectPicker,
@@ -1869,6 +1878,31 @@ function AppModalHost() {
         }}
         theme={theme}
       />
+      <WorktreeRenameModal
+        draft={
+          worktreeRename ?? {
+            currentName: "",
+            currentPath: "",
+            parentFolderName: "",
+            parentProjectPath: "",
+            projectId: "",
+            renameBranchDefault: false,
+            worktreeName: "worktree",
+          }
+        }
+        isOpen={activeModal === "renameWorktree" && worktreeRename !== undefined}
+        onCancel={closeModal}
+        onRename={(projectId, options) => {
+          vscode.postMessage({
+            name: options.name,
+            projectId,
+            renameBranch: options.renameBranch,
+            type: "confirmRenameWorktree",
+          });
+          closeModal();
+        }}
+        theme={theme}
+      />
       {/*
        * CDXC:Worktrees 2026-06-02-13:41:
        * Creating a project worktree is a full-window modal flow because macOS
@@ -2377,6 +2411,7 @@ function useModalStateFromNative() {
   const [gitCommit, setGitCommit] = useState<GitCommitModalDraft>();
   const [gitFileDiff, setGitFileDiff] = useState<GitFileDiffModalDraft>();
   const [worktreeDelete, setWorktreeDelete] = useState<WorktreeDeleteModalDraft>();
+  const [worktreeRename, setWorktreeRename] = useState<WorktreeRenameModalDraft>();
   const [missingProjectFolder, setMissingProjectFolder] =
     useState<MissingProjectFolderModalState>();
   const [remoteGxserverInstall, setRemoteGxserverInstall] =
@@ -2417,6 +2452,7 @@ function useModalStateFromNative() {
     setGitCommit(undefined);
     setGitFileDiff(undefined);
     setWorktreeDelete(undefined);
+    setWorktreeRename(undefined);
     setMissingProjectFolder(undefined);
     setRemoteGxserverInstall(undefined);
     setRemoteProjectPicker(undefined);
@@ -2619,6 +2655,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "renameSession") {
             if (!message.sessionId) {
               throw new Error("Rename modal request is missing sessionId.");
@@ -2639,6 +2676,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "firstUserMessage") {
             if (typeof message.message !== "string" || !message.message.trim()) {
               throw new Error("First message modal request is missing message text.");
@@ -2655,6 +2693,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "remoteGxserverInstall") {
             if (
               typeof message.remoteMachineId !== "string" ||
@@ -2683,6 +2722,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "remoteProjectPicker") {
             if (
               typeof message.remoteMachineId !== "string" ||
@@ -2713,6 +2753,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "delayedSend") {
             if (!message.sessionId) {
               throw new Error("Delayed Actions modal request is missing sessionId.");
@@ -2748,6 +2789,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "worktree") {
             setWorktree({
               projectId: typeof message.projectId === "string" ? message.projectId : undefined,
@@ -2765,6 +2807,7 @@ function useModalStateFromNative() {
             setGitCommit(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "portlessSetup") {
             if (
               message.mode !== "firstSetup" &&
@@ -2785,11 +2828,28 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setGitCommit(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "deleteWorktree") {
             if (!message.worktreeDeleteDraft) {
               throw new Error("Delete worktree modal request is missing worktreeDeleteDraft.");
             }
             setWorktreeDelete(message.worktreeDeleteDraft);
+            setWorktreeRename(undefined);
+            setConfig({});
+            setDelayedSend(undefined);
+            setFirstUserMessage(undefined);
+                    setRemoteGxserverInstall(undefined);
+            setRemoteProjectPicker(undefined);
+            setRenameSession(undefined);
+            setWorktree(undefined);
+            setPortlessSetup(undefined);
+            setGitCommit(undefined);
+          } else if (message.modal === "renameWorktree") {
+            if (!message.worktreeRenameDraft) {
+              throw new Error("Rename worktree modal request is missing worktreeRenameDraft.");
+            }
+            setWorktreeRename(message.worktreeRenameDraft);
+            setWorktreeDelete(undefined);
             setConfig({});
             setDelayedSend(undefined);
             setFirstUserMessage(undefined);
@@ -2813,6 +2873,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else if (message.modal === "gitFileDiff") {
             if (!message.gitFileDiff) {
               throw new Error("Git file diff modal request is missing gitFileDiff.");
@@ -2832,6 +2893,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           } else {
             setConfig({});
             setDelayedSend(undefined);
@@ -2842,6 +2904,7 @@ function useModalStateFromNative() {
             setWorktree(undefined);
             setPortlessSetup(undefined);
             setWorktreeDelete(undefined);
+            setWorktreeRename(undefined);
           }
           if (message.modal === "settings") {
             setGhostexFolderStats(undefined);
@@ -3108,6 +3171,7 @@ function useModalStateFromNative() {
     gitCommit,
     gitFileDiff,
     worktreeDelete,
+    worktreeRename,
     missingProjectFolder,
     commandPaletteInitialQuery,
     commandPaletteOpenRequestSequence,
@@ -3273,6 +3337,7 @@ function isModalRenderable({
   gitCommit,
   gitFileDiff,
   worktreeDelete,
+  worktreeRename,
   missingProjectFolder,
   recentProjects,
   remoteProjectPicker,
@@ -3292,6 +3357,7 @@ function isModalRenderable({
   gitCommit: GitCommitModalDraft | undefined;
   gitFileDiff: GitFileDiffModalDraft | undefined;
   worktreeDelete: WorktreeDeleteModalDraft | undefined;
+  worktreeRename: WorktreeRenameModalDraft | undefined;
   missingProjectFolder: MissingProjectFolderModalState | undefined;
   recentProjects: RecentProjectsModalState | undefined;
   remoteProjectPicker: RemoteProjectPickerState | undefined;
@@ -3327,6 +3393,8 @@ function isModalRenderable({
       return missingProjectFolder !== undefined;
     case "deleteWorktree":
       return worktreeDelete !== undefined;
+    case "renameWorktree":
+      return worktreeRename !== undefined;
     case "recentProjects":
       return recentProjects !== undefined;
     case "remoteProjectPicker":

--- a/shared/gxserver-protocol.ts
+++ b/shared/gxserver-protocol.ts
@@ -189,6 +189,7 @@ export type GxserverEndpointPath =
   | "/api/checkoutProjectNewBranch"
   | "/api/removeProject"
   | "/api/deleteWorktreeProject"
+  | "/api/renameWorktreeProject"
   | "/api/updateSession"
   | "/api/updateSessionOrder"
   | "/api/settleSession"

--- a/shared/session-grid-contract-sidebar.ts
+++ b/shared/session-grid-contract-sidebar.ts
@@ -2170,6 +2170,19 @@ export type SidebarToExtensionMessage =
       groupId: string;
     }
   | {
+      /**
+       * CDXC:WorktreeRename 2026-08-09-18:40:
+       * Rename Worktree collects the worktree's git state — populated
+       * submodules, lock, pushed branch, uncommitted changes, live sessions —
+       * before the native modal opens, because those answers decide whether the
+       * rename can happen at all and the modal has no way to ask for them
+       * itself. This is separate from the label-only `Rename` above it, which
+       * changes the project row's title and nothing on disk.
+       */
+      type: "promptRenameWorktreeForGroup";
+      groupId: string;
+    }
+  | {
       type: "closeGroup";
       groupId: string;
     }
@@ -2640,6 +2653,19 @@ export type SidebarToExtensionMessage =
   | {
       groupId: string;
       type: "commitWorktreeBeforeDelete";
+    }
+  | {
+      /**
+       * CDXC:WorktreeRename 2026-08-09-18:40:
+       * One typed name plus one boolean. gxserver derives the destination folder
+       * (`<ParentFolder>-<slug>`) and the project label from it, so the modal
+       * never names a path; `renameBranch` stays opt-in because renaming a
+       * pushed branch breaks the user's next push.
+       */
+      name: string;
+      projectId: string;
+      renameBranch?: boolean;
+      type: "confirmRenameWorktree";
     }
   | {
       type: "saveSidebarCommand";

--- a/shared/worktree-rename-name.test.ts
+++ b/shared/worktree-rename-name.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import {
+  WORKTREE_RENAME_NAME_CHARACTER_ERROR,
+  WORKTREE_RENAME_NAME_SEPARATOR_ERROR,
+  WORKTREE_RENAME_NAME_TOO_LONG_ERROR,
+  normalizeWorktreeRenameName,
+  worktreeRenameFolderSlug,
+  worktreeRenameNameError,
+} from "./worktree-rename-name";
+
+describe("worktreeRenameNameError", () => {
+  test("accepts every shape git accepts for a branch", () => {
+    for (const name of ["feat/kanban-assignee", "x/y/z", "a-b_c.d", "ABC/Def", "release/1.0"]) {
+      expect(worktreeRenameNameError(name), name).toBeUndefined();
+    }
+  });
+
+  test("rejects unsupported characters, leading punctuation, and git's reserved component shapes", () => {
+    /*
+     * CDXC:WorktreeRename 2026-08-09-18:40:
+     * `-abc` is the footgun this rule exists for: it passes
+     * `git check-ref-format`, so a laxer validator would let it through and
+     * `git branch -m -- -abc` would still parse it as a flag. Requiring a
+     * leading alphanumeric kills it, and the `.hidden` / `.lock` / trailing-dot
+     * component rules cover the shapes git refuses that the character allowlist
+     * alone would pass.
+     */
+    for (const name of [
+      "-abc",
+      "/feat",
+      ".hidden",
+      "a b",
+      "a~b",
+      "a^b",
+      "a:b",
+      "a?b",
+      "a*b",
+      "a[b",
+      "a\\b",
+      "a@{b",
+      "ünïcode",
+      "feat/.hidden",
+      "feat/x.lock",
+      "a.",
+    ]) {
+      expect(worktreeRenameNameError(name), name).toBe(WORKTREE_RENAME_NAME_CHARACTER_ERROR);
+    }
+  });
+
+  test("treats an empty name as an error rather than a request to auto-name", () => {
+    /*
+     * CDXC:WorktreeRename 2026-08-09-18:40:
+     * The create flow's branch field reads empty as "gxserver picks the name".
+     * Rename has no such fallback: there is nothing to rename to, so empty is a
+     * hard validation failure and Rename stays disabled.
+     */
+    expect(worktreeRenameNameError("")).toBe(WORKTREE_RENAME_NAME_CHARACTER_ERROR);
+    expect(worktreeRenameNameError("   ")).toBe(WORKTREE_RENAME_NAME_CHARACTER_ERROR);
+  });
+
+  test("rejects the separator shapes git refuses", () => {
+    for (const name of ["a..b", "feat//x", "feat/x/"]) {
+      expect(worktreeRenameNameError(name), name).toBe(WORKTREE_RENAME_NAME_SEPARATOR_ERROR);
+    }
+  });
+
+  test("caps the name at 200 characters", () => {
+    expect(worktreeRenameNameError("a".repeat(200))).toBeUndefined();
+    expect(worktreeRenameNameError("a".repeat(201))).toBe(WORKTREE_RENAME_NAME_TOO_LONG_ERROR);
+  });
+
+  test("validates the trimmed value", () => {
+    expect(normalizeWorktreeRenameName("  feat/x  ")).toBe("feat/x");
+    expect(worktreeRenameNameError("  feat/x  ")).toBeUndefined();
+  });
+});
+
+describe("worktreeRenameFolderSlug", () => {
+  test("folds path separators into hyphens without lowercasing", () => {
+    /*
+     * CDXC:WorktreeRename 2026-08-09-18:40:
+     * The branch keeps the typed name verbatim while the folder gets this slug,
+     * because `/` cannot appear in a directory name. Case is preserved: the
+     * existing worktree slugifiers lowercase because they slug a sentence, and
+     * lowercasing a name the user typed here would silently rename their folder
+     * to something they did not ask for.
+     */
+    expect(worktreeRenameFolderSlug("feat/kanban-assignee")).toBe("feat-kanban-assignee");
+    expect(worktreeRenameFolderSlug("feat/UI-Polish")).toBe("feat-UI-Polish");
+  });
+
+  test("truncates long names on a hyphen boundary and never trails a hyphen", () => {
+    const slug = worktreeRenameFolderSlug(
+      "rewrite-the-entire-presentation-snapshot-projection-pipeline-for-sidebar",
+    );
+
+    expect(slug.length).toBeLessThanOrEqual(48);
+    expect(slug.endsWith("-")).toBe(false);
+    expect(slug.startsWith("rewrite-the-entire-presentation-snapshot")).toBe(true);
+  });
+});

--- a/shared/worktree-rename-name.ts
+++ b/shared/worktree-rename-name.ts
@@ -1,0 +1,75 @@
+/*
+CDXC:WorktreeRename 2026-08-09-18:40:
+Renaming a worktree types ONE name that becomes two different things: the git
+branch (verbatim, so `feat/kanban-assignee` survives) and the sibling folder
+suffix (slugged, because `/` cannot appear in a directory name). Both rules live
+here, in `shared/`, so the sidebar modal and the gxserver-facing runtime validate
+the same way and `tsconfig.json` actually typechecks them.
+
+The character policy is gxserver's own `is_allowed_git_ref`
+(`gxserver-rs/src/typed_operations.rs`) plus the three shapes git rejects that
+the allowlist misses (a component starting with `.`, a component ending in
+`.lock`, a trailing `.`) and a length cap. Keeping it identical to the daemon's
+rule means a name the field accepts is a name `git branch -m` accepts, instead of
+the field passing something the daemon then refuses.
+*/
+
+const WORKTREE_RENAME_NAME_MAX_CHARS = 200;
+const WORKTREE_RENAME_FOLDER_SLUG_MAX_CHARS = 48;
+
+export const WORKTREE_RENAME_NAME_CHARACTER_ERROR =
+  "Use letters, numbers, and . _ / - only, starting with a letter or number.";
+export const WORKTREE_RENAME_NAME_SEPARATOR_ERROR =
+  'Names cannot contain "..", "//", or end with "/".';
+export const WORKTREE_RENAME_NAME_TOO_LONG_ERROR = "Name is too long (200 characters max).";
+
+export function normalizeWorktreeRenameName(value: string): string {
+  return value.trim();
+}
+
+export function worktreeRenameNameError(value: string): string | undefined {
+  const name = normalizeWorktreeRenameName(value);
+  if (name.length > WORKTREE_RENAME_NAME_MAX_CHARS) {
+    return WORKTREE_RENAME_NAME_TOO_LONG_ERROR;
+  }
+  /*
+   * CDXC:WorktreeRename 2026-08-09-18:40:
+   * An empty name is an error here, unlike the create flow's optional branch
+   * field where empty means "let gxserver pick". There is nothing to rename to.
+   */
+  if (!/^[A-Za-z0-9]/.test(name)) {
+    return WORKTREE_RENAME_NAME_CHARACTER_ERROR;
+  }
+  if (!/^[A-Za-z0-9._/-]*$/.test(name)) {
+    return WORKTREE_RENAME_NAME_CHARACTER_ERROR;
+  }
+  if (name.endsWith(".")) {
+    return WORKTREE_RENAME_NAME_CHARACTER_ERROR;
+  }
+  const components = name.split("/");
+  if (components.some((component) => component.startsWith(".") || component.endsWith(".lock"))) {
+    return WORKTREE_RENAME_NAME_CHARACTER_ERROR;
+  }
+  if (name.includes("..") || name.includes("//") || name.endsWith("/")) {
+    return WORKTREE_RENAME_NAME_SEPARATOR_ERROR;
+  }
+  return undefined;
+}
+
+/**
+ * The folder suffix for a typed name: `feat/kanban-assignee` becomes
+ * `feat-kanban-assignee`. Case is preserved on purpose — the existing worktree
+ * slugifiers lowercase because they slug a sentence, while this slugs a name the
+ * user typed and expects back.
+ */
+export function worktreeRenameFolderSlug(value: string): string {
+  const collapsed = normalizeWorktreeRenameName(value)
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (collapsed.length <= WORKTREE_RENAME_FOLDER_SLUG_MAX_CHARS) {
+    return collapsed;
+  }
+  const cut = collapsed.slice(0, WORKTREE_RENAME_FOLDER_SLUG_MAX_CHARS);
+  const boundary = cut.lastIndexOf("-");
+  return (boundary > 0 ? cut.slice(0, boundary) : cut).replace(/-+$/, "");
+}

--- a/shared/worktree-rename-plumbing.test.ts
+++ b/shared/worktree-rename-plumbing.test.ts
@@ -120,11 +120,13 @@ describe("gpui/sidebar/gxserver-runtime.ts rename handlers", () => {
 
   test("translates an out-of-date daemon into something the user can act on", () => {
     /*
-     * A gxserver that predates this feature answers with
-     * `"/api/renameWorktreeProject is not a gxserver HTTP endpoint."` — true,
-     * and useless to whoever just clicked Rename. It happens for real whenever a
-     * freshly built app attaches to a daemon the previously installed app left
-     * running, so the one recoverable case gets a recoverable sentence.
+     * Verified live against a stale daemon: it answers
+     * `notFound: "No gxserver endpoint for POST /api/renameWorktreeProject."`.
+     * gxserver has more than one phrasing for an unroutable path, so the match
+     * is on the ENDPOINT PATH, not on a sentence — an earlier version of this
+     * guard keyed off one phrasing and silently failed to fire against the real
+     * daemon. An error naming this route is always the daemon being older than
+     * the app, never anything the user did.
      */
     const reader = sourceBetweenIn(
       gpuiRuntimeSource,
@@ -132,7 +134,7 @@ describe("gpui/sidebar/gxserver-runtime.ts rename handlers", () => {
       "\n}",
     );
 
-    expect(reader).toContain("is not a gxserver HTTP endpoint");
+    expect(reader).toContain('message.includes("/api/renameWorktreeProject")');
     expect(reader).toContain("Quit Ghostex fully, reopen it, and try again.");
   });
 });

--- a/shared/worktree-rename-plumbing.test.ts
+++ b/shared/worktree-rename-plumbing.test.ts
@@ -117,6 +117,24 @@ describe("gpui/sidebar/gxserver-runtime.ts rename handlers", () => {
     expect(confirm).toContain("gpuiWorktreeRenameUserVisibleErrorMessage(error)");
     expect(confirm).not.toContain("gpuiWorktreeUserVisibleErrorMessage(error)");
   });
+
+  test("translates an out-of-date daemon into something the user can act on", () => {
+    /*
+     * A gxserver that predates this feature answers with
+     * `"/api/renameWorktreeProject is not a gxserver HTTP endpoint."` — true,
+     * and useless to whoever just clicked Rename. It happens for real whenever a
+     * freshly built app attaches to a daemon the previously installed app left
+     * running, so the one recoverable case gets a recoverable sentence.
+     */
+    const reader = sourceBetweenIn(
+      gpuiRuntimeSource,
+      "function gpuiWorktreeRenameUserVisibleErrorMessage(",
+      "\n}",
+    );
+
+    expect(reader).toContain("is not a gxserver HTTP endpoint");
+    expect(reader).toContain("Quit Ghostex fully, reopen it, and try again.");
+  });
 });
 
 describe("native/sidebar/modal-host.tsx rename modal", () => {

--- a/shared/worktree-rename-plumbing.test.ts
+++ b/shared/worktree-rename-plumbing.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+/**
+ * CDXC:WorktreeRename 2026-08-09-18:40:
+ * `tsconfig.json` covers `src/`, `shared/`, `sidebar/`, `native/sidebar/` and
+ * `mobile-chat/` — NOT `gpui/`, and there is no `gpui/tsconfig.json` either. So
+ * every edit to `gpui/sidebar/gxserver-runtime.ts` compiles clean no matter what
+ * it says, and `gpui/src/main.rs` cannot be cargo-checked in a reasonable time
+ * because its `build.rs` builds GhosttyKit via Zig plus CEF. Repo policy also
+ * forbids tests inside `gpui/`.
+ *
+ * That leaves the rename feature's longest chain unverified by anything, and its
+ * failure mode is silent: a field missing from the bridge allowlist is stripped
+ * without an error, and a command type missing from the dispatch list simply
+ * never reaches the allowlist at all. This test reads those files as text and
+ * asserts the hops exist, following the precedent set by
+ * `shared/gpui-hotkey-defaults-parity.test.ts`.
+ */
+
+const gpuiMainSource = readFileSync(new URL("../gpui/src/main.rs", import.meta.url), "utf8");
+const gpuiRuntimeSource = readFileSync(
+  new URL("../gpui/sidebar/gxserver-runtime.ts", import.meta.url),
+  "utf8",
+);
+const modalHostSource = readFileSync(
+  new URL("../native/sidebar/modal-host.tsx", import.meta.url),
+  "utf8",
+);
+
+function sourceBetweenIn(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+describe("gpui/src/main.rs rename bridge", () => {
+  test("forwards the rename confirmation's name, projectId, and renameBranch", () => {
+    /*
+     * The string loop and the boolean block are separate code paths in
+     * `forward_gpui_worktree_modal_command_to_sidebar`. A boolean listed only in
+     * `allowed_string_fields` is silently dropped, which would turn every
+     * "also rename the branch" tick into a folder-only rename with no error.
+     */
+    const allowlist = sourceBetweenIn(
+      gpuiMainSource,
+      "fn forward_gpui_worktree_modal_command_to_sidebar",
+      "let Some(sidebar) = self.sidebar.clone()",
+    );
+
+    expect(allowlist).toContain('"confirmRenameWorktree" => &["projectId", "name"]');
+    expect(allowlist).toContain('command_type == "confirmRenameWorktree"');
+    expect(allowlist).toContain('"renameBranch"');
+  });
+
+  test("dispatches confirmRenameWorktree to the worktree forwarder", () => {
+    /*
+     * This fixed list gates the forwarder. Without the new type here, hop 8
+     * above is never reached and the modal's Rename button does nothing at all.
+     */
+    const dispatch = sourceBetweenIn(
+      gpuiMainSource,
+      '"requestProjectWorktrees"\n            | "createProjectWorktree"',
+      "forward_gpui_worktree_modal_command_to_sidebar(command_type, command, cx);",
+    );
+
+    expect(dispatch).toContain('"confirmRenameWorktree"');
+  });
+
+  test("registers the renameWorktree app-modal kind", () => {
+    expect(gpuiMainSource).toContain('"renameWorktree" => Some(Self::RenameWorktree)');
+    expect(gpuiMainSource).toContain('Self::RenameWorktree => "renameWorktree"');
+    expect(gpuiMainSource).toContain('Self::RenameWorktree => "Ghostex Rename Worktree"');
+  });
+});
+
+describe("gpui/sidebar/gxserver-runtime.ts rename handlers", () => {
+  test("handles both rename messages", () => {
+    expect(gpuiRuntimeSource).toContain('case "promptRenameWorktreeForGroup":');
+    expect(gpuiRuntimeSource).toContain('case "confirmRenameWorktree":');
+    expect(gpuiRuntimeSource).toContain("private async promptRenameWorktreeForGroup(");
+    expect(gpuiRuntimeSource).toContain("private async confirmRenameWorktree(");
+  });
+
+  test("calls the single rename endpoint rather than orchestrating git itself", () => {
+    /*
+     * Rollback for a failed move lives in gxserver, not here: a renderer that
+     * reloads mid-rename must not be the only thing that can undo a half-applied
+     * branch rename.
+     */
+    const confirm = sourceBetweenIn(
+      gpuiRuntimeSource,
+      "private async confirmRenameWorktree(",
+      "private async promptDeleteRemoteWorktreeForGroup(",
+    );
+
+    expect(confirm).toContain('"/api/renameWorktreeProject"');
+    expect(confirm).not.toContain('action: "move"');
+    expect(confirm).not.toContain('action: "renameBranch"');
+  });
+
+  test("routes rename errors around the slash-stripping worktree error filter", () => {
+    /*
+     * `gpuiWorktreeUserVisibleErrorMessage` drops any message containing "/",
+     * which is every rename refusal that names a branch. The rename flow needs
+     * its own reader or the user gets a generic failure instead of
+     * `Branch "feat/x" already exists.`
+     */
+    expect(gpuiRuntimeSource).toContain("function gpuiWorktreeRenameUserVisibleErrorMessage(");
+    const confirm = sourceBetweenIn(
+      gpuiRuntimeSource,
+      "private async confirmRenameWorktree(",
+      "private async promptDeleteRemoteWorktreeForGroup(",
+    );
+    expect(confirm).toContain("gpuiWorktreeRenameUserVisibleErrorMessage(error)");
+    expect(confirm).not.toContain("gpuiWorktreeUserVisibleErrorMessage(error)");
+  });
+});
+
+describe("native/sidebar/modal-host.tsx rename modal", () => {
+  test("registers the modal kind, its fit-height selector, and its open arm", () => {
+    expect(modalHostSource).toContain('renameWorktree: ".worktree-rename-modal-shadcn"');
+    expect(modalHostSource).toContain('message.modal === "renameWorktree"');
+    expect(modalHostSource).toContain("worktreeRenameDraft?: WorktreeRenameModalDraft");
+    expect(modalHostSource).toContain('type: "confirmRenameWorktree"');
+  });
+});

--- a/sidebar/session-group-section.test.ts
+++ b/sidebar/session-group-section.test.ts
@@ -401,9 +401,15 @@ describe("getGroupContextMenuItemCount", () => {
      * while the count drifted and the last menu item opened off-screen.
      */
     const menuStart = sessionGroupSectionSource.indexOf("CDXC:WorktreeDelete 2026-05-28-07:46");
-    const menuEnd = sessionGroupSectionSource.indexOf("Add to project group", menuStart);
+    // The slice has to reach the END of the worktree branch, not its first
+    // shared item: anchored on "Add to project group" it stopped short of Delete
+    // Worktree and Remove Worktree, so a reintroduced label-only Rename placed
+    // below that item would have passed the negative assertions untouched.
+    const menuEnd = sessionGroupSectionSource.indexOf("Remove Worktree", menuStart);
+    const collectionsAnchor = sessionGroupSectionSource.indexOf("Add to project group", menuStart);
     expect(menuStart).toBeGreaterThanOrEqual(0);
-    expect(menuEnd).toBeGreaterThan(menuStart);
+    expect(collectionsAnchor).toBeGreaterThan(menuStart);
+    expect(menuEnd).toBeGreaterThan(collectionsAnchor);
     const worktreeMenuSource = sessionGroupSectionSource.slice(menuStart, menuEnd);
 
     expect(worktreeMenuSource).toContain("Rename Worktree");
@@ -430,6 +436,40 @@ describe("getGroupContextMenuItemCount", () => {
         isWorktreeProject: false,
       }),
     ).toBe(3);
+  });
+
+  test("counts the Hide item both project menus render", () => {
+    /*
+     * CDXC:SidebarContextMenu 2026-08-10:
+     * Hide/Unhide is rendered by the worktree AND the repository project menu
+     * whenever onHideGroup is supplied, and the sidebar always supplies it, so
+     * leaving it out measured every project menu one row short. The group menu
+     * has no Hide item, so it must not gain one here.
+     */
+    expect(
+      getGroupContextMenuItemCount({
+        canFullReloadGroup: false,
+        canHideGroup: true,
+        hasProjectContext: true,
+        isWorktreeProject: true,
+      }),
+    ).toBe(6);
+    expect(
+      getGroupContextMenuItemCount({
+        canFullReloadGroup: true,
+        canHideGroup: true,
+        hasProjectContext: true,
+        isWorktreeProject: false,
+      }),
+    ).toBe(7);
+    expect(
+      getGroupContextMenuItemCount({
+        canFullReloadGroup: true,
+        canHideGroup: true,
+        hasProjectContext: false,
+        isWorktreeProject: false,
+      }),
+    ).toBe(4);
   });
 });
 

--- a/sidebar/session-group-section.test.ts
+++ b/sidebar/session-group-section.test.ts
@@ -382,7 +382,30 @@ describe("getGroupContextMenuItemCount", () => {
         hasProjectContext: true,
         isWorktreeProject: true,
       }),
-    ).toBe(5);
+    ).toBe(6);
+  });
+
+  test("places Rename Worktree between the label rename and the collection action", () => {
+    /*
+     * CDXC:WorktreeRename 2026-08-09-18:40:
+     * getGroupContextMenuItemCount counts the items between these two anchors,
+     * and that count drives viewport clamping. Anchoring on POSITION rather than
+     * mere presence is the point: a test that only checked the item exists would
+     * still pass while the count silently drifted and the last menu item opened
+     * off-screen.
+     */
+    const menuStart = sessionGroupSectionSource.indexOf("CDXC:WorktreeDelete 2026-05-28-07:46");
+    const menuEnd = sessionGroupSectionSource.indexOf("Add to project group", menuStart);
+    expect(menuStart).toBeGreaterThanOrEqual(0);
+    expect(menuEnd).toBeGreaterThan(menuStart);
+    const worktreeMenuSource = sessionGroupSectionSource.slice(menuStart, menuEnd);
+
+    expect(worktreeMenuSource).toContain("Rename Worktree");
+    expect(worktreeMenuSource).toContain("promptRenameWorktree");
+    expect(worktreeMenuSource.indexOf("Rename Worktree")).toBeGreaterThan(
+      worktreeMenuSource.indexOf("IconPencil"),
+    );
+    expect(sessionGroupSectionSource).toContain('type: "promptRenameWorktreeForGroup"');
   });
 
   test("counts normal project and group actions separately", () => {

--- a/sidebar/session-group-section.test.ts
+++ b/sidebar/session-group-section.test.ts
@@ -382,17 +382,23 @@ describe("getGroupContextMenuItemCount", () => {
         hasProjectContext: true,
         isWorktreeProject: true,
       }),
-    ).toBe(6);
+    ).toBe(5);
   });
 
-  test("places Rename Worktree between the label rename and the collection action", () => {
+  test("worktree rows offer Rename Worktree and not the dead label-only Rename", () => {
     /*
-     * CDXC:WorktreeRename 2026-08-09-18:40:
-     * getGroupContextMenuItemCount counts the items between these two anchors,
-     * and that count drives viewport clamping. Anchoring on POSITION rather than
-     * mere presence is the point: a test that only checked the item exists would
-     * still pass while the count silently drifted and the last menu item opened
-     * off-screen.
+     * CDXC:WorktreeRename 2026-08-10:
+     * Two invariants in one place, because they are the same mistake.
+     *
+     * The label-only Rename posts `renameWorkspaceProjectForGroup`, which the
+     * GPUI runtime has no case for — on the desktop app it did nothing, sitting
+     * directly above a Rename Worktree that does. It must not come back for
+     * worktree rows, while ordinary project rows keep theirs.
+     *
+     * And getGroupContextMenuItemCount counts the items between these anchors,
+     * which drives viewport clamping. Anchoring on POSITION rather than mere
+     * presence is the point: a test that only checked the item exists would pass
+     * while the count drifted and the last menu item opened off-screen.
      */
     const menuStart = sessionGroupSectionSource.indexOf("CDXC:WorktreeDelete 2026-05-28-07:46");
     const menuEnd = sessionGroupSectionSource.indexOf("Add to project group", menuStart);
@@ -402,10 +408,11 @@ describe("getGroupContextMenuItemCount", () => {
 
     expect(worktreeMenuSource).toContain("Rename Worktree");
     expect(worktreeMenuSource).toContain("promptRenameWorktree");
-    expect(worktreeMenuSource.indexOf("Rename Worktree")).toBeGreaterThan(
-      worktreeMenuSource.indexOf("IconPencil"),
-    );
+    expect(worktreeMenuSource).not.toContain("IconPencil");
+    expect(worktreeMenuSource).not.toContain("setIsEditing(true)");
     expect(sessionGroupSectionSource).toContain('type: "promptRenameWorktreeForGroup"');
+    // Ordinary project rows are untouched — they still rename their label.
+    expect(sessionGroupSectionSource.slice(menuEnd)).toContain("IconPencil");
   });
 
   test("counts normal project and group actions separately", () => {

--- a/sidebar/session-group-section.tsx
+++ b/sidebar/session-group-section.tsx
@@ -553,13 +553,14 @@ export function getGroupContextMenuItemCount({
    * CDXC:ProjectGroups 2026-06-08-09:19:
    * Worktree project headings should expose Copy Path but omit the IDE Open action in their compact context menu. Keep the root context-menu item count explicit by project kind so viewport clamping stays aligned with the visible worktree and repository menu actions.
    *
-   * CDXC:WorktreeRename 2026-08-09-18:40:
-   * Rename Worktree added a sixth worktree action. This count drives viewport
-   * clamping, so it has to move with the menu or the last item opens off-screen.
+   * CDXC:WorktreeRename 2026-08-10:
+   * Rename Worktree replaced the dead label-only Rename on worktree rows rather
+   * than joining it, so the count is unchanged. It drives viewport clamping, so
+   * it has to move with the menu or the last item opens off-screen.
    */
   if (hasProjectContext) {
     return isWorktreeProject
-      ? 6 + Number(projectCollectionsEnabled)
+      ? 5 + Number(projectCollectionsEnabled)
       : 5 + Number(canFullReloadGroup) + Number(canCreateSessionGroup) + Number(projectCollectionsEnabled);
   }
 
@@ -2978,29 +2979,16 @@ export function SessionGroupSection({
                       />
                       Open Folder
                     </button>
-                    <button
-                      className="session-context-menu-item"
-                      onClick={() => {
-                        setContextMenuPosition(undefined);
-                        setIsEditing(true);
-                      }}
-                      role="menuitem"
-                      type="button"
-                    >
-                      <IconPencil
-                        aria-hidden="true"
-                        className="session-context-menu-icon"
-                        size={14}
-                      />
-                      Rename
-                    </button>
                     {/*
-                     * CDXC:WorktreeRename 2026-08-09-18:40:
-                     * Rename above only retitles the project row. This one moves
-                     * the checkout on disk to `<ParentFolder>-<name>` and can
-                     * rename the git branch with it, so it is a separate action
-                     * with its own confirmation rather than a change in what the
-                     * label rename does.
+                     * CDXC:WorktreeRename 2026-08-10:
+                     * Worktree rows deliberately do NOT offer the label-only
+                     * Rename. It posts `renameWorkspaceProjectForGroup`, which
+                     * the GPUI runtime has no case for, so on the desktop app it
+                     * was a menu item that did nothing at all — and sat directly
+                     * above a Rename Worktree that does, which is worse than
+                     * absent. Renaming a worktree means moving the checkout, so
+                     * the action below is the whole story for these rows.
+                     * Ordinary project rows keep their label rename unchanged.
                      */}
                     <button
                       className="session-context-menu-item"

--- a/sidebar/session-group-section.tsx
+++ b/sidebar/session-group-section.tsx
@@ -552,10 +552,14 @@ export function getGroupContextMenuItemCount({
   /*
    * CDXC:ProjectGroups 2026-06-08-09:19:
    * Worktree project headings should expose Copy Path but omit the IDE Open action in their compact context menu. Keep the root context-menu item count explicit by project kind so viewport clamping stays aligned with the visible worktree and repository menu actions.
+   *
+   * CDXC:WorktreeRename 2026-08-09-18:40:
+   * Rename Worktree added a sixth worktree action. This count drives viewport
+   * clamping, so it has to move with the menu or the last item opens off-screen.
    */
   if (hasProjectContext) {
     return isWorktreeProject
-      ? 5 + Number(projectCollectionsEnabled)
+      ? 6 + Number(projectCollectionsEnabled)
       : 5 + Number(canFullReloadGroup) + Number(canCreateSessionGroup) + Number(projectCollectionsEnabled);
   }
 
@@ -1789,6 +1793,18 @@ export function SessionGroupSection({
     });
   };
 
+  const promptRenameWorktree = () => {
+    if (!projectContext?.worktree) {
+      return;
+    }
+
+    setContextMenuPosition(undefined);
+    vscode.postMessage({
+      groupId: group.groupId,
+      type: "promptRenameWorktreeForGroup",
+    });
+  };
+
   const handleTitleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter") {
       event.preventDefault();
@@ -2977,6 +2993,27 @@ export function SessionGroupSection({
                         size={14}
                       />
                       Rename
+                    </button>
+                    {/*
+                     * CDXC:WorktreeRename 2026-08-09-18:40:
+                     * Rename above only retitles the project row. This one moves
+                     * the checkout on disk to `<ParentFolder>-<name>` and can
+                     * rename the git branch with it, so it is a separate action
+                     * with its own confirmation rather than a change in what the
+                     * label rename does.
+                     */}
+                    <button
+                      className="session-context-menu-item"
+                      onClick={promptRenameWorktree}
+                      role="menuitem"
+                      type="button"
+                    >
+                      <IconGitBranch
+                        aria-hidden="true"
+                        className="session-context-menu-icon"
+                        size={14}
+                      />
+                      Rename Worktree…
                     </button>
                     {onCreateProjectCollection && onMoveProjectToCollection ? (
                       <button

--- a/sidebar/session-group-section.tsx
+++ b/sidebar/session-group-section.tsx
@@ -539,12 +539,14 @@ function clampContextMenuPosition(
 export function getGroupContextMenuItemCount({
   canCreateSessionGroup = false,
   canFullReloadGroup,
+  canHideGroup = false,
   hasProjectContext,
   isWorktreeProject,
   projectCollectionsEnabled = false,
 }: {
   canCreateSessionGroup?: boolean;
   canFullReloadGroup: boolean;
+  canHideGroup?: boolean;
   hasProjectContext: boolean;
   isWorktreeProject: boolean;
   projectCollectionsEnabled?: boolean;
@@ -557,11 +559,23 @@ export function getGroupContextMenuItemCount({
    * Rename Worktree replaced the dead label-only Rename on worktree rows rather
    * than joining it, so the count is unchanged. It drives viewport clamping, so
    * it has to move with the menu or the last item opens off-screen.
+   *
+   * CDXC:SidebarContextMenu 2026-08-10:
+   * Hide/Unhide renders in both project menus whenever `onHideGroup` is supplied
+   * — which the sidebar always does — and was never counted, so every project
+   * menu was measured one row short and the last item could open off-screen. It
+   * is not part of the group menu, so only the project branches take it.
    */
   if (hasProjectContext) {
-    return isWorktreeProject
-      ? 5 + Number(projectCollectionsEnabled)
-      : 5 + Number(canFullReloadGroup) + Number(canCreateSessionGroup) + Number(projectCollectionsEnabled);
+    return (
+      Number(canHideGroup) +
+      (isWorktreeProject
+        ? 5 + Number(projectCollectionsEnabled)
+        : 5 +
+          Number(canFullReloadGroup) +
+          Number(canCreateSessionGroup) +
+          Number(projectCollectionsEnabled))
+    );
   }
 
   return 3 + Number(canFullReloadGroup);
@@ -1907,6 +1921,7 @@ export function SessionGroupSection({
         getGroupContextMenuItemCount({
           canCreateSessionGroup: group.canCreateSessionGroup === true,
           canFullReloadGroup,
+          canHideGroup: Boolean(onHideGroup),
           hasProjectContext: Boolean(projectContext),
           isWorktreeProject: Boolean(projectContext?.worktree),
           projectCollectionsEnabled: Boolean(onCreateProjectCollection && onMoveProjectToCollection),

--- a/sidebar/styles/modals.css
+++ b/sidebar/styles/modals.css
@@ -2472,6 +2472,160 @@ html:has(body.app-modal-host-native-window-body) {
   min-width: 112px;
 }
 
+.worktree-rename-modal-shadcn {
+  /**
+   * CDXC:WorktreeRename 2026-08-09-18:40:
+   * Rename Worktree is a compact one-field dialog in the same app-modal family
+   * as Delete Worktree, so it shares that surface but sizes to its own content:
+   * a name field, a live folder/branch preview, one checkbox, and however many
+   * warnings the checkout actually has.
+   */
+  height: auto;
+  max-height: min(560px, calc(100vh - 2rem));
+  max-width: min(640px, calc(100vw - 2rem));
+  width: min(640px, calc(100vw - 2rem));
+}
+
+.worktree-rename-modal-form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.worktree-rename-modal-header {
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  gap: 4px;
+  padding: 20px;
+}
+
+.worktree-rename-modal-subject {
+  color: color-mix(in srgb, var(--foreground) 78%, var(--muted-foreground) 22%);
+  font-size: 13px;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.worktree-rename-modal-body {
+  display: grid;
+  gap: 16px;
+  max-height: min(380px, calc(100vh - 180px));
+  min-height: 0;
+  overflow: auto;
+  padding: 20px;
+}
+
+.worktree-rename-modal-path {
+  color: color-mix(in srgb, var(--muted-foreground) 92%, transparent);
+  font-family: var(--app-monospace-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.worktree-rename-field-group {
+  gap: 10px;
+}
+
+.worktree-rename-preview {
+  display: grid;
+  gap: 3px;
+}
+
+.worktree-rename-preview-line code {
+  color: color-mix(in srgb, var(--foreground) 94%, var(--muted-foreground) 6%);
+  font-family: var(--app-monospace-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.worktree-rename-branch-option {
+  align-items: flex-start;
+  border: 1px solid color-mix(in srgb, var(--input) 62%, transparent);
+  color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground) 12%);
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.worktree-rename-branch-checkbox {
+  appearance: none;
+  background: color-mix(in srgb, var(--input) 30%, transparent);
+  border: 1px solid var(--input);
+  border-radius: 0;
+  flex: none;
+  height: 16px;
+  margin: 2px 0 0;
+  position: relative;
+  width: 16px;
+}
+
+.worktree-rename-branch-checkbox:checked {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.worktree-rename-branch-checkbox:checked::after {
+  border: solid var(--primary-foreground);
+  border-width: 0 2px 2px 0;
+  content: "";
+  height: 8px;
+  left: 5px;
+  position: absolute;
+  top: 2px;
+  transform: rotate(45deg);
+  width: 4px;
+}
+
+.worktree-rename-branch-option-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.worktree-rename-branch-option-label {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.worktree-rename-branch-option-help {
+  color: color-mix(in srgb, var(--muted-foreground) 92%, transparent);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.worktree-rename-message {
+  color: color-mix(in srgb, var(--foreground) 84%, var(--muted-foreground) 16%);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.worktree-rename-message-blocking {
+  color: var(--destructive);
+}
+
+.worktree-rename-modal-actions {
+  border-top: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+  padding: 14px 20px 20px;
+}
+
+.worktree-rename-modal-button {
+  min-width: 112px;
+}
+
 .git-file-diff-modal-shadcn {
   /*
    * CDXC:TitlebarGit 2026-05-25-10:16:

--- a/sidebar/worktree-rename-modal-source.test.ts
+++ b/sidebar/worktree-rename-modal-source.test.ts
@@ -54,6 +54,23 @@ describe("worktree rename modal submit", () => {
     expect(worktreeRenameModalSource).toContain("worktreeRenameNameError(name)");
   });
 
+  test("prefills the branch when the folder is only its slugged form", () => {
+    /*
+     * CDXC:WorktreeRename 2026-08-10:
+     * The bug this exists to stop, caught in manual testing: a worktree on
+     * `feat/kanban-assignee` lives in `<Parent>-feat-kanban-assignee`, so
+     * prefilling from the folder handed back `feat-kanban-assignee`. Reopening
+     * and pressing Rename then flattened the branch's slash without the user
+     * changing a character. Reopening has to be a no-op.
+     */
+    const resolver = sourceBetween("function resolveWorktreeRenameInitialName(", "\n}");
+
+    expect(resolver).toContain("worktreeRenameFolderSlug(branch) === draft.currentName");
+    expect(resolver).toContain("? branch");
+    expect(worktreeRenameModalSource).toContain("const [name, setName] = useState(initialName)");
+    expect(worktreeRenameModalSource).toContain("const unchanged = trimmedName === initialName");
+  });
+
   test("previews the folder slug and the verbatim branch separately", () => {
     /*
      * CDXC:WorktreeRename 2026-08-09-18:40:

--- a/sidebar/worktree-rename-modal-source.test.ts
+++ b/sidebar/worktree-rename-modal-source.test.ts
@@ -39,7 +39,10 @@ describe("worktree rename modal draft", () => {
 
 describe("worktree rename modal submit", () => {
   test("sends the shared confirmRenameWorktree fields and nothing else", () => {
-    const submit = sourceBetween("const submitRename = (", "};");
+    // Anchored on the function's own closing brace, not the first `};` after
+    // it: a nested object literal inside submitRename would otherwise truncate
+    // the slice before the onRename call and fail for the wrong reason.
+    const submit = sourceBetween("const submitRename = (", "\n  };");
 
     expect(submit).toContain("onRename(draft.projectId, { name: trimmedName, renameBranch })");
     expect(submit).toContain("if (!canSubmit)");

--- a/sidebar/worktree-rename-modal-source.test.ts
+++ b/sidebar/worktree-rename-modal-source.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+/**
+ * CDXC:WorktreeRename 2026-08-09-18:40:
+ * The rename modal renders inside the native app-modal child window, which this
+ * repo has no DOM harness for, so its contract is asserted against source text
+ * the way `native/sidebar/tasks-placeholder-source.test.ts` does. What matters
+ * here is not that the file compiles — typecheck already proves that — but that
+ * the three things the daemon depends on stay true: the draft carries the flags
+ * the runtime computed, submit sends the shared contract message, and Rename is
+ * genuinely disabled when the rename cannot run.
+ */
+
+const worktreeRenameModalSource = readFileSync(
+  new URL("./worktree-rename-modal.tsx", import.meta.url),
+  "utf8",
+);
+
+function sourceBetween(start: string, end: string): string {
+  const startIndex = worktreeRenameModalSource.indexOf(start);
+  const endIndex = worktreeRenameModalSource.indexOf(end, startIndex + start.length);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return worktreeRenameModalSource.slice(startIndex, endIndex);
+}
+
+describe("worktree rename modal draft", () => {
+  test("carries the flags the runtime resolved before the modal opened", () => {
+    const draftType = sourceBetween("export type WorktreeRenameModalDraft = {", "};");
+
+    expect(draftType).toContain("renameBranchDefault: boolean");
+    expect(draftType).toContain("blockingReason?: string");
+    expect(draftType).toContain("warnings?: readonly string[]");
+    expect(draftType).toContain("currentName: string");
+    expect(draftType).toContain("parentFolderName: string");
+  });
+});
+
+describe("worktree rename modal submit", () => {
+  test("sends the shared confirmRenameWorktree fields and nothing else", () => {
+    const submit = sourceBetween("const submitRename = (", "};");
+
+    expect(submit).toContain("onRename(draft.projectId, { name: trimmedName, renameBranch })");
+    expect(submit).toContain("if (!canSubmit)");
+    expect(worktreeRenameModalSource).not.toContain("destinationPath");
+  });
+
+  test("disables Rename for a blocking reason and for an invalid name", () => {
+    const footer = sourceBetween("<DialogFooter", "</DialogFooter>");
+
+    expect(footer).toContain("disabled={!canSubmit}");
+    expect(worktreeRenameModalSource).toContain("const canSubmit = !submitError && !draft.blockingReason");
+    expect(worktreeRenameModalSource).toContain("worktreeRenameNameError(name)");
+  });
+
+  test("previews the folder slug and the verbatim branch separately", () => {
+    /*
+     * CDXC:WorktreeRename 2026-08-09-18:40:
+     * The folder and the branch are deliberately different strings for the same
+     * typed name, so the preview must not collapse them into one line.
+     */
+    const preview = sourceBetween("worktree-rename-preview", "</FieldDescription>");
+
+    expect(preview).toContain("Folder:");
+    expect(preview).toContain("{nextFolderName");
+    expect(preview).toContain("Branch:");
+    expect(preview).toContain("{trimmedName");
+    expect(worktreeRenameModalSource).toContain("worktreeRenameFolderSlug(name)");
+  });
+});

--- a/sidebar/worktree-rename-modal.tsx
+++ b/sidebar/worktree-rename-modal.tsx
@@ -167,7 +167,6 @@ export function WorktreeRenameModal({
               <Field>
                 <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
                 <Input
-                  aria-label="Worktree name"
                   autoComplete="off"
                   className="worktree-rename-name-input"
                   id={nameInputId}
@@ -291,11 +290,20 @@ function resolveWorktreeRenameCollisionError({
   return undefined;
 }
 
+/*
+ * CDXC:WorktreeRename 2026-08-10:
+ * The draft carries the project path exactly as it is registered, and on Windows
+ * that is `C:\Users\me\repo`. Splitting on "/" alone found no separator there and
+ * produced `/feat-name`, which matches no main checkout and no registered
+ * project, so both live collision checks went quiet until the daemon refused the
+ * submit. Take whichever separator the path actually uses and keep it.
+ */
 function joinRenameParentDirectory(parentProjectPath: string, folderName: string): string {
-  const trimmed = parentProjectPath.replace(/\/+$/, "");
-  const separatorIndex = trimmed.lastIndexOf("/");
+  const trimmed = parentProjectPath.replace(/[/\\]+$/, "");
+  const separatorIndex = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  const separator = separatorIndex >= 0 ? trimmed[separatorIndex] : "/";
   const familyRoot = separatorIndex > 0 ? trimmed.slice(0, separatorIndex) : "";
-  return `${familyRoot}/${folderName}`;
+  return `${familyRoot}${separator}${folderName}`;
 }
 
 function getSidebarThemeVariant(theme: SidebarTheme): "dark" | "light" {

--- a/sidebar/worktree-rename-modal.tsx
+++ b/sidebar/worktree-rename-modal.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  normalizeWorktreeRenameName,
+  worktreeRenameFolderSlug,
+  worktreeRenameNameError,
+} from "../shared/worktree-rename-name";
+import type { SidebarTheme } from "../shared/session-grid-contract";
+
+export type WorktreeRenameModalDraft = {
+  /**
+   * A reason the rename cannot run at all, resolved before the modal opened
+   * (populated submodules, a locked checkout). Rename stays disabled while it
+   * is present — the field is still editable so the user can read the preview.
+   */
+  blockingReason?: string;
+  branch?: string;
+  /** The current folder's suffix, i.e. the field's prefill. */
+  currentName: string;
+  currentPath: string;
+  parentFolderName: string;
+  parentProjectPath: string;
+  projectId: string;
+  /**
+   * Absolute paths of every OTHER registered project, so a destination that is
+   * already someone else's project row is refused while the user types instead
+   * of after they submit.
+   */
+  registeredProjectPaths?: readonly string[];
+  renameBranchDefault: boolean;
+  warnings?: readonly string[];
+  worktreeName: string;
+};
+
+export type WorktreeRenameModalProps = {
+  draft: WorktreeRenameModalDraft;
+  isOpen: boolean;
+  onCancel: () => void;
+  onRename: (projectId: string, options: { name: string; renameBranch: boolean }) => void;
+  theme?: SidebarTheme;
+};
+
+/*
+ * CDXC:WorktreeRename 2026-08-09-18:40:
+ * One field, three effects: the folder becomes `<ParentFolder>-<slug>`, the
+ * project label follows it, and the branch takes the typed name verbatim when
+ * the checkbox is on. The live preview exists because those three are not the
+ * same string — the branch keeps `feat/kanban-assignee` while the folder gets
+ * `feat-kanban-assignee` — and a user who cannot see that mapping cannot predict
+ * what they are about to do to their filesystem.
+ *
+ * CDXC:WorktreeRename 2026-08-09-18:40:
+ * The branch checkbox is opt-in rather than automatic because renaming a branch
+ * that is already pushed silently breaks the user's next `git push` with an
+ * error that never mentions Ghostex. It defaults on only for branches gxserver
+ * minted itself: a branch the user named is theirs, a branch Ghostex named is
+ * Ghostex's to keep in step with the folder.
+ */
+export function WorktreeRenameModal({
+  draft,
+  isOpen,
+  onCancel,
+  onRename,
+  theme = "dark-1",
+}: WorktreeRenameModalProps) {
+  const [name, setName] = useState(draft.currentName);
+  const [renameBranch, setRenameBranch] = useState(draft.renameBranchDefault);
+  const nameInputId = useId();
+  const branchCheckboxId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isDarkTheme = getSidebarThemeVariant(theme) === "dark";
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setName(draft.currentName);
+    setRenameBranch(draft.renameBranchDefault);
+  }, [draft.currentName, draft.projectId, draft.renameBranchDefault, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const focusInput = () => {
+      const input = inputRef.current;
+      if (!input) {
+        return;
+      }
+      input.focus({ preventScroll: true });
+      input.setSelectionRange(0, input.value.length);
+    };
+    const animationFrame = window.requestAnimationFrame(focusInput);
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [isOpen]);
+
+  const trimmedName = normalizeWorktreeRenameName(name);
+  const folderSlug = worktreeRenameFolderSlug(name);
+  const nextFolderName = folderSlug ? `${draft.parentFolderName}-${folderSlug}` : "";
+  const nextFolderPath = useMemo(
+    () => (nextFolderName ? joinRenameParentDirectory(draft.parentProjectPath, nextFolderName) : ""),
+    [draft.parentProjectPath, nextFolderName],
+  );
+
+  const validationError = worktreeRenameNameError(name);
+  const unchanged = trimmedName === draft.currentName;
+  const collisionError = resolveWorktreeRenameCollisionError({
+    draft,
+    nextFolderName,
+    nextFolderPath,
+    unchanged,
+  });
+  const submitError =
+    validationError ??
+    (unchanged && !renameBranch ? "Nothing to rename." : undefined) ??
+    collisionError;
+  const canSubmit = !submitError && !draft.blockingReason;
+  const warnings = draft.warnings ?? [];
+
+  const submitRename = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    onRename(draft.projectId, { name: trimmedName, renameBranch });
+  };
+
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onCancel();
+        }
+      }}
+      open={isOpen}
+    >
+      <DialogContent
+        className={cn(
+          "ghostex-settings-shadcn command-config-modal-shadcn worktree-rename-modal-shadcn flex flex-col gap-0 overflow-hidden p-0 font-sans",
+          isDarkTheme && "dark",
+        )}
+        data-sidebar-theme={theme}
+      >
+        <form className="worktree-rename-modal-form" onSubmit={submitRename}>
+          <DialogHeader className="worktree-rename-modal-header">
+            <DialogTitle className="text-xl">Rename Worktree</DialogTitle>
+            <DialogDescription className="worktree-rename-modal-subject">
+              {draft.worktreeName}
+              {draft.branch ? ` · ${draft.branch}` : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="worktree-rename-modal-body">
+            <p className="worktree-rename-modal-path">{draft.currentPath}</p>
+            <FieldGroup className="worktree-rename-field-group">
+              <Field>
+                <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
+                <Input
+                  aria-label="Worktree name"
+                  autoComplete="off"
+                  className="worktree-rename-name-input"
+                  id={nameInputId}
+                  onChange={(event) => setName(event.currentTarget.value)}
+                  ref={inputRef}
+                  spellCheck={false}
+                  value={name}
+                />
+                <FieldDescription className="worktree-rename-preview">
+                  <span className="worktree-rename-preview-line">
+                    Folder: <code>{nextFolderName || "—"}</code>
+                  </span>
+                  {renameBranch ? (
+                    <span className="worktree-rename-preview-line">
+                      Branch: <code>{trimmedName || "—"}</code>
+                    </span>
+                  ) : null}
+                </FieldDescription>
+              </Field>
+            </FieldGroup>
+            <label className="worktree-rename-branch-option" htmlFor={branchCheckboxId}>
+              <input
+                checked={renameBranch}
+                className="worktree-rename-branch-checkbox"
+                id={branchCheckboxId}
+                onChange={(event) => setRenameBranch(event.currentTarget.checked)}
+                type="checkbox"
+              />
+              <span className="worktree-rename-branch-option-copy">
+                <span className="worktree-rename-branch-option-label">
+                  Also rename the git branch
+                </span>
+                <span className="worktree-rename-branch-option-help">
+                  The branch takes the typed name exactly, without the folder&apos;s slug.
+                </span>
+              </span>
+            </label>
+            {draft.blockingReason ? (
+              <p className="worktree-rename-message worktree-rename-message-blocking">
+                {draft.blockingReason}
+              </p>
+            ) : null}
+            {submitError && !draft.blockingReason ? (
+              <p className="worktree-rename-message worktree-rename-message-blocking">
+                {submitError}
+              </p>
+            ) : null}
+            {warnings.map((warning) => (
+              <p className="worktree-rename-message" key={warning}>
+                {warning}
+              </p>
+            ))}
+          </div>
+          <DialogFooter className="worktree-rename-modal-actions">
+            <Button
+              className="worktree-rename-modal-button"
+              onClick={onCancel}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button className="worktree-rename-modal-button" disabled={!canSubmit} type="submit">
+              Rename
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/*
+ * CDXC:WorktreeRename 2026-08-09-18:40:
+ * These two refusals are pure computations over data the draft already carries,
+ * so they answer while the user types instead of after they submit. Everything
+ * that needs the filesystem or git — the destination already existing on disk, a
+ * branch name already taken, a ref-namespace collision — is enforced by gxserver
+ * at submit, because this modal has no channel to ask the daemon anything.
+ */
+function resolveWorktreeRenameCollisionError({
+  draft,
+  nextFolderName,
+  nextFolderPath,
+  unchanged,
+}: {
+  draft: WorktreeRenameModalDraft;
+  nextFolderName: string;
+  nextFolderPath: string;
+  unchanged: boolean;
+}): string | undefined {
+  if (!nextFolderName || unchanged) {
+    return undefined;
+  }
+  if (nextFolderPath === draft.parentProjectPath) {
+    return "That name would collide with the main checkout.";
+  }
+  if ((draft.registeredProjectPaths ?? []).includes(nextFolderPath)) {
+    return "Another project is already registered at that folder.";
+  }
+  return undefined;
+}
+
+function joinRenameParentDirectory(parentProjectPath: string, folderName: string): string {
+  const trimmed = parentProjectPath.replace(/\/+$/, "");
+  const separatorIndex = trimmed.lastIndexOf("/");
+  const familyRoot = separatorIndex > 0 ? trimmed.slice(0, separatorIndex) : "";
+  return `${familyRoot}/${folderName}`;
+}
+
+function getSidebarThemeVariant(theme: SidebarTheme): "dark" | "light" {
+  /**
+   * CDXC:SidebarTheme 2026-06-15-01:43:
+   * Worktree rename is part of the app-modal family, so Light removes the dark
+   * class while Dark 1 and Dark 2 keep dark shadcn mode.
+   */
+  return theme.startsWith("light-") || theme === "plain-light" ? "light" : "dark";
+}

--- a/sidebar/worktree-rename-modal.tsx
+++ b/sidebar/worktree-rename-modal.tsx
@@ -74,7 +74,8 @@ export function WorktreeRenameModal({
   onRename,
   theme = "dark-1",
 }: WorktreeRenameModalProps) {
-  const [name, setName] = useState(draft.currentName);
+  const initialName = resolveWorktreeRenameInitialName(draft);
+  const [name, setName] = useState(initialName);
   const [renameBranch, setRenameBranch] = useState(draft.renameBranchDefault);
   const nameInputId = useId();
   const branchCheckboxId = useId();
@@ -85,9 +86,9 @@ export function WorktreeRenameModal({
     if (!isOpen) {
       return;
     }
-    setName(draft.currentName);
+    setName(initialName);
     setRenameBranch(draft.renameBranchDefault);
-  }, [draft.currentName, draft.projectId, draft.renameBranchDefault, isOpen]);
+  }, [draft.projectId, draft.renameBranchDefault, initialName, isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -114,7 +115,7 @@ export function WorktreeRenameModal({
   );
 
   const validationError = worktreeRenameNameError(name);
-  const unchanged = trimmedName === draft.currentName;
+  const unchanged = trimmedName === initialName;
   const collisionError = resolveWorktreeRenameCollisionError({
     draft,
     nextFolderName,
@@ -237,6 +238,26 @@ export function WorktreeRenameModal({
       </DialogContent>
     </Dialog>
   );
+}
+
+/*
+ * CDXC:WorktreeRename 2026-08-10:
+ * Reopening the dialog must be lossless. The folder can only ever hold the
+ * slugged name, so a worktree on `feat/kanban-assignee` lives in
+ * `<Parent>-feat-kanban-assignee` — and prefilling from the FOLDER handed back
+ * `feat-kanban-assignee`. Pressing Rename without touching anything then
+ * "renamed" the branch from `feat/kanban-assignee` to `feat-kanban-assignee`
+ * and silently ate the slash. Caught in manual testing, reflog and all.
+ *
+ * So when the current branch slugs down to exactly the current folder suffix,
+ * the branch IS the name the user typed last time, with the detail the folder
+ * had to drop. Prefill that instead, and reopening becomes a no-op.
+ */
+function resolveWorktreeRenameInitialName(draft: WorktreeRenameModalDraft): string {
+  const branch = draft.branch?.trim();
+  return branch && worktreeRenameFolderSlug(branch) === draft.currentName
+    ? branch
+    : draft.currentName;
 }
 
 /*


### PR DESCRIPTION
Adds **Rename Worktree…** to the worktree project context menu. One typed name moves the checkout on disk to `<ParentFolder>-<slug>`, retitles the project row, and — opt-in — renames the git branch to the typed name verbatim, so `feat/kanban-assignee` survives as a branch while the folder becomes `…-feat-kanban-assignee`.

Today both halves require a terminal, and doing it by hand behind Ghostex's back leaves the sidebar pointing at a dead path.

## Design

One new endpoint, `/api/renameWorktreeProject`, following the `deleteWorktreeProject` precedent: a multi-step git + database mutation must not depend on a renderer surviving it. The endpoint owns pre-flight, the branch rename, the folder move, rollback of the branch if the move fails, and the lockstep database updates.

The caller sends a **name**, never a path. gxserver slugs it and computes the destination beside the parent checkout itself, so a renderer can never point the move at a directory the user did not name.

### State kept in lockstep

A rename that moves the folder but leaves the database describing the old one is worse than no feature. All of it moves in one pass: `projects.path` (via the validated `relocate_project`), the derived project label, re-detected worktree metadata, every `sessions.cwd` under the old folder, the V2 worktree session marker's `path`, and an absolute `beadsDirectory`. Caches are deliberately untouched — the git-status cache, the 60s worktree-topology probe and the project-icon cache are all keyed by path and self-heal.

## Two git behaviours that drove this, both verified against real git

- **`git worktree move A B` with B already present is NOT an error.** Git nests the worktree at `B/A` and exits 0 — the operation "succeeds" while the folder lands somewhere nobody asked for and the registered path becomes wrong. The destination is refused before git runs, with a regression test.
- **`git worktree move` hard-refuses populated submodules.** Detected and surfaced with a specific message. No `mv` + `git worktree repair` fallback exists anywhere in the diff: that repairs the top level and leaves the submodules broken in a way the user will not notice until `git status` fails.

Ref-namespace collisions (`test` while `test/board-batch` exists) are probed in both directions before the rename, so the user gets a sentence naming the blocking ref instead of a bare `fatal: branch rename failed`. `-m`, never `-M` — force cannot dissolve a ref namespace and would let a rename clobber a branch.

The branch rename is opt-in because renaming a pushed branch silently breaks the next `git push` with an error that never mentions Ghostex. It defaults on only for branches gxserver minted itself.

## Behaviour changes worth review

- **Worktree rows lose the label-only `Rename`.** It posted `renameWorkspaceProjectForGroup`, which the GPUI runtime has no case for, so on the desktop app it did nothing while sitting above a Rename Worktree that does. More importantly the label on a worktree row is *derived* — this endpoint rewrites it on every rename — so a hand-typed label there is a name the user cannot keep. Ordinary project rows are untouched. Note `ghostex-web` does handle that message, so this removes a niche working action from worktree rows on the web surface.
- **Remote worktrees are refused** with a clear message rather than opening a dialog that cannot submit; the remote presentation-project indirection has no rename counterpart yet.

## Verification

- `bun run typecheck` — clean
- `bunx vitest run native/sidebar/ shared/ sidebar/` — 152 files / 1358 tests pass
- `cargo check --manifest-path gxserver-rs/Cargo.toml` — clean
- `cargo test --lib worktree` — 50 pass

Full `cargo test` shows 57 failures; those were diffed by name against a pristine `b084cfce` worktree and are byte-identical pre-existing failures. This branch adds 12 passing tests and breaks none.

`gpui/**` is outside `tsconfig.json` and `gpui`'s own cargo check builds GhosttyKit + CEF, so those hops are covered by `shared/worktree-rename-plumbing.test.ts`, which reads `gpui/src/main.rs` and the runtime as text and asserts the bridge allowlist, the dispatch list and the modal registration — the failure modes there are silent (a field missing from the allowlist is stripped without an error).

## Manually tested end to end

Built and driven in the real app. Folder move, branch rename with the slash preserved, database follow-through and git's own `worktree list` all confirmed on disk. Four of the commits here exist **because** of that session:

- an out-of-date daemon leaked `No gxserver endpoint for POST /api/renameWorktreeProject.` into the toast — a freshly built app attaches to whatever gxserver is already on 58744, so the first run of any new build hits it
- a symlinked project path (`/tmp/rt` vs `/private/tmp/rt-old`) leaked the internal `worktreePath must stay inside…` guard message; this is pre-existing and shared with Delete Worktree, so only the message changed, not the guard
- reopening the dialog prefilled from the *folder*, so pressing Rename without touching anything flattened `feat/kanban-assignee` to `feat-kanban-assignee`

## Knowingly out of scope

`stashed_prompts.cwd` (display-only per its own schema comment), the unvalidated `path` passthrough in `/api/updateProject`, third-party agent history (Claude transcripts, Cursor's md5 chat dirs — warned about, never rewritten), and Sidebar V2, which models a worktree as an attribute of a session rather than a project row.

Conflicts to expect with the pending custom-branch-name feature: a slug helper, a validation rule, and adjacent arms of one `match` in `gpui/src/main.rs`. Whichever lands second should delete its copy and import the other's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Rename Worktree” to worktree context menus.
  * Added a rename dialog with folder and branch previews, validation, optional branch renaming, and collision warnings.
  * Renaming updates the worktree location and related session information.

* **Bug Fixes**
  * Added safeguards for invalid names, conflicting paths or branches, locked worktrees, populated submodules, and unavailable worktrees.
  * Added clear success and error feedback for rename operations.

* **Tests**
  * Added coverage for validation, previews, conflicts, state updates, and rename flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->