### PR TITLE
fix(gpui): remote sidebar double-highlight — strip first-row visible fallback from remote groups

### DIFF
--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -19907,16 +19907,33 @@ function createGpuiRemotePresentationSidebarGroups({
           machineName: machine.name,
           ...(project ? { projectId: project.projectId } : {}),
         },
-        sessions: group.sessions.map((session) => ({
-          ...session,
-          canPopOutPane:
-            session.sessionKind === "terminal" &&
-            Boolean(session.agentIcon) &&
-            session.isSleeping !== true &&
-            session.lifecycleState !== "sleeping",
-          canScheduleDelayedSend: session.sessionKind === "terminal",
-          canToggleCloseAfterDone: session.sessionKind === "terminal",
-        })),
+        sessions: group.sessions.map((session) => {
+          const remoteSession = parseGpuiRemotePresentationSessionId(session.sessionId);
+          return {
+            ...session,
+            canPopOutPane:
+              session.sessionKind === "terminal" &&
+              Boolean(session.agentIcon) &&
+              session.isSleeping !== true &&
+              session.lifecycleState !== "sleeping",
+            canScheduleDelayedSend: session.sessionKind === "terminal",
+            canToggleCloseAfterDone: session.sessionKind === "terminal",
+            /*
+            CDXC:GPUIRemoteVisibleFallback 2026-08-15:
+            Mirror the local-group override in createSidebarGroups: the shared
+            projection's first-row visible fallback must not survive into
+            remote groups. Whenever a remote project became active, it marked
+            the projection's index-0 session visible (fill highlight) on top of
+            the actually focused session. Remote visibility is owned by the
+            native workspace callback's visibleSessionIds, exactly like local
+            terminals.
+            */
+            isVisible:
+              group.isActive === true &&
+              remoteSession !== undefined &&
+              visibleRawSessionIds.has(remoteSession.sessionId),
+          };
+        }),
       };
     });
   });

--- a/gpui/sidebar/gxserver-runtime.ts
+++ b/gpui/sidebar/gxserver-runtime.ts
@@ -19907,33 +19907,29 @@ function createGpuiRemotePresentationSidebarGroups({
           machineName: machine.name,
           ...(project ? { projectId: project.projectId } : {}),
         },
-        sessions: group.sessions.map((session) => {
-          const remoteSession = parseGpuiRemotePresentationSessionId(session.sessionId);
-          return {
-            ...session,
-            canPopOutPane:
-              session.sessionKind === "terminal" &&
-              Boolean(session.agentIcon) &&
-              session.isSleeping !== true &&
-              session.lifecycleState !== "sleeping",
-            canScheduleDelayedSend: session.sessionKind === "terminal",
-            canToggleCloseAfterDone: session.sessionKind === "terminal",
-            /*
-            CDXC:GPUIRemoteVisibleFallback 2026-08-15:
-            Mirror the local-group override in createSidebarGroups: the shared
-            projection's first-row visible fallback must not survive into
-            remote groups. Whenever a remote project became active, it marked
-            the projection's index-0 session visible (fill highlight) on top of
-            the actually focused session. Remote visibility is owned by the
-            native workspace callback's visibleSessionIds, exactly like local
-            terminals.
-            */
-            isVisible:
-              group.isActive === true &&
-              remoteSession !== undefined &&
-              visibleRawSessionIds.has(remoteSession.sessionId),
-          };
-        }),
+        sessions: group.sessions.map((session) => ({
+          ...session,
+          canPopOutPane:
+            session.sessionKind === "terminal" &&
+            Boolean(session.agentIcon) &&
+            session.isSleeping !== true &&
+            session.lifecycleState !== "sleeping",
+          canScheduleDelayedSend: session.sessionKind === "terminal",
+          canToggleCloseAfterDone: session.sessionKind === "terminal",
+          /*
+          CDXC:GPUIRemoteVisibleFallback 2026-08-15:
+          Mirror the local-group override in createSidebarGroups: the shared
+          projection's first-row visible fallback must not survive into
+          remote groups. Whenever a remote project became active, it marked
+          the projection's index-0 session visible (fill highlight) on top of
+          the actually focused session. Remote visibility is owned by the
+          native workspace callback's visibleSessionIds, exactly like local
+          terminals. Match the complete machine/project/session-scoped row id
+          because gxserver session ids are unique only within a project.
+          */
+          isVisible:
+            group.isActive === true && visibleSessionIds?.has(session.sessionId) === true,
+        })),
       };
     });
   });


### PR DESCRIPTION
## Problem

Clicking any remote-machine session in the sidebar highlighted **two** rows:

- the clicked session — highlight fill + bright focus outline
- one extra session in the same remote project — highlight fill only, no outline (in practice the bottom row, since the projection's first session sorts last by activity)

Local projects never showed this; only remote machines did.

## Root cause

`createGxserverPresentationSidebarSession` (shared projection) computes:

```ts
isVisible: isActiveProject && (
  visibleSessionIds?.has(presentation.sessionId) === true ||
  index === 0
)
```

The `index === 0` fallback marks the projection's first session visible whenever its project is active — regardless of which session actually owns a pane.

The local-group path in `gpui/sidebar/gxserver-runtime.ts` (`createSidebarGroups`) already re-derives `isVisible` strictly from `visibleSessionIds` and carries a comment saying the shared projection's first-row fallback must **not** be preserved. The remote path (`createGpuiRemotePresentationSidebarGroups`) went straight through the shared projection and kept the fallback, so any active remote project always painted a second, fill-only highlight on top of the actually focused session.

## Fix

Mirror the local-group override in the remote path: after building remote groups, re-derive terminal-session `isVisible` as strict membership in the machine-scoped `visibleRawSessionIds` (gated on `group.isActive`), dropping the `index === 0` fallback. Remote visibility stays owned by the native workspace callback's `visibleSessionIds`, exactly like local terminals.

The shared projection itself is untouched — other consumers may still rely on the fallback.

## Verification

- Field-tested on macOS: side-by-side dev build, remote machine with multiple sessions per project; clicking any remote session now highlights exactly one row (focus fill + outline), including clicking the previously always-highlighted bottom row.
- `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote session visibility handling.
  * Sessions are now shown only when their group is active and they are marked as visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->