### PR TITLE
feat(settings): one web-link destination, and a rail that shows every section

### DIFF
--- a/gpui/sidebar/chat-main.tsx
+++ b/gpui/sidebar/chat-main.tsx
@@ -520,6 +520,12 @@ in Ghostex's own Browser view (Shift+click asks for the OS browser instead),
 and a file path opens in the project's Docs view when Docs can show it, else in
 the Code view. Both ride the same host-action bridge as the button cluster; the
 page never navigates itself, since chat.html has nowhere to navigate to.
+
+CDXC:GPUISessionChatLinks 2026-08-18:
+Where a web URL actually lands is the host's call, not this page's: it reads the
+"Open links in embedded browser" Browser setting, the same one Command-clicked
+terminal links use, and hands the URL to the system default browser when that
+setting is off.
 */
 const GPUI_SESSION_CHAT_HOST_LINKS: SessionChatHostLinks = {
   openUrl: (url, { external }) => postSessionChatHostAction("openLink", { external, url }),

--- a/gpui/src/main.rs
+++ b/gpui/src/main.rs
@@ -30311,7 +30311,7 @@ impl GhostexGpuiApp {
             return;
         }
         let open_in_app =
-            shared_settings::shared_sidebar_settings_snapshot().open_terminal_links_in_app();
+            shared_settings::shared_sidebar_settings_snapshot().web_links_open_in_app();
         if external || !open_in_app {
             if let Some(url) = normalize_address(url) {
                 let _ = gpui_open_external_http_url(&url);
@@ -31234,9 +31234,7 @@ impl GhostexGpuiApp {
             ),
             "showBetaFeatures": settings_snapshot.show_beta_features(),
             "sidebarTheme": gpui_app_modal_sidebar_theme_from_settings(settings_object),
-            "terminalDevServerOpenTarget": gpui_titlebar_terminal_dev_server_open_target_from_settings(
-                settings_object,
-            ),
+            "webLinkOpenTarget": gpui_titlebar_web_link_open_target_from_settings(settings_object),
         });
         if let Some(project_id) = active_project_id {
             update["projectId"] = serde_json::json!(project_id);
@@ -57926,7 +57924,7 @@ impl GhostexGpuiApp {
         }
         let open_value = gpui_terminal_markdown_image_reference_path(trimmed).unwrap_or(trimmed);
         if gpui_terminal_link_is_web_url(open_value) {
-            if !shared_settings::shared_sidebar_settings_snapshot().open_terminal_links_in_app() {
+            if !shared_settings::shared_sidebar_settings_snapshot().web_links_open_in_app() {
                 let _ = gpui_open_terminal_action_url(open_value);
                 return;
             }
@@ -81006,10 +81004,7 @@ impl GpuiTitlebarReadingPanel {
                             let main_url = main_url.clone();
                             let _ = this.main_app.update_in(cx, move |app, main_window, cx| {
                                 let settings = shared_settings::shared_sidebar_settings_snapshot();
-                                if gpui_titlebar_terminal_dev_server_open_target_from_settings(
-                                    settings.object(),
-                                ) == "system-default-browser"
-                                {
+                                if !settings.web_links_open_in_app() {
                                     let _ = gpui_spawn_os_open(std::ffi::OsStr::new(&main_url));
                                 } else {
                                     app.open_gpui_browser_action_url(main_url, main_window, cx);
@@ -87573,16 +87568,19 @@ fn gpui_titlebar_resources_project_editor_kind(
     }
 }
 
-fn gpui_titlebar_terminal_dev_server_open_target_from_settings(
+/*
+CDXC:WebLinkOpenTarget 2026-08-19:
+The titlebar Resources list needs the merged web-link destination as a string
+for its own payload, so route it through the same snapshot accessor that owns
+the legacy-key precedence instead of reading the raw field a second time.
+*/
+fn gpui_titlebar_web_link_open_target_from_settings(
     settings: &serde_json::Map<String, serde_json::Value>,
 ) -> &'static str {
-    match settings
-        .get("terminalDevServerOpenTarget")
-        .and_then(serde_json::Value::as_str)
-    {
-        Some("internal-browser") => "internal-browser",
-        Some("system-default-browser") => "system-default-browser",
-        _ => "system-default-browser",
+    if shared_settings::web_links_open_in_app_from_object(settings) {
+        "internal-browser"
+    } else {
+        "system-default-browser"
     }
 }
 

--- a/gpui/src/main.rs
+++ b/gpui/src/main.rs
@@ -30024,9 +30024,11 @@ impl GhostexGpuiApp {
         /*
         CDXC:GPUISessionChatLinks 2026-08-03:
         Conversation links open in the app's own surfaces: a web URL goes to
-        the integrated Browser (Shift+click asks for the OS browser instead),
-        and a file path goes to Docs or Code. Both leave the chat pane behind
-        by design, so neither needs the focused-session routing below.
+        the integrated Browser while "Open links in embedded browser" is on
+        (Shift+click, or that setting off, asks for the system default browser
+        instead), and a file path goes to Docs or Code. Both leave the chat
+        pane behind by design, so neither needs the focused-session routing
+        below.
         */
         if action == "openLink" {
             let Some(url) = message.get("url").and_then(serde_json::Value::as_str) else {
@@ -30291,6 +30293,12 @@ impl GhostexGpuiApp {
     `ghostex browser open` (same-origin reuse, so re-clicking a dev-server URL
     does not multiply tabs). Shift+click is the explicit escape hatch to the OS
     browser and takes the http/https-only external opener.
+
+    CDXC:GPUISessionChatLinks 2026-08-18:
+    Chat web links answer to the same "Open links in embedded browser" setting
+    as Command-clicked terminal links, so a single switch decides where every
+    agent-sent web link lands. With that setting off, an ordinary click leaves
+    for the system default browser exactly like Shift+click already does.
     */
     fn open_session_chat_link(
         &mut self,
@@ -30302,7 +30310,9 @@ impl GhostexGpuiApp {
         if url.chars().count() > GPUI_SIDEBAR_OPEN_BROWSER_URL_MAX_CHARS {
             return;
         }
-        if external {
+        let open_in_app =
+            shared_settings::shared_sidebar_settings_snapshot().open_terminal_links_in_app();
+        if external || !open_in_app {
             if let Some(url) = normalize_address(url) {
                 let _ = gpui_open_external_http_url(&url);
             }

--- a/gpui/src/shared_settings.rs
+++ b/gpui/src/shared_settings.rs
@@ -62,7 +62,7 @@ const DEFAULT_TERMINAL_SCROLLBAR: &str = "system";
 const DEFAULT_TERMINAL_MOUSE_SCROLL_MULTIPLIER_DISCRETE: f64 = 1.0;
 const DEFAULT_TERMINAL_MOUSE_SCROLL_MULTIPLIER_PRECISION: f64 = 1.0;
 const DEFAULT_TERMINAL_SCROLL_TO_BOTTOM_WHEN_TYPING: bool = true;
-const DEFAULT_OPEN_TERMINAL_LINKS_IN_APP: bool = true;
+const DEFAULT_WEB_LINKS_OPEN_IN_APP: bool = true;
 const DEFAULT_TERMINAL_PANE_PADDING_PX: f64 = 0.0;
 const MIN_TERMINAL_PANE_PADDING_PX: f64 = 0.0;
 const MAX_TERMINAL_PANE_PADDING_PX: f64 = 64.0;
@@ -877,9 +877,17 @@ impl SharedSidebarSettingsSnapshot {
             .unwrap_or(DEFAULT_TERMINAL_CLIPBOARD_PASTE_PROTECTION)
     }
 
-    pub fn open_terminal_links_in_app(&self) -> bool {
-        strict_bool_field(&self.object, "openTerminalLinksInApp")
-            .unwrap_or(DEFAULT_OPEN_TERMINAL_LINKS_IN_APP)
+    /*
+    CDXC:WebLinkOpenTarget 2026-08-19:
+    Command-clicked terminal links, session chat links, and detected dev-server
+    rows share one destination. The settings file is written by the sidebar, so
+    an install that has not saved settings since the merge still carries the two
+    legacy keys: read them in the same precedence the TypeScript normalizer
+    uses, or every one of those users would silently jump to whichever default
+    this accessor happened to pick.
+    */
+    pub fn web_links_open_in_app(&self) -> bool {
+        web_links_open_in_app_from_object(&self.object)
     }
 
     pub fn terminal_pane_padding_px(&self) -> (f32, f32) {
@@ -2199,6 +2207,27 @@ fn shared_settings_iso8601_utc_millis_like(value: &str) -> bool {
 
 fn strict_bool_field(object: &Map<String, Value>, key: &str) -> Option<bool> {
     object.get(key)?.as_bool()
+}
+
+pub fn web_links_open_in_app_from_object(object: &Map<String, Value>) -> bool {
+    if let Some(target) = object.get("webLinkOpenTarget").and_then(Value::as_str) {
+        match target {
+            "internal-browser" => return true,
+            "system-default-browser" => return false,
+            _ => {}
+        }
+    }
+    if let Some(open_in_app) = strict_bool_field(object, "openTerminalLinksInApp") {
+        return open_in_app;
+    }
+    match object
+        .get("terminalDevServerOpenTarget")
+        .and_then(Value::as_str)
+    {
+        Some("internal-browser") => true,
+        Some("system-default-browser") => false,
+        _ => DEFAULT_WEB_LINKS_OPEN_IN_APP,
+    }
 }
 
 fn normalize_keep_awake_duration_minutes(value: Option<&Value>) -> SharedKeepAwakeDurationMinutes {

--- a/native/sidebar/native-sidebar.tsx
+++ b/native/sidebar/native-sidebar.tsx
@@ -761,7 +761,7 @@ type NativeHostCommand =
       agentHookStatus?: SidebarAgentHookStatusMessage;
       ghostexCliStatus?: SidebarGhostexCliStatusMessage;
       sessionPersistenceProvider?: ghostexSettings["sessionPersistenceProvider"];
-      terminalDevServerOpenTarget?: ghostexSettings["terminalDevServerOpenTarget"];
+      webLinkOpenTarget?: ghostexSettings["webLinkOpenTarget"];
       titlebarCodeEditorProjectIds?: string[];
       titlebarPortless?: SidebarPortlessState;
       titlebarResourceGroups?: TitlebarResourceGroup[];
@@ -6869,9 +6869,9 @@ function handleTerminalOpenUrlRequested(
    * opt back into the system browser in Settings, so honor that choice here
    * with the existing native external-open command.
    */
-  if (!settings.openTerminalLinksInApp) {
+  if (settings.webLinkOpenTarget === "system-default-browser") {
     appendTerminalLinkDebugLog("sidebar.terminalOpenUrl.external", {
-      openTerminalLinksInApp: false,
+      webLinkOpenTarget: settings.webLinkOpenTarget,
       sourceSessionId: hostEvent.sourceSessionId,
     });
     postNative({ type: "openExternalUrl", url: hostEvent.url });
@@ -47963,7 +47963,7 @@ function syncNativeLayout(
      * undefined here; undefined means the titlebar should keep prior state.
      */
     sessionPersistenceProvider: settings.sessionPersistenceProvider,
-    terminalDevServerOpenTarget: settings.terminalDevServerOpenTarget,
+    webLinkOpenTarget: settings.webLinkOpenTarget,
     sessionTitleBarActions,
     sessionTitles,
     petOverlayEnabled: settings.petOverlayEnabled,

--- a/native/sidebar/titlebar-host.tsx
+++ b/native/sidebar/titlebar-host.tsx
@@ -93,7 +93,7 @@ import {
   type KeepAwakeDurationMinutes,
   type SidebarSide,
   type SessionPersistenceProvider,
-  type TerminalDevServerOpenTarget,
+  type WebLinkOpenTarget,
 } from "../../shared/ghostex-settings";
 import {
   normalizeghostexHotkeySettings,
@@ -347,7 +347,7 @@ type TitlebarProjectState = {
   hotkeys: ghostexHotkeySettings;
   showProjectEditorDiffFileCount: boolean;
   sessionPersistenceProvider: SessionPersistenceProvider;
-  terminalDevServerOpenTarget: TerminalDevServerOpenTarget;
+  webLinkOpenTarget: WebLinkOpenTarget;
   toggleSidebarHotkeyLabel: string;
   workspaceOpenTargets: TitlebarOpenTargetsSettings;
   isFocusModeActive?: boolean;
@@ -4658,7 +4658,7 @@ function App() {
           selectedActionCommandId={selectedActionCommandId}
           hotkeys={projectState.hotkeys}
           sidebarTheme={projectState.sidebarTheme}
-          serverOpenTarget={projectState.terminalDevServerOpenTarget}
+          linkOpenTarget={projectState.webLinkOpenTarget}
           sessionPersistenceProvider={
             projectState.sessionPersistenceProvider === "off"
               ? undefined
@@ -5126,7 +5126,7 @@ function TitlebarDropdownPanelSurface({
   selectedActionCommandId,
   hotkeys,
   sidebarTheme,
-  serverOpenTarget,
+  linkOpenTarget,
   sessionPersistenceProvider,
   visibleActions,
   visibleTargets,
@@ -5187,7 +5187,7 @@ function TitlebarDropdownPanelSurface({
   selectedActionCommandId: string | undefined;
   hotkeys: ghostexHotkeySettings;
   sidebarTheme: SidebarTheme;
-  serverOpenTarget: TerminalDevServerOpenTarget;
+  linkOpenTarget: WebLinkOpenTarget;
   sessionPersistenceProvider: Exclude<SessionPersistenceProvider, "off"> | undefined;
   visibleActions: SidebarCommandButton[];
   visibleTargets: ResolvedOpenTarget[];
@@ -5321,7 +5321,7 @@ function TitlebarDropdownPanelSurface({
             processTotals={resourceProcessTotals}
             quittingKeys={quittingResourceKeys}
             serverBundles={serverBundles}
-            serverOpenTarget={serverOpenTarget}
+            linkOpenTarget={linkOpenTarget}
             sessionPersistenceProvider={sessionPersistenceProvider}
           />
         </div>
@@ -6004,7 +6004,7 @@ function createInitialProjectState(bootstrap: Record<string, unknown>): Titlebar
     },
     showProjectEditorDiffFileCount: settings.showProjectEditorDiffFileCount,
     sessionPersistenceProvider: settings.sessionPersistenceProvider,
-    terminalDevServerOpenTarget: settings.terminalDevServerOpenTarget,
+    webLinkOpenTarget: settings.webLinkOpenTarget,
     toggleSidebarHotkeyLabel: formatToggleSidebarTooltipLabel(
       settings.hotkeys.toggleSidebarCollapsed,
     ),
@@ -6545,7 +6545,7 @@ function TitlebarResourcesMenu({
   orphanBundles,
   quittingKeys,
   serverBundles,
-  serverOpenTarget,
+  linkOpenTarget,
   sessionPersistenceProvider,
 }: {
   browserBundles: ResourceProcessBundle[];
@@ -6571,7 +6571,7 @@ function TitlebarResourcesMenu({
   orphanBundles: ResourceProcessBundle[];
   quittingKeys: Set<string>;
   serverBundles: ResourceProcessBundle[];
-  serverOpenTarget: TerminalDevServerOpenTarget;
+  linkOpenTarget: WebLinkOpenTarget;
   sessionPersistenceProvider?: Exclude<SessionPersistenceProvider, "off">;
 }) {
   const visibleGroupViews = processSnapshotReady
@@ -6822,7 +6822,7 @@ function TitlebarResourcesMenu({
               onFocusSession={onFocusSession}
               onToggle={onToggle}
               quittingKeys={quittingKeys}
-              serverOpenTarget={serverOpenTarget}
+              linkOpenTarget={linkOpenTarget}
               title="Dev Servers"
               bundles={serverBundles}
             />
@@ -6979,7 +6979,7 @@ function TitlebarResourceSection({
   onFocusSession,
   onToggle,
   quittingKeys,
-  serverOpenTarget,
+  linkOpenTarget,
   title,
 }: {
   bundles: ResourceProcessBundle[];
@@ -6988,7 +6988,7 @@ function TitlebarResourceSection({
   onFocusSession: (sessionId: string) => void;
   onToggle: (key: string) => void;
   quittingKeys: Set<string>;
-  serverOpenTarget?: TerminalDevServerOpenTarget;
+  linkOpenTarget?: WebLinkOpenTarget;
   title: string;
 }) {
   if (bundles.length === 0) {
@@ -7100,7 +7100,7 @@ function TitlebarResourceSection({
             onFocusSession={onFocusSession}
             onQuit={onQuit}
             onToggle={onToggle}
-            serverOpenTarget={serverOpenTarget}
+            linkOpenTarget={linkOpenTarget}
           />
         ))}
       </div>
@@ -7115,7 +7115,7 @@ function TitlebarResourceBundle({
   onQuit,
   onFocusSession,
   onToggle,
-  serverOpenTarget,
+  linkOpenTarget,
 }: {
   bundle: ResourceProcessBundle;
   collapsedKeys: Set<string>;
@@ -7123,7 +7123,7 @@ function TitlebarResourceBundle({
   onQuit: (bundles: ResourceProcessBundle[]) => void;
   onFocusSession: (sessionId: string) => void;
   onToggle: (key: string) => void;
-  serverOpenTarget?: TerminalDevServerOpenTarget;
+  linkOpenTarget?: WebLinkOpenTarget;
 }) {
   const hasChildren = bundle.childProcesses.length > 0;
   /**
@@ -7222,7 +7222,7 @@ function TitlebarResourceBundle({
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  openResourceBundleMainUrl(bundle, mainUrl, serverOpenTarget);
+                  openResourceBundleMainUrl(bundle, mainUrl, linkOpenTarget);
                 }}
               >
                 {mainLabel}
@@ -7403,13 +7403,16 @@ function getResourceBundleMainUrl(bundle: ResourceProcessBundle): string | undef
 function openResourceBundleMainUrl(
   bundle: ResourceProcessBundle,
   url: string,
-  serverOpenTarget: TerminalDevServerOpenTarget | undefined,
+  linkOpenTarget: WebLinkOpenTarget | undefined,
 ): void {
   /*
    * CDXC:TerminalDevServers 2026-06-23-19:22:
    * Resources dev-server links should open either in the user's system default browser or the internal browser. Do not expose a per-browser target list here; only server bundles should read this setting so future resource links keep their existing route.
+   *
+   * CDXC:WebLinkOpenTarget 2026-08-19:
+   * That choice is now the app-wide webLinkOpenTarget shared with terminal and session chat links, so these rows stop disagreeing with the Browser setting.
    */
-  if (bundle.type === "server" && serverOpenTarget === "system-default-browser") {
+  if (bundle.type === "server" && linkOpenTarget === "system-default-browser") {
     postNative({ type: "openExternalUrl", url });
     return;
   }

--- a/shared/ghostex-settings.test.ts
+++ b/shared/ghostex-settings.test.ts
@@ -37,7 +37,7 @@ import {
   SIDEBAR_PROJECT_GROUP_STYLE_OPTIONS,
   SIDEBAR_SIDE_OPTIONS,
   SIDEBAR_THEME_SETTING_OPTIONS,
-  TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS,
+  WEB_LINK_OPEN_TARGET_OPTIONS,
 } from "./ghostex-settings";
 import { DEFAULT_PET_ID } from "./pets";
 import {
@@ -173,25 +173,19 @@ describe("normalizeghostexSettings", () => {
   test("normalizes terminal dev-server discovery settings", () => {
     /*
      * CDXC:TerminalDevServers 2026-06-23-19:22:
-     * Terminal dev-server preferences should persist as app settings with detection enabled by default, one launch target for either the user's system browser or the internal browser, and ignored ports stored as canonical port or range strings.
+     * Terminal dev-server preferences should persist as app settings with detection enabled by default and ignored ports stored as canonical port or range strings.
+     *
+     * CDXC:WebLinkOpenTarget 2026-08-19:
+     * Where a detected URL opens is no longer a dev-server setting; it lives in webLinkOpenTarget with every other web link.
      */
     expect(DEFAULT_ghostex_SETTINGS.terminalDevServerDetectionEnabled).toBe(true);
-    expect(DEFAULT_ghostex_SETTINGS.terminalDevServerOpenTarget).toBe(
-      "system-default-browser",
-    );
-    expect(TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS).toEqual([
-      { label: "System Default Browser", value: "system-default-browser" },
-      { label: "Internal Browser", value: "internal-browser" },
-    ]);
     expect(normalizeghostexSettings({})).toMatchObject({
       terminalDevServerDetectionEnabled: true,
-      terminalDevServerOpenTarget: "system-default-browser",
       terminalDevServerIgnoredPortRules: [],
     });
     expect(
       normalizeghostexSettings({
         terminalDevServerDetectionEnabled: false,
-        terminalDevServerOpenTarget: "internal-browser",
         terminalDevServerIgnoredPortRules: [
           "3000-3005",
           "3004-3008",
@@ -202,16 +196,7 @@ describe("normalizeghostexSettings", () => {
       }),
     ).toMatchObject({
       terminalDevServerDetectionEnabled: false,
-      terminalDevServerOpenTarget: "internal-browser",
       terminalDevServerIgnoredPortRules: ["3000-3008", "9229-9230"],
-    });
-    expect(
-      normalizeghostexSettings({
-        terminalDevServerDefaultBrowserId: "edge",
-        terminalDevServerEnabledBrowserIds: ["firefox"],
-      }),
-    ).toMatchObject({
-      terminalDevServerOpenTarget: "system-default-browser",
     });
     expect(normalizeTerminalDevServerIgnoredPortRuleInput(" 24678 - 24680 ")).toBe(
       "24678-24680",
@@ -222,6 +207,42 @@ describe("normalizeghostexSettings", () => {
     expect(normalizeTerminalDevServerIgnoredPortRules(["3000", "3001", "3002-3003"])).toEqual([
       "3000-3003",
     ]);
+  });
+
+  test("merges the legacy link-destination settings into one web-link target", () => {
+    /*
+     * CDXC:WebLinkOpenTarget 2026-08-19:
+     * The Browser toggle and the Dev Servers dropdown answered the same question with opposite defaults. They merge into one target, so the toggle has to win migration: it is the switch users actually flipped, while nearly every install carries a dev-server default it never chose.
+     */
+    expect(DEFAULT_ghostex_SETTINGS.webLinkOpenTarget).toBe("internal-browser");
+    expect(WEB_LINK_OPEN_TARGET_OPTIONS).toEqual([
+      { label: "Internal Browser", value: "internal-browser" },
+      { label: "System Default Browser", value: "system-default-browser" },
+    ]);
+    expect(normalizeghostexSettings({})).toMatchObject({
+      webLinkOpenTarget: "internal-browser",
+    });
+    expect(
+      normalizeghostexSettings({ webLinkOpenTarget: "system-default-browser" }),
+    ).toMatchObject({ webLinkOpenTarget: "system-default-browser" });
+    expect(
+      normalizeghostexSettings({
+        openTerminalLinksInApp: false,
+        terminalDevServerOpenTarget: "internal-browser",
+      }),
+    ).toMatchObject({ webLinkOpenTarget: "system-default-browser" });
+    expect(
+      normalizeghostexSettings({
+        openTerminalLinksInApp: true,
+        terminalDevServerOpenTarget: "system-default-browser",
+      }),
+    ).toMatchObject({ webLinkOpenTarget: "internal-browser" });
+    expect(
+      normalizeghostexSettings({ terminalDevServerOpenTarget: "system-default-browser" }),
+    ).toMatchObject({ webLinkOpenTarget: "system-default-browser" });
+    expect(
+      normalizeghostexSettings({ terminalDevServerDefaultBrowserId: "edge" }),
+    ).toMatchObject({ webLinkOpenTarget: "system-default-browser" });
   });
 
   test("normalizes global Portless settings", () => {

--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -841,6 +841,12 @@ export type ghostexSettings = {
    * Browser view by default. Turning this off restores handing web links to
    * the system default browser. File paths and non-web schemes always keep
    * the external NSWorkspace route regardless of this setting.
+   *
+   * CDXC:GPUISessionChatLinks 2026-08-18:
+   * Web links clicked in session chat follow the same switch, so this is the
+   * single answer to "where do agent-sent web links open". Chat file links
+   * still open in Docs or Code, and Shift+click still forces the system
+   * default browser while the setting is on.
    */
   openTerminalLinksInApp: boolean;
   /**
@@ -1479,6 +1485,9 @@ export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
    * In-app terminal link routing is the default so cmd-clicked web links land
    * in the project Browser view unless the user opts back into the system
    * browser in Settings.
+   *
+   * CDXC:GPUISessionChatLinks 2026-08-18:
+   * Session chat web links share this default for the same reason.
    */
   openTerminalLinksInApp: true,
   /**

--- a/shared/ghostex-settings.ts
+++ b/shared/ghostex-settings.ts
@@ -53,7 +53,14 @@ export type WindowsTerminalBackend = "wsl";
 export type BrowserOpenMode = "browser-pane";
 export type BrowserFeedbackTool = "agentation";
 export type PortlessProtocol = "https" | "http";
-export type TerminalDevServerOpenTarget = "internal-browser" | "system-default-browser";
+/**
+ * CDXC:WebLinkOpenTarget 2026-08-19:
+ * One answer to "where does a web link Ghostex opens land". Command-clicked
+ * terminal links, session chat links, and detected dev-server rows all read
+ * this single target instead of the old split between a Browser toggle and a
+ * Dev Servers dropdown, which could disagree with each other.
+ */
+export type WebLinkOpenTarget = "internal-browser" | "system-default-browser";
 export type DefaultEditorCommand =
   | "code"
   | "code-insiders"
@@ -456,18 +463,17 @@ const CUSTOM_SIDEBAR_TITLEBAR_BACKGROUND_DARK_TINTS: ReadonlyMap<string, string>
   ["#854f7a", "#100611"],
   ["#8a4f5f", "#100409"],
 ]);
-export const TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS: ReadonlyArray<{
+export const WEB_LINK_OPEN_TARGET_OPTIONS: ReadonlyArray<{
   label: string;
-  value: TerminalDevServerOpenTarget;
+  value: WebLinkOpenTarget;
 }> = [
-  { label: "System Default Browser", value: "system-default-browser" },
   { label: "Internal Browser", value: "internal-browser" },
+  { label: "System Default Browser", value: "system-default-browser" },
 ];
-const DEFAULT_TERMINAL_DEV_SERVER_OPEN_TARGET: TerminalDevServerOpenTarget =
-  "system-default-browser";
+const DEFAULT_WEB_LINK_OPEN_TARGET: WebLinkOpenTarget = "internal-browser";
 const DEFAULT_TERMINAL_DEV_SERVER_IGNORED_PORT_RULES: readonly string[] = [];
-const TERMINAL_DEV_SERVER_OPEN_TARGET_SET = new Set(
-  TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS.map((option) => option.value),
+const WEB_LINK_OPEN_TARGET_SET = new Set(
+  WEB_LINK_OPEN_TARGET_OPTIONS.map((option) => option.value),
 );
 const SETTINGS_MODAL_NAVIGATION_TAB_SET = new Set<string>(SETTINGS_MODAL_NAVIGATION_TABS);
 const MAX_SETTINGS_MODAL_SCROLL_TOP = 1_000_000;
@@ -838,17 +844,23 @@ export type ghostexSettings = {
   /**
    * CDXC:TerminalLinkInAppBrowser 2026-07-02-13:05:
    * Command-clicked http/https terminal links open as tabs in the project
-   * Browser view by default. Turning this off restores handing web links to
-   * the system default browser. File paths and non-web schemes always keep
-   * the external NSWorkspace route regardless of this setting.
+   * Browser view by default. Pointing this at the system default browser
+   * restores handing web links to it. File paths and non-web schemes always
+   * keep the external NSWorkspace route regardless of this setting.
    *
    * CDXC:GPUISessionChatLinks 2026-08-18:
    * Web links clicked in session chat follow the same switch, so this is the
    * single answer to "where do agent-sent web links open". Chat file links
    * still open in Docs or Code, and Shift+click still forces the system
-   * default browser while the setting is on.
+   * default browser while the target is the internal browser.
+   *
+   * CDXC:WebLinkOpenTarget 2026-08-19:
+   * Detected dev-server rows read this too, replacing the separate Dev Servers
+   * open-target dropdown. Migrated from the legacy openTerminalLinksInApp
+   * boolean, which wins over the legacy dev-server target when both persist,
+   * because it is the switch users actually flipped.
    */
-  openTerminalLinksInApp: boolean;
+  webLinkOpenTarget: WebLinkOpenTarget;
   /**
    * CDXC:SettingsAdvanced 2026-06-28-08:01:
    * Show Advanced is a persisted Settings browsing preference. When users enable
@@ -1245,7 +1257,6 @@ export type ghostexSettings = {
    * Dev-server discovery is app-owned terminal behavior, not a terminal emulator config key. Persist detection, a single open-target choice, and ignored ports with the main settings contract so Terminal settings stay focused on opening in the user's system browser or the internal browser instead of exposing per-browser checkboxes.
    */
   terminalDevServerDetectionEnabled: boolean;
-  terminalDevServerOpenTarget: TerminalDevServerOpenTarget;
   terminalDevServerIgnoredPortRules: readonly string[];
   /**
    * CDXC:PortlessSettings 2026-06-22-22:35:
@@ -1482,14 +1493,19 @@ export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
   browserOpenMode: "browser-pane",
   /**
    * CDXC:TerminalLinkInAppBrowser 2026-07-02-13:05:
-   * In-app terminal link routing is the default so cmd-clicked web links land
-   * in the project Browser view unless the user opts back into the system
-   * browser in Settings.
+   * In-app link routing is the default so cmd-clicked web links land in the
+   * project Browser view unless the user opts back into the system browser in
+   * Settings.
    *
    * CDXC:GPUISessionChatLinks 2026-08-18:
    * Session chat web links share this default for the same reason.
+   *
+   * CDXC:WebLinkOpenTarget 2026-08-19:
+   * Detected dev-server rows now share it as well, so a fresh install answers
+   * every web link the same way instead of splitting chat and terminal links
+   * from dev-server links.
    */
-  openTerminalLinksInApp: true,
+  webLinkOpenTarget: DEFAULT_WEB_LINK_OPEN_TARGET,
   /**
    * CDXC:SettingsAdvanced 2026-06-28-08:01:
    * New installs should start with ordinary Settings density, but an explicit
@@ -1982,10 +1998,12 @@ export const DEFAULT_ghostex_SETTINGS: ghostexSettings = {
   terminalScrollbar: "system",
   /**
    * CDXC:TerminalDevServers 2026-06-23-19:22:
-   * New installs should discover local dev servers from terminal output, open detected URLs with the user's system default browser unless changed to the internal browser, and start with no ignored ports.
+   * New installs should discover local dev servers from terminal output and start with no ignored ports.
+   *
+   * CDXC:WebLinkOpenTarget 2026-08-19:
+   * Where a detected URL opens is no longer a Dev Servers choice; it follows webLinkOpenTarget with every other web link.
    */
   terminalDevServerDetectionEnabled: true,
-  terminalDevServerOpenTarget: DEFAULT_TERMINAL_DEV_SERVER_OPEN_TARGET,
   terminalDevServerIgnoredPortRules: DEFAULT_TERMINAL_DEV_SERVER_IGNORED_PORT_RULES,
   /**
    * CDXC:PortlessSettingsDisabled 2026-07-25:
@@ -2392,10 +2410,7 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
       : DEFAULT_ghostex_SETTINGS.sessionPersistenceProvider,
     ),
   );
-  const terminalDevServerOpenTarget = normalizeTerminalDevServerOpenTarget(
-    source.terminalDevServerOpenTarget,
-    source.terminalDevServerDefaultBrowserId,
-  );
+  const webLinkOpenTarget = normalizeWebLinkOpenTarget(source);
   const rawLegacyCustomSidebarTitlebarBackgroundColor =
     source.customSidebarTitlebarBackgroundColor;
   const hasValidLegacyCustomSidebarTitlebarBackgroundColor =
@@ -2494,11 +2509,7 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
         DEFAULT_ghostex_SETTINGS.customSessionTitleGenerationCommand,
       ),
     ),
-    openTerminalLinksInApp: readBoolean(
-      source,
-      "openTerminalLinksInApp",
-      DEFAULT_ghostex_SETTINGS.openTerminalLinksInApp,
-    ),
+    webLinkOpenTarget,
     /** Normalize legacy feedback-tool settings to the sole supported tool. */
     browserFeedbackTool: normalizeBrowserFeedbackTool(
       readString(source, "browserFeedbackTool", DEFAULT_ghostex_SETTINGS.browserFeedbackTool),
@@ -3327,14 +3338,16 @@ export function normalizeghostexSettings(candidate: unknown): ghostexSettings {
     ),
     /**
      * CDXC:TerminalDevServers 2026-06-23-19:22:
-     * Dev-server settings normalize in the app layer because they are not Ghostty keys. Keep the launch choice to system default versus internal browser, migrate legacy per-browser defaults to system default, and canonicalize ignored port rules to sorted, merged strings.
+     * Dev-server settings normalize in the app layer because they are not Ghostty keys. Canonicalize ignored port rules to sorted, merged strings.
+     *
+     * CDXC:WebLinkOpenTarget 2026-08-19:
+     * The launch choice moved to webLinkOpenTarget, which absorbs both the legacy dev-server target and its older per-browser default.
      */
     terminalDevServerDetectionEnabled: readBoolean(
       source,
       "terminalDevServerDetectionEnabled",
       DEFAULT_ghostex_SETTINGS.terminalDevServerDetectionEnabled,
     ),
-    terminalDevServerOpenTarget,
     terminalDevServerIgnoredPortRules: normalizeTerminalDevServerIgnoredPortRules(
       source.terminalDevServerIgnoredPortRules,
     ),
@@ -3722,21 +3735,44 @@ function normalizeCustomPromptEditorCommand(value: string | undefined): string {
   return ((value ?? "").trim() || DEFAULT_ghostex_SETTINGS.customPromptEditorCommand).slice(0, 240);
 }
 
-function normalizeTerminalDevServerOpenTarget(
-  candidate: unknown,
-  legacyDefaultBrowserId: unknown,
-): TerminalDevServerOpenTarget {
-  const value = readLooseString(candidate);
-  if (TERMINAL_DEV_SERVER_OPEN_TARGET_SET.has(value as TerminalDevServerOpenTarget)) {
-    return value as TerminalDevServerOpenTarget;
+/*
+ * CDXC:WebLinkOpenTarget 2026-08-19:
+ * Two settings answered "where does this web link open" and could disagree:
+ * the Browser toggle openTerminalLinksInApp (default on) and the Dev Servers
+ * dropdown terminalDevServerOpenTarget (default system browser). They merge
+ * into one target, so migration has to pick a winner for existing installs.
+ * The toggle wins: it is the switch users actually flipped and the one the
+ * in-app toast points at, while nearly every install carries the dev-server
+ * default it never chose. Reading that field first would silently move
+ * everyone off the embedded browser.
+ */
+function normalizeWebLinkOpenTarget(source: Record<string, unknown>): WebLinkOpenTarget {
+  const value = readLooseString(source.webLinkOpenTarget);
+  if (WEB_LINK_OPEN_TARGET_SET.has(value as WebLinkOpenTarget)) {
+    return value as WebLinkOpenTarget;
   }
 
-  const legacyValue = readLooseString(legacyDefaultBrowserId);
-  if (legacyValue !== undefined) {
+  const legacyOpenLinksInApp = source.openTerminalLinksInApp;
+  if (typeof legacyOpenLinksInApp === "boolean") {
+    return legacyOpenLinksInApp ? "internal-browser" : "system-default-browser";
+  }
+
+  const legacyDevServerTarget = readLooseString(source.terminalDevServerOpenTarget);
+  if (WEB_LINK_OPEN_TARGET_SET.has(legacyDevServerTarget as WebLinkOpenTarget)) {
+    return legacyDevServerTarget as WebLinkOpenTarget;
+  }
+
+  /*
+   * readLooseString returns "" for a missing key, not undefined, so this has to
+   * test for content. The predecessor compared against undefined and therefore
+   * matched every install; it went unnoticed only because it returned the value
+   * that was already the default.
+   */
+  if (readLooseString(source.terminalDevServerDefaultBrowserId).length > 0) {
     return "system-default-browser";
   }
 
-  return DEFAULT_TERMINAL_DEV_SERVER_OPEN_TARGET;
+  return DEFAULT_WEB_LINK_OPEN_TARGET;
 }
 
 type TerminalDevServerPortRule = {

--- a/sidebar/settings-modal-source.test.ts
+++ b/sidebar/settings-modal-source.test.ts
@@ -464,7 +464,10 @@ describe("settings modal source", () => {
   test("keeps dev-server controls in the Terminal settings flow", () => {
     /*
      * CDXC:TerminalDevServers 2026-06-23-19:22:
-     * Dev-server detection, one system-default/internal-browser launch choice, and ignored ports should live in a dedicated Terminal settings section rather than the generic Browser section or a per-browser checklist.
+     * Dev-server detection and ignored ports should live in a dedicated Terminal settings section rather than the generic Browser section or a per-browser checklist.
+     *
+     * CDXC:WebLinkOpenTarget 2026-08-19:
+     * The launch choice moved the other way: it is now the Browser section's single web-link target, shared with terminal and session chat links.
      */
     const sectionKeys = sourceBetween(
       settingsModalSource,
@@ -483,12 +486,12 @@ describe("settings modal source", () => {
     );
 
     expect(sectionKeys).toContain("terminalDevServerDetectionEnabled");
-    expect(sectionKeys).toContain("terminalDevServerOpenTarget");
+    expect(sectionKeys).not.toContain("terminalDevServerOpenTarget");
     expect(sectionKeys).toContain("terminalDevServerIgnoredPortRules");
     expect(settingsNavigation).toContain('id: "tools"');
     expect(settingsNavigation).toContain("mainSettingsGroupSearch.tools");
     expect(settingsModalSource).toContain('"terminalDevServers"');
-    expect(devServersSection).toContain("TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS");
+    expect(devServersSection).not.toContain("WEB_LINK_OPEN_TARGET_OPTIONS");
     expect(devServersSection).not.toContain("TerminalDevServerBrowserTargetsField");
     expect(devServersSection).toContain("TerminalDevServerIgnoredPortsField");
   });

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -1,6 +1,7 @@
 import { DragDropProvider, type DragDropEventHandlers } from "@dnd-kit/react";
 import { isSortableOperation, useSortable } from "@dnd-kit/react/sortable";
 import {
+  Fragment,
   useCallback,
   useEffect,
   useId,
@@ -177,7 +178,7 @@ import {
   SIDEBAR_SETTINGS_PRESETS,
   SIDEBAR_SIDE_OPTIONS,
   SIDEBAR_VERSION_OPTIONS,
-  TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS,
+  WEB_LINK_OPEN_TARGET_OPTIONS,
   applySidebarSettingsPreset,
   areDiagnosticLoggingSettingsEqual,
   getSessionTitleGenerationCommandPreview,
@@ -219,7 +220,7 @@ import {
   type SidebarSide,
   type SidebarVersion,
   type TerminalBackgroundImageFit,
-  type TerminalDevServerOpenTarget,
+  type WebLinkOpenTarget,
   type TerminalCursorStyle,
   type ghostexSettingsPatch,
   type ghostexSettingsUpdateSource,
@@ -533,6 +534,22 @@ type SettingsSidebarPageSection = {
   active: boolean;
   id: string;
   onSelect: () => void;
+  /*
+   * CDXC:SettingsNavigation 2026-08-19:
+   * General groups several rendered section headers each ("Tools" holds
+   * Browser, Editor, and Dev Servers), and those headers had no rail entry at
+   * all. They expand as a third level under the active group instead of being
+   * promoted to top-level destinations, which would undo the deliberate
+   * "fewer sidebar destinations" grouping.
+   */
+  subsections?: readonly SettingsSidebarPageSubsection[];
+  title: string;
+};
+
+type SettingsSidebarPageSubsection = {
+  active: boolean;
+  id: string;
+  onSelect: () => void;
   title: string;
 };
 
@@ -746,16 +763,18 @@ const MAIN_SETTINGS_SECTION_SETTING_KEYS: Record<
     "terminalScrollToBottomWhenTyping",
   ],
   tools: [
-    "openTerminalLinksInApp",
+    "webLinkOpenTarget",
     "codeServerLinkVscodeUserConfig",
     "codeServerUseVscodeInsidersUserConfig",
     "showUntrackedProjectDiffWhenNoTrackedChanges",
     /*
      * CDXC:TerminalDevServers 2026-06-23-19:22:
-     * Dev-server discovery preferences belong under Terminal settings because they govern terminal-output detection and launch choices, while remaining separate from Ghostty config-backed terminal emulator controls. Keep the launch control to system default versus internal browser instead of presenting per-browser checkboxes.
+     * Dev-server discovery preferences belong under Terminal settings because they govern terminal-output detection, while remaining separate from Ghostty config-backed terminal emulator controls.
+     *
+     * CDXC:WebLinkOpenTarget 2026-08-19:
+     * Where a detected URL opens is no longer a Dev Servers row; it reads the Browser section's single web-link target.
      */
     "terminalDevServerDetectionEnabled",
-    "terminalDevServerOpenTarget",
     "terminalDevServerIgnoredPortRules",
   ],
   notifications: [
@@ -837,7 +856,6 @@ const MAIN_SETTINGS_SCROLL_TARGET_SETTING_KEYS = {
   ],
   terminalDevServers: [
     "terminalDevServerDetectionEnabled",
-    "terminalDevServerOpenTarget",
     "terminalDevServerIgnoredPortRules",
   ],
   builtInFeatures: [
@@ -846,7 +864,7 @@ const MAIN_SETTINGS_SCROLL_TARGET_SETTING_KEYS = {
     "automateViewTabHidden",
     "docsViewTabHidden",
   ],
-  browser: ["openTerminalLinksInApp"],
+  browser: ["webLinkOpenTarget"],
   editor: [
     "codeServerLinkVscodeUserConfig",
     "codeServerUseVscodeInsidersUserConfig",
@@ -889,6 +907,97 @@ const MAIN_SETTINGS_SCROLL_TARGET_SETTING_KEYS = {
   storage: ["ghostexFolderStats"],
   beta: ["showBetaFeatures"],
 } satisfies Record<MainSettingsScrollTargetId, readonly string[]>;
+
+type MainSettingsSubsectionId =
+  | "appIcon"
+  | "autoSleep"
+  | "beta"
+  | "browser"
+  | "debugging"
+  | "editor"
+  | "power"
+  | "sessionCards"
+  | "sidebar"
+  | "sidebarTags"
+  | "storage"
+  | "terminal"
+  | "terminalBehavior"
+  | "terminalDevServers"
+  | "terminalScrolling"
+  | "theming";
+
+type MainSettingsSubsectionNavigationItem = {
+  id: MainSettingsSubsectionId;
+  title: string;
+};
+
+/*
+ * CDXC:SettingsNavigation 2026-08-19:
+ * The rail rows for each General group, in the order the sections render on the
+ * page. A group's own anchor is listed first so its header (Browser under
+ * Tools, Terminal under Terminal) is reachable by name rather than only as the
+ * side effect of clicking the group. Groups with a single section stay flat and
+ * are omitted here.
+ */
+const MAIN_SETTINGS_SUBSECTION_NAVIGATION: Partial<
+  Record<MainSettingsSectionId, readonly MainSettingsSubsectionNavigationItem[]>
+> = {
+  advanced: [
+    { id: "beta", title: "Experimental" },
+    { id: "debugging", title: "Debugging" },
+  ],
+  appearance: [
+    { id: "theming", title: "Theming" },
+    { id: "appIcon", title: "App Icon" },
+  ],
+  sidebar: [
+    { id: "sidebar", title: "Sidebar" },
+    { id: "sessionCards", title: "Session Cards" },
+    { id: "sidebarTags", title: "Sidebar Tags" },
+  ],
+  system: [
+    { id: "autoSleep", title: "Auto Sleep" },
+    { id: "power", title: "Power" },
+    { id: "storage", title: "Storage" },
+  ],
+  terminal: [
+    { id: "terminal", title: "Terminal" },
+    { id: "terminalBehavior", title: "Terminal Behavior" },
+    { id: "terminalScrolling", title: "Terminal Scrolling" },
+  ],
+  tools: [
+    { id: "browser", title: "Browser" },
+    { id: "editor", title: "Editor" },
+    { id: "terminalDevServers", title: "Dev Servers" },
+  ],
+};
+
+const MAIN_SETTINGS_SUBSECTION_PARENT_IDS: Partial<
+  Record<MainSettingsScrollTargetId, MainSettingsSectionId>
+> = Object.fromEntries(
+  (
+    Object.entries(MAIN_SETTINGS_SUBSECTION_NAVIGATION) as Array<
+      [MainSettingsSectionId, readonly MainSettingsSubsectionNavigationItem[]]
+    >
+  ).flatMap(([sectionId, subsections]) =>
+    subsections.map((subsection) => [subsection.id, sectionId] as const),
+  ),
+);
+
+/*
+ * CDXC:SettingsNavigation 2026-08-19:
+ * Scroll tracking now reports the exact section header in view so a nested row
+ * can highlight itself. The rail's top-level row still highlights by group, so
+ * map the tracked anchor back to the group that owns it.
+ */
+function getMainSettingsSectionGroupId(
+  scrollTargetId: MainSettingsScrollTargetId,
+): MainSettingsSectionId {
+  return (
+    MAIN_SETTINGS_SUBSECTION_PARENT_IDS[scrollTargetId] ??
+    (scrollTargetId as MainSettingsSectionId)
+  );
+}
 
 /**
  * CDXC:SidebarSessionRename 2026-06-26-06:27:
@@ -1372,7 +1481,7 @@ export function SettingsModal({
   const showAdvancedSettings = draft.showAdvancedSettings;
   const [settingsSearchQuery, setSettingsSearchQuery] = useState("");
   const [activeMainSettingsSectionId, setActiveMainSettingsSectionId] =
-    useState<MainSettingsSectionId>("sidebar");
+    useState<MainSettingsScrollTargetId>("sidebar");
   const [activeHotkeySettingsSectionId, setActiveHotkeySettingsSectionId] =
     useState<HotkeySettingsSectionId>("general");
   const [expandedSettingsSidebarPages, setExpandedSettingsSidebarPages] = useState<
@@ -1763,10 +1872,11 @@ export function SettingsModal({
     ),
     browser: getSettingsSectionSearch(settingsSearchQuery, "Browser", [
       {
-        key: "openTerminalLinksInApp",
+        key: "webLinkOpenTarget",
+        options: WEB_LINK_OPEN_TARGET_OPTIONS,
         subtitle:
-          "Open web links from terminal output (Command-click) and session chat as tabs in the project Browser view instead of the system default browser.",
-        title: "Open links in embedded browser",
+          "Open web links from terminal output (Command-click), session chat, and detected dev servers in the project Browser view or the system default browser.",
+        title: "Open links in",
       },
     ]),
     editor: getSettingsSectionSearch(settingsSearchQuery, "Editor", [
@@ -2449,12 +2559,6 @@ export function SettingsModal({
         title: "Detect running servers in terminals",
       },
       {
-        key: "terminalDevServerOpenTarget",
-        options: TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS,
-        subtitle: "Open detected server URLs in the system default browser or internal browser.",
-        title: "Open detected servers in",
-      },
-      {
         key: "terminalDevServerIgnoredPortRules",
         options: [
           { label: "9229", value: "9229" },
@@ -2739,7 +2843,7 @@ export function SettingsModal({
     terminalScrolling: ghosttyScrollingSectionRef,
     theming: themingSectionRef,
   };
-  const scrollMainSettingsSectionIntoView = (sectionId: MainSettingsSectionId) => {
+  const scrollMainSettingsSectionIntoView = (sectionId: MainSettingsScrollTargetId) => {
     getMainSettingsSectionRef(sectionId, mainSettingsSectionRefs).current?.scrollIntoView({
       behavior: "smooth",
       block: "start",
@@ -2748,6 +2852,7 @@ export function SettingsModal({
   const visibleMainSettingsSectionNavigation: Array<
     SettingsSectionNavigationItem<MainSettingsSectionId> & {
       searchResult: SettingsSectionSearchResult;
+      subsections: readonly MainSettingsSubsectionNavigationItem[];
     }
   > =
     (isFirstLaunchSetup
@@ -2760,19 +2865,41 @@ export function SettingsModal({
           ...mainSettingsSectionNavigation,
         ]
       : mainSettingsSectionNavigation
-    ).filter((section) =>
-      section.id === "agents"
-        ? mainSectionVisible("agents", settingsSearch.sidebar)
-        : mainSectionVisible(section.id, section.searchResult),
+    )
+      .filter((section) =>
+        section.id === "agents"
+          ? mainSectionVisible("agents", settingsSearch.sidebar)
+          : mainSectionVisible(section.id, section.searchResult),
+      )
+      .map((section) => ({
+        ...section,
+        /*
+         * CDXC:SettingsNavigation 2026-08-19:
+         * A nested row must not outlive the section it points at, so hide the
+         * ones a search query, Show Advanced, or an unavailable capability
+         * (Power without experimental features, App Icon off macOS) already
+         * removed from the page.
+         */
+        subsections: (MAIN_SETTINGS_SUBSECTION_NAVIGATION[section.id] ?? []).filter((subsection) =>
+          mainSubsectionVisible(subsection.id, settingsSearch[subsection.id]),
+        ),
+      }));
+  const getMainSettingsSectionMeasurementItems = (): SettingsSectionMeasurementItem<MainSettingsScrollTargetId>[] =>
+    visibleMainSettingsSectionNavigation.flatMap((section) =>
+      (section.subsections.length > 0
+        ? section.subsections.map((subsection) => subsection.id)
+        : [section.id as MainSettingsScrollTargetId]
+      ).map((scrollTargetId) => ({
+        id: scrollTargetId,
+        ref: getMainSettingsSectionRef(scrollTargetId, mainSettingsSectionRefs),
+      })),
     );
-  const getMainSettingsSectionMeasurementItems = (): SettingsSectionMeasurementItem<MainSettingsSectionId>[] =>
-    visibleMainSettingsSectionNavigation.map((section) => ({
-      id: section.id,
-      ref: getMainSettingsSectionRef(section.id, mainSettingsSectionRefs),
-    }));
+  const activeMainSettingsGroupId = getMainSettingsSectionGroupId(activeMainSettingsSectionId);
   const hasVisibleMainSettings = visibleMainSettingsSectionNavigation.length > 0;
   const visibleMainSettingsSectionIds = visibleMainSettingsSectionNavigation
-    .map((section) => section.id)
+    .map((section) =>
+      [section.id, ...section.subsections.map((subsection) => subsection.id)].join(">"),
+    )
     .join("|");
   const hotkeyDefinitionsById = useMemo<HotkeySettingsDefinitionById>(
     () => new Map(GHOSTEX_HOTKEY_DEFINITIONS.map((definition) => [definition.id, definition])),
@@ -2862,13 +2989,32 @@ export function SettingsModal({
       icon: IconSettings,
       id: "settings",
       sections: visibleMainSettingsSectionNavigation.map((section) => ({
-        active: activeTab === "settings" && activeMainSettingsSectionId === section.id,
+        active: activeTab === "settings" && activeMainSettingsGroupId === section.id,
         id: section.id,
         onSelect: () => {
           setActiveMainSettingsSectionId(section.id);
           setActiveTab("settings");
           requestAnimationFrame(() => scrollMainSettingsSectionIntoView(section.id));
         },
+        /*
+         * CDXC:SettingsNavigation 2026-08-19:
+         * A group whose first anchor carries the group's own name (Sidebar,
+         * Terminal) would otherwise render "Sidebar > Sidebar". Drop that row
+         * from the rail only: scroll tracking still measures the anchor, so
+         * reading that header keeps the group row highlighted.
+         */
+        subsections: section.subsections
+          .filter((subsection) => subsection.title !== section.title)
+          .map((subsection) => ({
+            active: activeTab === "settings" && activeMainSettingsSectionId === subsection.id,
+            id: subsection.id,
+            onSelect: () => {
+              setActiveMainSettingsSectionId(subsection.id);
+              setActiveTab("settings");
+              requestAnimationFrame(() => scrollMainSettingsSectionIntoView(subsection.id));
+            },
+            title: subsection.title,
+          })),
         title: section.title,
       })),
       title: "General",
@@ -4069,24 +4215,31 @@ export function SettingsModal({
             {mainSubsectionVisible("browser", settingsSearch.browser) ? (
             <SettingsSection sectionRef={browserSectionRef} title="Browser">
               {/* CDXC:BrowserPanes 2026-05-27-07:24: Settings no longer exposes Chrome Canary attachment. Browser actions always open in workspace browser panes, leaving this section focused on pane behavior controls. */}
-              {mainSettingVisible(settingsSearch.browser, "openTerminalLinksInApp") ? (
+              {mainSettingVisible(settingsSearch.browser, "webLinkOpenTarget") ? (
               /*
                * CDXC:TerminalLinkInAppBrowser 2026-07-02-13:05:
                * Command-clicked terminal web links route into the project
                * Browser view by default, and the in-app toast points users at
-               * this toggle. Keep it a normal visible Browser setting so the
+               * this control. Keep it a normal visible Browser setting so the
                * toast's "change in settings" hint stays discoverable.
                *
                * CDXC:GPUISessionChatLinks 2026-08-18:
-               * The same toggle also routes web links clicked in session chat,
+               * The same control also routes web links clicked in session chat,
                * so one Browser setting covers every agent-sent web link.
+               *
+               * CDXC:WebLinkOpenTarget 2026-08-19:
+               * Detected dev-server rows read it too. This replaced a Browser
+               * toggle plus a Dev Servers dropdown that answered the same
+               * question with opposite defaults; a select rather than a toggle
+               * because the destination, not an on/off state, is the choice.
                */
-              <ToggleField
-                checked={draft.openTerminalLinksInApp}
-                description="Open web links from terminal output (Command-click) and session chat as tabs in the project Browser view instead of the system default browser."
-                label="Open links in embedded browser"
-                {...getSettingModificationProps("openTerminalLinksInApp")}
-                onChange={(checked) => updateDraft("openTerminalLinksInApp", checked)}
+              <SelectField
+                description="Open web links from terminal output (Command-click), session chat, and detected dev servers in the project Browser view or the system default browser."
+                label="Open links in"
+                {...getSettingModificationProps("webLinkOpenTarget")}
+                onChange={(value) => updateDraft("webLinkOpenTarget", value as WebLinkOpenTarget)}
+                options={WEB_LINK_OPEN_TARGET_OPTIONS}
+                value={draft.webLinkOpenTarget}
               />
               ) : null}
             </SettingsSection>
@@ -4689,7 +4842,7 @@ export function SettingsModal({
 
             {mainSubsectionVisible("terminalDevServers", settingsSearch.terminalDevServers) ? (
               <SettingsSection
-                description="Choose how Ghostex discovers running dev servers, where detected server URLs open, and which ports stay hidden."
+                description="Choose how Ghostex discovers running dev servers and which ports stay hidden. Detected URLs follow Browser → Open links in."
                 sectionRef={terminalDevServersSectionRef}
                 title="Dev Servers"
               >
@@ -4709,24 +4862,6 @@ export function SettingsModal({
                     onChange={(checked) =>
                       updateDraft("terminalDevServerDetectionEnabled", checked)
                     }
-                  />
-                ) : null}
-                {mainSettingVisible(
-                  settingsSearch.terminalDevServers,
-                  "terminalDevServerOpenTarget",
-                ) ? (
-                  <SelectField
-                    description="Open detected server URLs in the system default browser or internal browser."
-                    label="Open detected servers in"
-                    {...getSettingModificationProps("terminalDevServerOpenTarget")}
-                    onChange={(value) =>
-                      updateDraft(
-                        "terminalDevServerOpenTarget",
-                        value as TerminalDevServerOpenTarget,
-                      )
-                    }
-                    options={TERMINAL_DEV_SERVER_OPEN_TARGET_OPTIONS}
-                    value={draft.terminalDevServerOpenTarget}
                   />
                 ) : null}
                 {mainSettingVisible(
@@ -5682,16 +5817,40 @@ function SettingsSidebarNavigation({
               {hasSections && expanded ? (
                 <div className="settings-sidebar-subsection-list">
                   {page.sections?.map((section) => (
-                    <Button
-                      className="settings-section-sidebar-button settings-sidebar-subsection-button"
-                      data-active={section.active ? "true" : "false"}
-                      key={section.id}
-                      onClick={section.onSelect}
-                      type="button"
-                      variant="ghost"
-                    >
-                      {section.title}
-                    </Button>
+                    <Fragment key={section.id}>
+                      <Button
+                        className="settings-section-sidebar-button settings-sidebar-subsection-button"
+                        data-active={section.active ? "true" : "false"}
+                        onClick={section.onSelect}
+                        type="button"
+                        variant="ghost"
+                      >
+                        {section.title}
+                      </Button>
+                      {/*
+                       * CDXC:SettingsNavigation 2026-08-19:
+                       * Nested rows belong to the section being read, so they
+                       * appear under the active group only. Showing every
+                       * group's rows at once would turn a nine-row rail into a
+                       * twenty-row one and bury the categories.
+                       */}
+                      {section.active && section.subsections?.length ? (
+                        <div className="settings-sidebar-nested-subsection-list">
+                          {section.subsections.map((subsection) => (
+                            <Button
+                              className="settings-section-sidebar-button settings-sidebar-subsection-button settings-sidebar-nested-subsection-button"
+                              data-active={subsection.active ? "true" : "false"}
+                              key={subsection.id}
+                              onClick={subsection.onSelect}
+                              type="button"
+                              variant="ghost"
+                            >
+                              {subsection.title}
+                            </Button>
+                          ))}
+                        </div>
+                      ) : null}
+                    </Fragment>
                   ))}
                 </div>
               ) : null}

--- a/sidebar/settings-modal.tsx
+++ b/sidebar/settings-modal.tsx
@@ -1765,8 +1765,8 @@ export function SettingsModal({
       {
         key: "openTerminalLinksInApp",
         subtitle:
-          "Open Command-clicked terminal web links as tabs in the project Browser view instead of the system browser.",
-        title: "Open terminal links in embedded browser",
+          "Open web links from terminal output (Command-click) and session chat as tabs in the project Browser view instead of the system default browser.",
+        title: "Open links in embedded browser",
       },
     ]),
     editor: getSettingsSectionSearch(settingsSearchQuery, "Editor", [
@@ -4076,11 +4076,15 @@ export function SettingsModal({
                * Browser view by default, and the in-app toast points users at
                * this toggle. Keep it a normal visible Browser setting so the
                * toast's "change in settings" hint stays discoverable.
+               *
+               * CDXC:GPUISessionChatLinks 2026-08-18:
+               * The same toggle also routes web links clicked in session chat,
+               * so one Browser setting covers every agent-sent web link.
                */
               <ToggleField
                 checked={draft.openTerminalLinksInApp}
-                description="Open Command-clicked terminal web links as tabs in the project Browser view instead of the system browser."
-                label="Open terminal links in embedded browser"
+                description="Open web links from terminal output (Command-click) and session chat as tabs in the project Browser view instead of the system default browser."
+                label="Open links in embedded browser"
                 {...getSettingModificationProps("openTerminalLinksInApp")}
                 onChange={(checked) => updateDraft("openTerminalLinksInApp", checked)}
               />

--- a/sidebar/styles.css
+++ b/sidebar/styles.css
@@ -2921,6 +2921,24 @@ body {
   font-weight: 500;
 }
 
+/*
+ * CDXC:SettingsNavigation 2026-08-19:
+ * Section headers grouped inside a General category (Browser under Tools, Power
+ * under System) expand one level deeper than their group row. Repeat the 14px
+ * step so the nesting reads by inset alone, and keep the rule list separate so
+ * the third level can gain its own treatment without disturbing the second.
+ */
+.ghostex-settings-shadcn .settings-sidebar-nested-subsection-list {
+  display: grid;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.ghostex-settings-shadcn .settings-sidebar-nested-subsection-button {
+  font-size: 0.75rem;
+  padding-left: calc(0.625rem + 28px) !important;
+}
+
 .ghostex-settings-shadcn .settings-section-anchor {
   scroll-margin-top: 1rem;
 }

--- a/sidebar/titlebar-reading-panels.stories.tsx
+++ b/sidebar/titlebar-reading-panels.stories.tsx
@@ -107,7 +107,7 @@ function installTitlebarStoryHost(panel: "resources" | "tips") {
     ],
     sessionPersistenceProvider: "zmx",
     sidebarTheme: "dark",
-    terminalDevServerOpenTarget: "internal-browser",
+    webLinkOpenTarget: "internal-browser",
     workspaceName: "Ghostex",
   };
 


### PR DESCRIPTION
## The bug

Clicking a web link an agent wrote in the session chat always opened a Ghostex Browser tab, no matter how Settings was configured. `open_session_chat_link` never read the setting that governs this; only the terminal (Command-click) path did.

Looking at it turned up the larger problem: Ghostex answered *"where does a web link open"* **twice**, with opposite defaults.

| | key | type / default | UI |
|---|---|---|---|
| Browser | `openTerminalLinksInApp` | boolean, default **on** | *Open terminal links in embedded browser* |
| Dev Servers | `terminalDevServerOpenTarget` | enum, default **system browser** | *Open detected servers in* |

Set one and you still got the other's behaviour on the surfaces it owned, with nothing in Settings explaining the split.

## The fix

**One setting.** `webLinkOpenTarget` (`internal-browser` | `system-default-browser`) replaces both keys. Terminal Command-clicks, session chat links, and detected dev-server rows all read it.

It renders as a **Browser** dropdown, *"Open links in"* — the destination, not an on/off state, is the choice, and an enum leaves room for a named external browser later. Dev Servers keeps detection and ignored ports; its section copy now points at the Browser row.

**Migration** prefers the legacy toggle when both keys persist. It is the switch users actually flipped and the one the in-app toast points at, while nearly every install carries a dev-server default it never chose — reading that field first would silently move everyone off the embedded browser. Rust reads the same precedence directly from the settings JSON, since that file is written by the sidebar and an install that has not saved since the merge still carries only the legacy keys.

While there: `readLooseString` returns `""` for a missing key, so the inherited `!== undefined` legacy check matched *every* install. It was invisible only because it returned the value that was already the default.

## Settings rail

About ten rendered section headers had no entry in the General rail at all — **Browser** among them, which is where this setting lives.

They now expand as a third level under the active group rather than being promoted to top-level destinations, which would undo the deliberate "fewer sidebar destinations" grouping:

```
▾ General
   ▾ Tools
        Browser
        Editor
        Dev Servers
     Terminal
     System
```

Scroll tracking now follows the exact header in view, so a nested row highlights itself while its group row stays lit. A nested row is hidden whenever a search query, Show Advanced, or an unavailable capability (Power without experimental features, App Icon off macOS) already removed its section from the page, and a group whose first anchor repeats the group name does not render "Sidebar › Sidebar".

## Verification

- `bun run typecheck`, `bun run web:typecheck` — clean
- `vitest run` — 1684 passed, 173 files
- `cargo check --bin ghostex-gpui` — exit 0, no new warnings
- `cargo fmt --check` — only the three pre-existing `main.rs` diffs, untouched and unrelated
- Rail nesting driven live in Storybook over CDP: clicking **Tools** expands `Browser` / `Dev Servers` (Editor correctly hidden with Show Advanced off) and marks Tools active; the Browser section renders the *Open links in* select.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified web-link routing across Session Chat, terminal, detected development-server, titlebar, and resource links.
  * Choose whether links open in the embedded browser or your system’s default browser from Browser settings.
  * Added nested navigation for grouped settings sections.

* **Documentation**
  * Clarified shared Browser setting behavior and system-browser fallback when embedded browsing is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->