### PR TITLE
Kanban: filter the board by tag

### DIFF
--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -5,6 +5,7 @@ import {
   BOARD_SORT_OPTIONS,
   beadsStatusToBoardStatus,
   boardStatusBeadsValue,
+  boardTagFilterOptions,
   buildAgentWorkPrompt,
   DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   extractDescriptionImagePreviews,
@@ -20,6 +21,7 @@ import {
   PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,
   removeDescriptionImageReference,
   resolveAssignedAgentId,
+  resolveBoardTagFilter,
   sortBoardTickets,
   ticketCreatorName,
   type BoardTicket,
@@ -115,6 +117,7 @@ describe("project board filters", () => {
       displayId: "ZMX-1",
       estimate: 15,
       id: "urgent-xs",
+      labels: ["vault", "needs:sven"],
       priority: 0,
       status: "open",
       title: "Urgent XS task",
@@ -124,6 +127,7 @@ describe("project board filters", () => {
       displayId: "ZMX-2",
       estimate: null,
       id: "medium-none",
+      labels: ["ghostex", "vault"],
       priority: 2,
       status: "in_progress",
       title: "Medium unestimated task",
@@ -140,15 +144,57 @@ describe("project board filters", () => {
   ];
 
   test("filters by normalized priority and estimate without changing lane status", () => {
-    expect(filterBoardTickets(tickets, "", "3", "all").map((ticket) => ticket.id)).toEqual([
+    expect(filterBoardTickets(tickets, "", "3", "all", "all").map((ticket) => ticket.id)).toEqual([
       "legacy-low",
     ]);
-    expect(filterBoardTickets(tickets, "", "all", "none").map((ticket) => ticket.id)).toEqual([
+    expect(filterBoardTickets(tickets, "", "all", "none", "all").map((ticket) => ticket.id)).toEqual([
       "medium-none",
     ]);
-    expect(filterBoardTickets(tickets, "", "0", "XS").map((ticket) => ticket.id)).toEqual([
+    expect(filterBoardTickets(tickets, "", "0", "XS", "all").map((ticket) => ticket.id)).toEqual([
       "urgent-xs",
     ]);
+  });
+
+  test("filters by tag alongside the other toolbar selections", () => {
+    /*
+     * CDXC:ProjectBoardTagFilter 2026-08-21:
+     * The tag control only ever includes, so a selected tag narrows the board to the tickets that
+     * carry it and stacks with priority and estimate instead of replacing them. Tickets with no
+     * labels are simply not in that set rather than being treated as a selectable state of their
+     * own, because an untagged bead is untriaged rather than a kind of work.
+     */
+    expect(filterBoardTickets(tickets, "", "all", "all", "vault").map((ticket) => ticket.id)).toEqual([
+      "urgent-xs",
+      "medium-none",
+    ]);
+    expect(filterBoardTickets(tickets, "", "all", "all", "ghostex").map((ticket) => ticket.id)).toEqual([
+      "medium-none",
+    ]);
+    expect(filterBoardTickets(tickets, "", "0", "all", "vault").map((ticket) => ticket.id)).toEqual([
+      "urgent-xs",
+    ]);
+    expect(filterBoardTickets(tickets, "", "0", "all", "ghostex")).toEqual([]);
+    expect(filterBoardTickets(tickets, "", "all", "all", "all").map((ticket) => ticket.id)).toEqual([
+      "urgent-xs",
+      "medium-none",
+      "legacy-low",
+    ]);
+  });
+
+  test("offers the loaded tickets' own labels, sorted, with all first", () => {
+    expect(boardTagFilterOptions(tickets)).toEqual(["all", "ghostex", "needs:sven", "vault"]);
+    expect(boardTagFilterOptions([])).toEqual(["all"]);
+  });
+
+  test("resolves a tag the loaded board does not offer back to all", () => {
+    /*
+     * CDXC:ProjectBoardTagFilter 2026-08-21:
+     * A stored tag outlives the board that produced it, so opening a project that never used it
+     * must show the whole board rather than an empty one under a tag nothing carries.
+     */
+    expect(resolveBoardTagFilter("hermes", boardTagFilterOptions(tickets))).toBe("all");
+    expect(resolveBoardTagFilter("vault", boardTagFilterOptions(tickets))).toBe("vault");
+    expect(resolveBoardTagFilter("vault", boardTagFilterOptions([]))).toBe("all");
   });
 });
 
@@ -452,17 +498,19 @@ describe("project board view preferences", () => {
     expect(PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY).toBe("ghostex-project-board-view");
   });
 
-  test("restores stored priority, estimate, and sort selections", () => {
+  test("restores stored priority, estimate, sort, and tag selections", () => {
     expect(
       normalizeProjectBoardViewPreferences({
         estimateFilter: "M",
         priorityFilter: "1",
         sortOption: "created-asc",
+        tagFilter: "vault",
       }),
     ).toEqual({
       estimateFilter: "M",
       priorityFilter: "1",
       sortOption: "created-asc",
+      tagFilter: "vault",
     });
     expect(normalizeProjectBoardViewPreferences({ estimateFilter: "none" }).estimateFilter).toBe(
       "none",
@@ -484,8 +532,26 @@ describe("project board view preferences", () => {
         estimateFilter: "XXL",
         priorityFilter: 1,
         sortOption: "closed-desc",
+        tagFilter: 7,
       }),
     ).toEqual(DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES);
+  });
+
+  test("keeps a stored tag the current board may no longer offer", () => {
+    /*
+     * CDXC:ProjectBoardTagFilter 2026-08-21:
+     * Tag options are the labels the loaded tickets carry, so nothing at storage-read time can say
+     * whether a tag is still real. Normalisation therefore rejects only values that could never be
+     * a tag and leaves a stale-looking one intact, so a board that still has it restores the
+     * selection instead of the first tagless project erasing it. resolveBoardTagFilter is what
+     * lands an unavailable tag on "all" once a board has actually loaded.
+     */
+    expect(normalizeProjectBoardViewPreferences({ tagFilter: "vault" }).tagFilter).toBe("vault");
+    expect(normalizeProjectBoardViewPreferences({ tagFilter: "retired-lane-tag" }).tagFilter).toBe(
+      "retired-lane-tag",
+    );
+    expect(normalizeProjectBoardViewPreferences({ tagFilter: "   " }).tagFilter).toBe("all");
+    expect(normalizeProjectBoardViewPreferences({ tagFilter: ["vault"] }).tagFilter).toBe("all");
   });
 
   test("keeps every offered toolbar option restorable", () => {

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -117,7 +117,7 @@ describe("project board filters", () => {
       displayId: "ZMX-1",
       estimate: 15,
       id: "urgent-xs",
-      labels: ["vault", "needs:sven"],
+      labels: ["docs", "needs:review"],
       priority: 0,
       status: "open",
       title: "Urgent XS task",
@@ -127,7 +127,7 @@ describe("project board filters", () => {
       displayId: "ZMX-2",
       estimate: null,
       id: "medium-none",
-      labels: ["ghostex", "vault"],
+      labels: ["backend", "docs"],
       priority: 2,
       status: "in_progress",
       title: "Medium unestimated task",
@@ -163,17 +163,17 @@ describe("project board filters", () => {
      * labels are simply not in that set rather than being treated as a selectable state of their
      * own, because an untagged bead is untriaged rather than a kind of work.
      */
-    expect(filterBoardTickets(tickets, "", "all", "all", "vault").map((ticket) => ticket.id)).toEqual([
+    expect(filterBoardTickets(tickets, "", "all", "all", "docs").map((ticket) => ticket.id)).toEqual([
       "urgent-xs",
       "medium-none",
     ]);
-    expect(filterBoardTickets(tickets, "", "all", "all", "ghostex").map((ticket) => ticket.id)).toEqual([
+    expect(filterBoardTickets(tickets, "", "all", "all", "backend").map((ticket) => ticket.id)).toEqual([
       "medium-none",
     ]);
-    expect(filterBoardTickets(tickets, "", "0", "all", "vault").map((ticket) => ticket.id)).toEqual([
+    expect(filterBoardTickets(tickets, "", "0", "all", "docs").map((ticket) => ticket.id)).toEqual([
       "urgent-xs",
     ]);
-    expect(filterBoardTickets(tickets, "", "0", "all", "ghostex")).toEqual([]);
+    expect(filterBoardTickets(tickets, "", "0", "all", "backend")).toEqual([]);
     expect(filterBoardTickets(tickets, "", "all", "all", "all").map((ticket) => ticket.id)).toEqual([
       "urgent-xs",
       "medium-none",
@@ -182,7 +182,7 @@ describe("project board filters", () => {
   });
 
   test("offers the loaded tickets' own labels, sorted, with all first", () => {
-    expect(boardTagFilterOptions(tickets)).toEqual(["all", "ghostex", "needs:sven", "vault"]);
+    expect(boardTagFilterOptions(tickets)).toEqual(["all", "backend", "docs", "needs:review"]);
     expect(boardTagFilterOptions([])).toEqual(["all"]);
   });
 
@@ -192,9 +192,9 @@ describe("project board filters", () => {
      * A stored tag outlives the board that produced it, so opening a project that never used it
      * must show the whole board rather than an empty one under a tag nothing carries.
      */
-    expect(resolveBoardTagFilter("hermes", boardTagFilterOptions(tickets))).toBe("all");
-    expect(resolveBoardTagFilter("vault", boardTagFilterOptions(tickets))).toBe("vault");
-    expect(resolveBoardTagFilter("vault", boardTagFilterOptions([]))).toBe("all");
+    expect(resolveBoardTagFilter("frontend", boardTagFilterOptions(tickets))).toBe("all");
+    expect(resolveBoardTagFilter("docs", boardTagFilterOptions(tickets))).toBe("docs");
+    expect(resolveBoardTagFilter("docs", boardTagFilterOptions([]))).toBe("all");
   });
 });
 
@@ -504,13 +504,13 @@ describe("project board view preferences", () => {
         estimateFilter: "M",
         priorityFilter: "1",
         sortOption: "created-asc",
-        tagFilter: "vault",
+        tagFilter: "docs",
       }),
     ).toEqual({
       estimateFilter: "M",
       priorityFilter: "1",
       sortOption: "created-asc",
-      tagFilter: "vault",
+      tagFilter: "docs",
     });
     expect(normalizeProjectBoardViewPreferences({ estimateFilter: "none" }).estimateFilter).toBe(
       "none",
@@ -546,12 +546,12 @@ describe("project board view preferences", () => {
      * selection instead of the first tagless project erasing it. resolveBoardTagFilter is what
      * lands an unavailable tag on "all" once a board has actually loaded.
      */
-    expect(normalizeProjectBoardViewPreferences({ tagFilter: "vault" }).tagFilter).toBe("vault");
+    expect(normalizeProjectBoardViewPreferences({ tagFilter: "docs" }).tagFilter).toBe("docs");
     expect(normalizeProjectBoardViewPreferences({ tagFilter: "retired-lane-tag" }).tagFilter).toBe(
       "retired-lane-tag",
     );
     expect(normalizeProjectBoardViewPreferences({ tagFilter: "   " }).tagFilter).toBe("all");
-    expect(normalizeProjectBoardViewPreferences({ tagFilter: ["vault"] }).tagFilter).toBe("all");
+    expect(normalizeProjectBoardViewPreferences({ tagFilter: ["docs"] }).tagFilter).toBe("all");
   });
 
   test("keeps every offered toolbar option restorable", () => {

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -166,6 +166,7 @@ export const TSHIRT_OPTIONS = [
 export type TshirtSize = (typeof TSHIRT_OPTIONS)[number]["label"];
 export type BoardPriorityFilter = "all" | (typeof PRIORITY_OPTIONS)[number]["value"];
 export type BoardEstimateFilter = "all" | "none" | TshirtSize;
+export type BoardTagFilter = string;
 export type BoardSortDirection = "asc" | "desc";
 export type BoardSortKey = "created" | "priority" | "updated";
 export type BoardSortOption = "default" | `${BoardSortKey}-${BoardSortDirection}`;
@@ -189,6 +190,7 @@ export type ProjectBoardViewPreferences = {
   estimateFilter: BoardEstimateFilter;
   priorityFilter: BoardPriorityFilter;
   sortOption: BoardSortOption;
+  tagFilter: BoardTagFilter;
 };
 
 /*
@@ -196,11 +198,17 @@ export type ProjectBoardViewPreferences = {
   The Kanban is its own web surface, so leaving the board tears it down and every toolbar selection dies with it. Priority, estimate, and sort are durable view settings and are restored on the next mount; ticket search stays ephemeral because a restored query would hide most of the board without an obvious cause.
   The three selections describe how the user wants to read a board rather than anything about a particular project, so one app-wide set follows them into every project instead of each board keeping its own.
   Stored values outlive the option lists that produced them, so a preference that no longer matches a current option falls back to its default instead of leaving the toolbar showing a value the board cannot filter or sort by.
+
+  CDXC:ProjectBoardTagFilter 2026-08-21:
+  Tags are the only ticket metadata the board could write but never read back, so a board of mixed work had to be scrolled rather than narrowed. The tag selection joins the other three under the same storage key and the same app-wide scope.
+  Unlike priority, estimate, and sort, the tag options are not a fixed list: they are the labels the loaded tickets actually carry, so validity is only knowable once a board has loaded. Normalisation therefore only rejects values that could never be a tag, and a stored tag that the loaded board does not offer is resolved to "all" at read time by resolveBoardTagFilter rather than being written over, so returning to the board that has the tag restores the selection.
+  The tag filter only ever includes: there is no hide-by-tag mode, because a board silently omitting cards the user never asked to hide is the failure this control exists to fix.
 */
 export const DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES: ProjectBoardViewPreferences = {
   estimateFilter: "all",
   priorityFilter: "all",
   sortOption: "default",
+  tagFilter: "all",
 };
 
 export const PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY = "ghostex-project-board-view";
@@ -622,6 +630,10 @@ export function normalizeProjectBoardViewPreferences(
       BOARD_SORT_OPTION_VALUES,
       DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES.sortOption,
     ),
+    tagFilter:
+      typeof stored.tagFilter === "string" && stored.tagFilter.trim().length > 0
+        ? stored.tagFilter
+        : DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES.tagFilter,
   };
 }
 
@@ -661,11 +673,33 @@ export async function ensureWorkflowStatuses(
   }
 }
 
+/*
+  CDXC:ProjectBoardTagFilter 2026-08-21:
+  The tag dropdown offers the labels the loaded tickets actually carry rather than every label the project has ever defined, so selecting one can never produce an empty board and the list shrinks as retired tags stop being used.
+*/
+export function boardTagFilterOptions(tickets: BoardTicket[]): BoardTagFilter[] {
+  const tags = new Set<string>();
+  for (const ticket of tickets) {
+    for (const label of ticket.labels ?? []) {
+      tags.add(label);
+    }
+  }
+  return ["all", ...Array.from(tags).sort((left, right) => left.localeCompare(right))];
+}
+
+export function resolveBoardTagFilter(
+  tagFilter: BoardTagFilter,
+  options: ReadonlyArray<BoardTagFilter>,
+): BoardTagFilter {
+  return options.includes(tagFilter) ? tagFilter : DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES.tagFilter;
+}
+
 export function filterBoardTickets(
   tickets: BoardTicket[],
   query: string,
   priorityFilter: BoardPriorityFilter,
   estimateFilter: BoardEstimateFilter,
+  tagFilter: BoardTagFilter,
 ): BoardTicket[] {
   const normalizedQuery = query.trim();
   /*
@@ -684,6 +718,10 @@ export function filterBoardTickets(
           const ticketEstimate = estimateToTshirt(ticket.estimate);
           return estimateFilter === "none" ? ticketEstimate === undefined : ticketEstimate === estimateFilter;
         });
+  filtered =
+    tagFilter === "all"
+      ? filtered
+      : filtered.filter((ticket) => ticket.labels?.includes(tagFilter) ?? false);
   if (!normalizedQuery) {
     return filtered;
   }

--- a/native/sidebar/tasks-placeholder-source.test.ts
+++ b/native/sidebar/tasks-placeholder-source.test.ts
@@ -400,7 +400,7 @@ describe("Project Board form event handling", () => {
     /*
      * CDXC:ProjectBoardViewPreferences 2026-08-07:
      * Switching away from the Kanban tab unmounts the board surface, so the toolbar must seed its
-     * priority, estimate, and sort state from the stored preferences and write every later
+     * priority, estimate, sort, and tag state from the stored preferences and write every later
      * selection back. The key and the write are project-independent so the selections follow the
      * user into every board. Search stays out of that payload.
      */
@@ -423,10 +423,11 @@ describe("Project Board form event handling", () => {
       "useState<BoardEstimateFilter>(\n    storedViewPreferences.estimateFilter,\n  );",
     );
     expect(projectBoardSource).toContain("useState<BoardSortOption>(storedViewPreferences.sortOption);");
+    expect(projectBoardSource).toContain("useState<BoardTagFilter>(storedViewPreferences.tagFilter);");
     expect(projectBoardSource).toContain(
-      "try {\n      window.localStorage.setItem(\n        PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,\n        JSON.stringify({ estimateFilter, priorityFilter, sortOption }),\n      );\n    } catch {",
+      "try {\n      window.localStorage.setItem(\n        PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,\n        JSON.stringify({ estimateFilter, priorityFilter, sortOption, tagFilter }),\n      );\n    } catch {",
     );
-    expect(projectBoardSource).toContain("}, [estimateFilter, priorityFilter, sortOption]);");
+    expect(projectBoardSource).toContain("}, [estimateFilter, priorityFilter, sortOption, tagFilter]);");
     expect(projectBoardSource).not.toContain("JSON.stringify({ estimateFilter, priorityFilter, searchQuery");
     expect(projectBoardSource).toContain('const [searchQuery, setSearchQuery] = useState("");');
   });

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -2882,22 +2882,18 @@ function ProjectBoardApp() {
               ))}
             </SelectContent>
           </Select>
-          <Select
-            items={tagFilterSelectItems}
-            onValueChange={(value) => setTagFilter(value as BoardTagFilter)}
+          <select
+            aria-label="Filter by tag"
+            className="project-board-filter-select project-board-native-filter-select"
+            onChange={(event) => setTagFilter(event.currentTarget.value as BoardTagFilter)}
             value={activeTagFilter}
           >
-            <SelectTrigger aria-label="Filter by tag" className="project-board-filter-select" size="sm">
-              <SelectValue placeholder="All tags" />
-            </SelectTrigger>
-            <SelectContent>
-              {tagFilterSelectItems.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            {tagFilterSelectItems.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
           <select
             aria-label="Sort tickets"
             className="project-board-filter-select project-board-native-filter-select"

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -85,6 +85,7 @@ import {
   beadsStatusToBoardStatus,
   boardStatusBeadsValue,
   boardStatusLabel,
+  boardTagFilterOptions,
   buildAgentWorkPrompt,
   conversationLinkActionKind,
   conversationLinkLabel,
@@ -111,6 +112,7 @@ import {
   projectBoardRawProjectIdFromUrlParam,
   removeDescriptionImageReference,
   resolveAssignedAgentId,
+  resolveBoardTagFilter,
   isDescriptionImageSource,
   sortBoardTickets,
   ticketCreatorName,
@@ -122,6 +124,7 @@ import {
   type BoardEstimateFilter,
   type BoardPriorityFilter,
   type BoardSortOption,
+  type BoardTagFilter,
   type ProjectBoardCommentMetadata,
   type ProjectBoardViewPreferences,
   type BeadsIssue,
@@ -641,6 +644,7 @@ function ProjectBoardApp() {
   const [estimateFilter, setEstimateFilter] = useState<BoardEstimateFilter>(
     storedViewPreferences.estimateFilter,
   );
+  const [tagFilter, setTagFilter] = useState<BoardTagFilter>(storedViewPreferences.tagFilter);
   const [sortOption, setSortOption] = useState<BoardSortOption>(storedViewPreferences.sortOption);
   const [detail, setDetail] = useState<DetailDraft>(createEmptyDetailDraft);
   const [newTicketOpen, setNewTicketOpen] = useState(false);
@@ -892,12 +896,12 @@ function ProjectBoardApp() {
     try {
       window.localStorage.setItem(
         PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,
-        JSON.stringify({ estimateFilter, priorityFilter, sortOption }),
+        JSON.stringify({ estimateFilter, priorityFilter, sortOption, tagFilter }),
       );
     } catch {
       // Keep the current in-memory preferences when localStorage is unavailable.
     }
-  }, [estimateFilter, priorityFilter, sortOption]);
+  }, [estimateFilter, priorityFilter, sortOption, tagFilter]);
 
   const openNewTicket = useCallback((status: BoardStatusKey = "todo") => {
     setNewTicket((current) => ({ ...current, status }));
@@ -1400,9 +1404,25 @@ function ProjectBoardApp() {
     };
   }, [activeSurfaceTab, experimentalFeaturesEnabled, loadAutomationState, loadConversationState, loadTickets]);
 
+  const tagFilterSelectItems = useMemo(
+    () =>
+      boardTagFilterOptions(tickets).map((tag) => ({
+        label: tag === "all" ? "All tags" : tag,
+        value: tag,
+      })),
+    [tickets],
+  );
+  const activeTagFilter = useMemo(
+    () =>
+      resolveBoardTagFilter(
+        tagFilter,
+        tagFilterSelectItems.map((item) => item.value),
+      ),
+    [tagFilter, tagFilterSelectItems],
+  );
   const filteredTickets = useMemo(
-    () => filterBoardTickets(tickets, searchQuery, priorityFilter, estimateFilter),
-    [estimateFilter, priorityFilter, searchQuery, tickets],
+    () => filterBoardTickets(tickets, searchQuery, priorityFilter, estimateFilter, activeTagFilter),
+    [activeTagFilter, estimateFilter, priorityFilter, searchQuery, tickets],
   );
 
   const ticketsByColumn = useMemo(() => {
@@ -2856,6 +2876,22 @@ function ProjectBoardApp() {
             </SelectTrigger>
             <SelectContent>
               {PROJECT_BOARD_ESTIMATE_FILTER_SELECT_ITEMS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            items={tagFilterSelectItems}
+            onValueChange={(value) => setTagFilter(value as BoardTagFilter)}
+            value={activeTagFilter}
+          >
+            <SelectTrigger aria-label="Filter by tag" className="project-board-filter-select" size="sm">
+              <SelectValue placeholder="All tags" />
+            </SelectTrigger>
+            <SelectContent>
+              {tagFilterSelectItems.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}
                 </SelectItem>


### PR DESCRIPTION
## What

Adds a **Tag** dropdown to the project board toolbar, next to Priority and Estimate.

Tags were write-only before this: the board could carry labels but had no way to filter by them, so a board with many cards could only be narrowed by priority, estimate, or free-text search.

## Behaviour

- Options are derived from the labels present on the loaded tickets, sorted, with `All tags` first. No server change — `labels` already reaches the client on `BoardTicket`.
- The selection persists alongside the existing filters under the same `ghostex-project-board-view` storage key.
- A stored tag that no longer exists on any card resolves back to `all` at render time rather than showing an empty board.
- Include-only. No hide-by-tag / exclude mode, per the existing design note in `project-board-shared.ts` arguing against silent hiding.

## Notes

- `filterBoardTickets` gains a fifth parameter (the fourth filter). Required, not optional, so no caller silently keeps old behaviour.
- `tasks-placeholder-source.test.ts` asserts on the literal source text of the persistence effect, so its assertions were updated to match the new payload. No assertion was loosened.

## Testing

- `bun run typecheck` — clean
- `bunx vitest run native/sidebar/` — 42 files, all passing
- Built and exercised in the running app: the dropdown filters all lanes and the selection survives leaving and re-entering the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag filtering to the project board.
  * Added an “All tags” selector with sorted tag options.
  * Tag filtering works alongside search, priority, and estimate filters.
  * Selected tag preferences are saved and restored between sessions.
  * Tag selections remain available as tickets and board data are loaded.

* **Bug Fixes**
  * Invalid or unavailable saved tag selections now safely reset to “All tags.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->