### PR TITLE
feat(chat): add a per-session Verbose toggle to the composer

### DIFF
--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -1145,7 +1145,11 @@ export type ghostexSettings = {
   sessionChatFontFamily: string;
   /** Transcript width on a 64rem scale; 75% preserves the historical 48rem cap. */
   sessionChatTranscriptWidthPercent: number;
-  /** Reveal thinking-owned tool calls by default in Session Chat. */
+  /**
+   * Reveal thinking-owned tool calls by default in Session Chat. Chats that
+   * use the composer's Verbose pill store their own value and stop following
+   * this (sidebar/chat/session-chat-verbose-override.ts).
+   */
   sessionChatVerboseMode: boolean;
   /**
    * CDXC:SidebarTitlebarColors 2026-06-15-11:24:

--- a/sidebar/chat/session-chat-verbose-override.ts
+++ b/sidebar/chat/session-chat-verbose-override.ts
@@ -1,0 +1,47 @@
+// Per-session Verbose Mode override. The `sessionChatVerboseMode` Ghostex
+// setting stays the default for every chat; the composer pill pins a value for
+// one session only, so a chat keeps its mode across reloads and restarts
+// without moving the global default. Same per-session localStorage shape the
+// option pills use (session-chat-session-options.ts §Persistence).
+
+const STORAGE_PREFIX = "ghostex.sessionChat.verbose.";
+
+function storage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage disabled by the embedder: the pill still works, just per-mount.
+    return null;
+  }
+}
+
+/** Stored override for this session, or null when it follows the setting. */
+export function readStoredSessionChatVerbose(
+  sessionKey: string | null | undefined,
+): boolean | null {
+  if (!sessionKey) {
+    return null;
+  }
+  const raw = storage()?.getItem(`${STORAGE_PREFIX}${sessionKey}`);
+  if (raw === "1") {
+    return true;
+  }
+  if (raw === "0") {
+    return false;
+  }
+  return null;
+}
+
+export function writeStoredSessionChatVerbose(
+  sessionKey: string | null | undefined,
+  verbose: boolean,
+): void {
+  if (!sessionKey) {
+    return;
+  }
+  try {
+    storage()?.setItem(`${STORAGE_PREFIX}${sessionKey}`, verbose ? "1" : "0");
+  } catch {
+    // Quota/private-mode failures must not break the toggle.
+  }
+}

--- a/sidebar/chat/session-chat-verbose-override.ts
+++ b/sidebar/chat/session-chat-verbose-override.ts
@@ -22,7 +22,12 @@ export function readStoredSessionChatVerbose(
   if (!sessionKey) {
     return null;
   }
-  const raw = storage()?.getItem(`${STORAGE_PREFIX}${sessionKey}`);
+  let raw: string | null;
+  try {
+    raw = storage()?.getItem(`${STORAGE_PREFIX}${sessionKey}`) ?? null;
+  } catch {
+    return null;
+  }
   if (raw === "1") {
     return true;
   }

--- a/sidebar/chat/session-chat-view.tsx
+++ b/sidebar/chat/session-chat-view.tsx
@@ -3,14 +3,15 @@
 // the composer while showing. Hosts inject a SessionChatTransport; everything
 // else is derived by useSessionChat.
 
-import { IconRobot } from "@tabler/icons-react";
+import { IconEye, IconEyeOff, IconRobot } from "@tabler/icons-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
+import { Button } from "../../components/ui/button";
 import { cn } from "../../lib/utils";
 import type { SessionChatSkill, SessionChatTheme } from "../../shared/session-chat";
 import { getDefaultSidebarAgentById } from "../../shared/sidebar-agents";
 import { getBrandAgentLogoStyle } from "../agent-logos";
-import { TooltipProvider } from "../app-tooltip";
+import { AppTooltip, TooltipProvider } from "../app-tooltip";
 import {
   SessionChatComposer,
   type SessionChatComposerHandle,
@@ -34,6 +35,10 @@ import {
   useSessionChatSessionOptions,
 } from "./session-chat-option-pills";
 import { sessionChatOptionCommandNames } from "./session-chat-session-options";
+import {
+  readStoredSessionChatVerbose,
+  writeStoredSessionChatVerbose,
+} from "./session-chat-verbose-override";
 import {
   sessionChatSlashCommandsForAgent,
   sessionChatSlashHeadingForAgent,
@@ -210,6 +215,47 @@ function SessionAgentIdentity({ agentLabel }: { agentLabel?: string | null }) {
   );
 }
 
+/*
+Verbose pill: a per-session override of the sessionChatVerboseMode setting.
+The setting stays the default for chats that never touch the pill; a session
+that does keeps its own value (session-chat-verbose-override.ts).
+*/
+function SessionVerbosePill({
+  onToggle,
+  verbose,
+}: {
+  onToggle: () => void;
+  verbose: boolean;
+}) {
+  const Icon = verbose ? IconEye : IconEyeOff;
+  return (
+    <AppTooltip
+      content={
+        verbose
+          ? "Verbose on for this chat: thinking blocks start expanded"
+          : "Verbose off for this chat: thinking blocks start collapsed"
+      }
+    >
+      <span className="inline-flex">
+        <Button
+          aria-label="Verbose mode"
+          aria-pressed={verbose}
+          className={cn(
+            "ghostex-chat-footer-control rounded-full",
+            verbose ? "text-foreground" : "text-muted-foreground",
+          )}
+          onClick={onToggle}
+          size="xs"
+          variant={verbose ? "secondary" : "ghost"}
+        >
+          <Icon aria-hidden="true" className="size-3 shrink-0" stroke={2} />
+          <span className="truncate">Verbose</span>
+        </Button>
+      </span>
+    </AppTooltip>
+  );
+}
+
 export function SessionChatView({
   agentLabel,
   canSend = true,
@@ -280,6 +326,19 @@ export function SessionChatView({
     agent: agentLabel ?? null,
     ...(sessionKey !== undefined ? { sessionKey } : {}),
   });
+  // null = this chat has never been toggled, so it follows the global setting.
+  const [verboseOverride, setVerboseOverride] = useState<boolean | null>(() =>
+    readStoredSessionChatVerbose(sessionKey),
+  );
+  useEffect(() => {
+    setVerboseOverride(readStoredSessionChatVerbose(sessionKey));
+  }, [sessionKey]);
+  const verbose = verboseOverride ?? verboseMode;
+  const toggleVerbose = useCallback(() => {
+    const next = !verbose;
+    writeStoredSessionChatVerbose(sessionKey, next);
+    setVerboseOverride(next);
+  }, [sessionKey, verbose]);
   /*
   What the agent is actually running, confirmed by gxserver from structured
   transcript metadata and the terminal statusline. Keyed on detectedAt so a
@@ -480,7 +539,7 @@ export function SessionChatView({
             loadingEarlier={chat.loadingEarlier}
             messages={chat.messages}
             onLoadEarlier={chat.loadEarlier}
-            verboseMode={verboseMode}
+            verboseMode={verbose}
           />
         ) : showNewSessionWelcome ? (
           <NewSessionWelcome agentLabel={agentLabel} />
@@ -545,6 +604,7 @@ export function SessionChatView({
                       }
                     : {})}
                 />
+                <SessionVerbosePill onToggle={toggleVerbose} verbose={verbose} />
               </>
             }
             placeholder={canSend ? undefined : "Input is held by another device."}

--- a/sidebar/chat/session-chat-view.tsx
+++ b/sidebar/chat/session-chat-view.tsx
@@ -3,7 +3,7 @@
 // the composer while showing. Hosts inject a SessionChatTransport; everything
 // else is derived by useSessionChat.
 
-import { IconEye, IconEyeOff, IconRobot } from "@tabler/icons-react";
+import { IconEyeFilled, IconEyeOff, IconRobot } from "@tabler/icons-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 import { Button } from "../../components/ui/button";
@@ -227,7 +227,7 @@ function SessionVerbosePill({
   onToggle: () => void;
   verbose: boolean;
 }) {
-  const Icon = verbose ? IconEye : IconEyeOff;
+  const Icon = verbose ? IconEyeFilled : IconEyeOff;
   return (
     <AppTooltip
       content={

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -2162,7 +2162,8 @@ export function SettingsModal({
       },
       {
         key: "sessionChatVerboseMode",
-        subtitle: "Expand thinking blocks to show their tool calls by default.",
+        subtitle:
+          "Expand thinking blocks to show their tool calls by default. Each chat can override it from its composer.",
         title: "Verbose mode",
       },
     ]),
@@ -4018,7 +4019,7 @@ export function SettingsModal({
                 {mainSettingVisible(settingsSearch.chat, "sessionChatVerboseMode") ? (
                   <ToggleField
                     checked={draft.sessionChatVerboseMode}
-                    description="Expand thinking blocks to show their tool calls by default. Individual command and output details remain collapsible."
+                    description="Expand thinking blocks to show their tool calls by default. Individual command and output details remain collapsible. This is the default for new chats; the Verbose pill in a chat's composer overrides it for that chat only."
                     label="Verbose Mode"
                     {...getSettingModificationProps("sessionChatVerboseMode")}
                     onChange={(checked) => updateDraft("sessionChatVerboseMode", checked)}


### PR DESCRIPTION
## What

Verbose Mode is reachable only from Settings today, and it applies to every chat at once — so following one session's tool calls means expanding thinking blocks everywhere.

This adds a **Verbose** pill to the chat composer's option row, right after the model and effort pills.

## How it behaves

- The pill overrides `sessionChatVerboseMode` **for that session only**.
- The choice persists in `localStorage`, keyed per session, so a chat keeps its mode across reloads and restarts.
- Chats that never touch the pill keep following the setting. The Settings toggle is now described as the default rather than the only control.
- Off = crossed eye, muted. On = open eye, filled.

## Scope

It lives in `SessionChatView`, so the gpui desktop surface, `ghostex-web`, and `mobile-chat` all pick it up with no new host bridge and no settings-patch plumbing — the chat surface has no settings channel, and this deliberately avoids adding one.

## Testing

`bun run typecheck` passes clean. Verified end to end against a live session through `bun run web:dev` and in the desktop app via a `GHOSTEX_GPUI_CHAT_URL` override: toggling the pill expands/collapses the transcript's tool calls, and the state survives a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Verbose Mode toggle to individual chats.
  * Chat-specific Verbose Mode choices are remembered and take precedence over the default setting.
  * Thinking blocks can reveal tool calls, while command and output details remain collapsible.
  * The setting remains unchanged when no chat-specific preference has been selected.

* **Documentation**
  * Clarified how the default Verbose Mode setting and per-chat overrides work.
  * Explained that individual command and output details can still be collapsed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->