### PR TITLE
Kanban: draw the board's own custom bd statuses as columns

### DIFF
--- a/gxserver-rs/src/typed_operations.rs
+++ b/gxserver-rs/src/typed_operations.rs
@@ -2177,12 +2177,23 @@ fn normalize_issue_id(input: Option<&Value>) -> Result<String, TypedOperationErr
     ))
 }
 
+/*
+CDXC:ProjectBoardCustomColumns 2026-08-21:
+Beads owns the set of valid statuses: a board can define its own through
+`bd config set status.custom`, so a fixed list here was rejecting real statuses
+before bd ever saw them and made custom board columns undraggable. Validate the
+shape only and let bd be the authority on which statuses exist — it already
+returns a clear error for a name it does not know, and args are passed to the
+process without a shell, so this is a well-formedness check, not a safety gate.
+*/
 fn normalize_beads_status(input: Option<&Value>) -> Result<String, TypedOperationError> {
     let status = normalize_required_text(input, "status")?;
-    if matches!(
-        status.as_str(),
-        "backlog" | "closed" | "in_progress" | "open" | "review" | "test"
-    ) {
+    if status.len() <= 64
+        && status.chars().enumerate().all(|(index, ch)| {
+            (index == 0 && ch.is_ascii_alphabetic())
+                || (index > 0 && (ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')))
+        })
+    {
         Ok(status)
     } else {
         Err(TypedOperationError::bad_request(format!(

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "vitest";
 import {
   appendImageMarkdownToDescription,
-  BOARD_COLUMNS,
   BOARD_SORT_OPTIONS,
   beadsStatusToBoardStatus,
   boardStatusBeadsValue,
+  boardStatusLabel,
   buildAgentWorkPrompt,
+  buildBoardColumns,
   DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   extractDescriptionImagePreviews,
   extractDescriptionImageReferences,
@@ -428,8 +429,10 @@ describe("project board comment metadata", () => {
 });
 
 describe("project board statuses", () => {
+  const builtinColumns = buildBoardColumns("");
+
   test("places Backlog before Todo and persists it as a Beads custom status", () => {
-    expect(BOARD_COLUMNS.map((column) => column.key)).toEqual([
+    expect(builtinColumns.map((column) => column.key)).toEqual([
       "backlog",
       "todo",
       "in_progress",
@@ -437,8 +440,42 @@ describe("project board statuses", () => {
       "review",
       "done",
     ]);
-    expect(beadsStatusToBoardStatus("backlog")).toBe("backlog");
-    expect(boardStatusBeadsValue("backlog")).toBe("backlog");
+    expect(beadsStatusToBoardStatus("backlog", builtinColumns)).toBe("backlog");
+    expect(boardStatusBeadsValue("backlog", builtinColumns)).toBe("backlog");
+  });
+
+  test("adds the board's own extra statuses as columns after the built-in lanes", () => {
+    const columns = buildBoardColumns("backlog,review,test,needs_input:wip");
+
+    expect(columns.map((column) => column.key)).toEqual([
+      "backlog",
+      "todo",
+      "in_progress",
+      "test",
+      "review",
+      "done",
+      "needs_input",
+    ]);
+    expect(columns[columns.length - 1]).toEqual({
+      key: "needs_input",
+      label: "Needs Input",
+      beadsStatus: "needs_input",
+      tone: "muted",
+    });
+  });
+
+  test("shows a bead parked in an extra status in that status's own lane", () => {
+    const columns = buildBoardColumns("backlog,review,test,needs_input:wip");
+
+    expect(beadsStatusToBoardStatus("needs_input", columns)).toBe("needs_input");
+    expect(boardStatusLabel("needs_input", columns)).toBe("Needs Input");
+    expect(boardStatusBeadsValue("needs_input", columns)).toBe("needs_input");
+  });
+
+  test("keeps a bead whose status has no lane visible in Todo", () => {
+    expect(beadsStatusToBoardStatus("needs_input", builtinColumns)).toBe("todo");
+    expect(boardStatusLabel("needs_input", builtinColumns)).toBe("Todo");
+    expect(boardStatusBeadsValue("needs_input", builtinColumns)).toBe("open");
   });
 });
 

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -7,7 +7,17 @@ import type { ProjectBoardConversationLinkView } from "../../shared/bead-convers
   Shared Beads board helpers keep display-id formatting, t-shirt estimate mapping, and filter logic consistent between the Project WKWebView surface and future Storybook coverage.
 */
 
-export type BoardStatusKey = "backlog" | "todo" | "in_progress" | "test" | "review" | "done";
+export type BoardBuiltinStatusKey = "backlog" | "todo" | "in_progress" | "test" | "review" | "done";
+
+/*
+  CDXC:ProjectBoardCustomColumns 2026-08-21:
+  A board's lanes are whatever statuses bd is configured with, not a fixed six, so a bead parked in
+  a project's own status (for example needs_input) is drawn where it actually is instead of being
+  folded into Todo and read as fresh work.
+  An extra lane's key is the raw bd status name, so BoardStatusKey stays open to any string while
+  still offering the six built-in keys for completion.
+*/
+export type BoardStatusKey = BoardBuiltinStatusKey | (string & {});
 
 export type BeadsComment = {
   author?: string;
@@ -125,12 +135,14 @@ export type BeadsBridgeResponse = {
   stdout: string;
 };
 
-export const BOARD_COLUMNS: Array<{
+export type BoardColumn = {
   key: BoardStatusKey;
   label: string;
   beadsStatus: string;
   tone: string;
-}> = [
+};
+
+const BUILTIN_BOARD_COLUMNS: ReadonlyArray<BoardColumn> = [
   /*
     CDXC:ProjectBoard 2026-05-30-08:58:
     The Kanban Project view needs a Backlog swim lane positioned before Todo, persisted as the Beads custom status `backlog` so drag/drop, edit-status selects, and reloads all share the same workflow state.
@@ -143,6 +155,43 @@ export const BOARD_COLUMNS: Array<{
   { key: "review", label: "Review", beadsStatus: "review", tone: "violet" },
   { key: "done", label: "Done", beadsStatus: "closed", tone: "green" },
 ];
+
+const BUILTIN_BOARD_STATUS_NAMES = new Set(
+  BUILTIN_BOARD_COLUMNS.flatMap((column) => [column.key, column.beadsStatus]),
+);
+
+/*
+  CDXC:ProjectBoardCustomColumns 2026-08-21:
+  Columns are derived from the board's `status.custom` config (the same comma list ensureWorkflowStatuses reconciles, entries optionally suffixed with `:<bd category>`) rather than being a constant, so every surface that renders, drags, or edits a status works from the lanes the board actually has.
+  The six built-in lanes always come first and unchanged; each additional configured status becomes one muted lane whose key and Beads value are the raw status name, so no mapping table has to be kept in sync with a user's board.
+  Creating, renaming, and reordering columns stays a bd concern: this only draws what bd already knows.
+*/
+export function buildBoardColumns(customStatusConfig: string): BoardColumn[] {
+  const extraColumns: BoardColumn[] = [];
+  const seenNames = new Set<string>();
+  for (const entry of customStatusConfig.split(",")) {
+    const name = entry.split(":")[0].trim();
+    if (!name || BUILTIN_BOARD_STATUS_NAMES.has(name) || seenNames.has(name)) {
+      continue;
+    }
+    seenNames.add(name);
+    extraColumns.push({
+      key: name,
+      label: boardStatusNameToLabel(name),
+      beadsStatus: name,
+      tone: "muted",
+    });
+  }
+  return [...BUILTIN_BOARD_COLUMNS, ...extraColumns];
+}
+
+function boardStatusNameToLabel(name: string): string {
+  return name
+    .split(/[\s_-]+/u)
+    .filter(Boolean)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}
 
 export const PRIORITY_OPTIONS = [
   /*
@@ -222,29 +271,29 @@ const PROJECT_BOARD_COMMENT_METADATA_SEPARATOR = "---";
 const PROJECT_BOARD_COMMENT_AGENT_PREFIX = "Agent:";
 const PROJECT_BOARD_COMMENT_SESSION_PREFIX = "Session:";
 
-export function beadsStatusToBoardStatus(status: string): BoardStatusKey {
-  switch (status) {
-    case "backlog":
-      return "backlog";
-    case "closed":
-      return "done";
-    case "in_progress":
-      return "in_progress";
-    case "review":
-      return "review";
-    case "test":
-      return "test";
-    default:
-      return "todo";
-  }
+/*
+  CDXC:ProjectBoardCustomColumns 2026-08-21:
+  Status resolution reads the caller's column list instead of a fixed table so a bead sitting in one of the board's own statuses lands in that lane. Todo remains the home for a status with no lane at all — a bead whose status was removed from the board config still has to be visible somewhere.
+*/
+export function beadsStatusToBoardStatus(
+  status: string,
+  columns: ReadonlyArray<BoardColumn>,
+): BoardStatusKey {
+  return columns.find((column) => column.beadsStatus === status)?.key ?? "todo";
 }
 
-export function boardStatusLabel(status: BoardStatusKey): string {
-  return BOARD_COLUMNS.find((column) => column.key === status)?.label ?? "Todo";
+export function boardStatusLabel(
+  status: BoardStatusKey,
+  columns: ReadonlyArray<BoardColumn>,
+): string {
+  return columns.find((column) => column.key === status)?.label ?? "Todo";
 }
 
-export function boardStatusBeadsValue(status: BoardStatusKey): string {
-  return BOARD_COLUMNS.find((column) => column.key === status)?.beadsStatus ?? "open";
+export function boardStatusBeadsValue(
+  status: BoardStatusKey,
+  columns: ReadonlyArray<BoardColumn>,
+): string {
+  return columns.find((column) => column.key === status)?.beadsStatus ?? "open";
 }
 
 export function normalizeIssuePrefix(value: string | undefined): string {
@@ -319,13 +368,14 @@ export function formatTicketDisplayId(
 export function toBoardTickets(
   issues: BeadsIssue[],
   displayKey: string,
+  columns: ReadonlyArray<BoardColumn>,
 ): BoardTicket[] {
   const serialByIssueId = buildDisplayIdMap(issues);
   return issues
     .filter((issue) => issue && typeof issue.id === "string")
     .map((issue) => ({
       ...issue,
-      boardStatus: beadsStatusToBoardStatus(issue.status),
+      boardStatus: beadsStatusToBoardStatus(issue.status, columns),
       displayId: formatTicketDisplayId(issue, displayKey, serialByIssueId),
     }));
 }
@@ -633,9 +683,13 @@ function normalizeBoardViewPreference<TValue extends string>(
   return allowedValues.includes(candidate as TValue) ? (candidate as TValue) : fallback;
 }
 
+/*
+  CDXC:ProjectBoardCustomColumns 2026-08-21:
+  Reconciliation already holds the board's full status list, extra statuses included, so it returns that list for buildBoardColumns instead of making the board read the same config a second time.
+*/
 export async function ensureWorkflowStatuses(
   runBeads: (request: Omit<BeadsBridgeRequest, "cwd" | "requestId">) => Promise<unknown>,
-): Promise<void> {
+): Promise<string> {
   const payload = await runBeads({ action: "configGet" });
   const currentValue = normalizeBeadsPayload<{ value?: string }>(payload, {}).value ?? "";
   const requiredEntries = REQUIRED_CUSTOM_STATUS_CONFIG.split(",");
@@ -659,6 +713,7 @@ export async function ensureWorkflowStatuses(
   if (nextValue !== currentValue) {
     await runBeads({ action: "configSet", value: nextValue });
   }
+  return nextValue;
 }
 
 export function filterBoardTickets(

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -685,13 +685,21 @@ function normalizeBoardViewPreference<TValue extends string>(
 
 /*
   CDXC:ProjectBoardCustomColumns 2026-08-21:
-  Reconciliation already holds the board's full status list, extra statuses included, so it returns that list for buildBoardColumns instead of making the board read the same config a second time.
+  Status reads return the board's full list, extra statuses included, for buildBoardColumns.
+  Background refreshes use this read-only helper so polling cannot overwrite a concurrent config edit;
+  initial and manual loads call ensureWorkflowStatuses to reconcile Ghostex's required lanes.
 */
-export async function ensureWorkflowStatuses(
+export async function readWorkflowStatuses(
   runBeads: (request: Omit<BeadsBridgeRequest, "cwd" | "requestId">) => Promise<unknown>,
 ): Promise<string> {
   const payload = await runBeads({ action: "configGet" });
-  const currentValue = normalizeBeadsPayload<{ value?: string }>(payload, {}).value ?? "";
+  return normalizeBeadsPayload<{ value?: string }>(payload, {}).value ?? "";
+}
+
+export async function ensureWorkflowStatuses(
+  runBeads: (request: Omit<BeadsBridgeRequest, "cwd" | "requestId">) => Promise<unknown>,
+): Promise<string> {
+  const currentValue = await readWorkflowStatuses(runBeads);
   const requiredEntries = REQUIRED_CUSTOM_STATUS_CONFIG.split(",");
   const requiredNames = new Set(requiredEntries.map((entry) => entry.split(":")[0]));
   const currentEntries = currentValue

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -74,7 +74,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  BOARD_COLUMNS,
   BOARD_SORT_OPTIONS,
   DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   PRIORITY_OPTIONS,
@@ -86,6 +85,7 @@ import {
   boardStatusBeadsValue,
   boardStatusLabel,
   buildAgentWorkPrompt,
+  buildBoardColumns,
   conversationLinkActionKind,
   conversationLinkLabel,
   conversationLinkStatusText,
@@ -119,6 +119,7 @@ import {
   estimateToTshirt,
   type BeadsBridgeRequest,
   type BeadsBridgeResponse,
+  type BoardColumn,
   type BoardEstimateFilter,
   type BoardPriorityFilter,
   type BoardSortOption,
@@ -294,10 +295,6 @@ const PROJECT_BOARD_START_LOCATION_SELECT_ITEMS: ReadonlyArray<{
   { label: "Current project", value: "currentProject" },
   { label: "New worktree", value: "newWorktree" },
 ];
-const PROJECT_BOARD_STATUS_SELECT_ITEMS = BOARD_COLUMNS.map((column) => ({
-  label: column.label,
-  value: column.key,
-}));
 const PROJECT_BOARD_PRIORITY_SELECT_ITEMS = PRIORITY_OPTIONS.map((option) => ({
   label: option.label,
   value: option.value,
@@ -543,6 +540,10 @@ function createProjectBoardDraftTitle(prompt: string): string {
     .trim() || "New ticket";
 }
 
+function boardColumnsSignature(columns: ReadonlyArray<BoardColumn>): string {
+  return columns.map((column) => column.key).join("\u001f");
+}
+
 function applyPendingBoardStatusMoves(
   issues: BeadsIssue[],
   pendingMoves: Map<string, PendingBoardStatusMove>,
@@ -617,6 +618,16 @@ function ProjectBoardApp() {
   const issuePrefix = normalizeIssuePrefix(
     projectName || projectPath.split("/").filter(Boolean).at(-1) || displayKey,
   );
+  /*
+   * CDXC:ProjectBoardCustomColumns 2026-08-21:
+   * Lanes are the board's own bd statuses, which are only known once ensureWorkflowStatuses has read
+   * the config, so the board opens on the six built-in lanes and adopts the extras on the first load.
+   * The columns are mirrored into a ref because the refresh callback maps issue statuses onto them:
+   * reading them from state instead would rebuild loadTickets, and with it restart the auto-refresh
+   * interval, every time a refresh produced a fresh columns array.
+   */
+  const boardColumnsRef = useRef<BoardColumn[]>(buildBoardColumns(""));
+  const [boardColumns, setBoardColumns] = useState<BoardColumn[]>(boardColumnsRef.current);
   const [tickets, setTickets] = useState<BoardTicket[]>([]);
   const [allIssues, setAllIssues] = useState<BeadsIssue[]>([]);
   const [knownLabels, setKnownLabels] = useState<string[]>([]);
@@ -1118,7 +1129,7 @@ function ProjectBoardApp() {
     (issue: BeadsIssue) => {
       setAllIssues((current) => upsertProjectBoardIssue(current, issue));
       setTickets((current) => {
-        const localTicket = toCreatedBoardTicket(issue, current, displayKey);
+        const localTicket = toCreatedBoardTicket(issue, current, displayKey, boardColumns);
         return localTicket ? upsertProjectBoardTicket(current, localTicket) : current;
       });
       setDetail((current) =>
@@ -1129,20 +1140,20 @@ function ProjectBoardApp() {
               labels: issue.labels ?? current.labels,
               priority:
                 issue.priority === undefined ? current.priority : prioritySelectValue(issue.priority),
-              status: beadsStatusToBoardStatus(issue.status),
+              status: beadsStatusToBoardStatus(issue.status, boardColumns),
               title: issue.title,
               tshirt: estimateToTshirt(issue.estimate),
               ticket: {
                 ...current.ticket,
                 ...issue,
-                boardStatus: beadsStatusToBoardStatus(issue.status),
+                boardStatus: beadsStatusToBoardStatus(issue.status, boardColumns),
                 displayId: current.ticket.displayId,
               },
             }
           : current,
       );
     },
-    [displayKey],
+    [boardColumns, displayKey],
   );
 
   const setLocalTicketTitle = useCallback((ticketId: string, title: string) => {
@@ -1175,16 +1186,27 @@ function ProjectBoardApp() {
     try {
       if (mode === "initial" || mode === "manual") {
         await ensureIssuePrefix(runBeads, issuePrefix);
-        await ensureWorkflowStatuses(runBeads);
+        const nextColumns = buildBoardColumns(await ensureWorkflowStatuses(runBeads));
+        if (boardColumnsSignature(nextColumns) !== boardColumnsSignature(boardColumnsRef.current)) {
+          boardColumnsRef.current = nextColumns;
+          setBoardColumns(nextColumns);
+        }
       }
       const payload = await runBeads({ action: "listIssues" });
       const rawIssues = normalizeBeadsPayload<BeadsIssue[]>(payload, Array.isArray(payload) ? payload : []);
       const issues = applyPendingBoardStatusMoves(rawIssues, pendingStatusMovesRef.current);
-      const issuesSignature = `${displayKey}:${createIssuesSignature(issues)}`;
+      /*
+       * CDXC:ProjectBoardCustomColumns 2026-08-21:
+       * The lane a bead belongs to is resolved against the column list, so the signature carries the
+       * columns too. A status added to the board config while beads already sit in it changes no
+       * issue, and remapping only on an issue change would leave the new lane empty and those beads
+       * drawn in Todo until something unrelated moved.
+       */
+      const issuesSignature = `${displayKey}:${boardColumnsSignature(boardColumnsRef.current)}:${createIssuesSignature(issues)}`;
       if (issuesSignature !== issuesSignatureRef.current) {
         issuesSignatureRef.current = issuesSignature;
         setAllIssues(issues);
-        setTickets(toBoardTickets(issues, displayKey));
+        setTickets(toBoardTickets(issues, displayKey, boardColumnsRef.current));
       }
       const labels = deriveKnownLabelsFromIssues(issues);
       const labelsSignature = labels.join("\u001f");
@@ -1406,7 +1428,7 @@ function ProjectBoardApp() {
   );
 
   const ticketsByColumn = useMemo(() => {
-    return BOARD_COLUMNS.reduce<Record<BoardStatusKey, BoardTicket[]>>(
+    return boardColumns.reduce<Record<string, BoardTicket[]>>(
       (result, column) => {
         result[column.key] = sortBoardTickets(
           filteredTickets.filter((ticket) => ticket.boardStatus === column.key),
@@ -1415,9 +1437,9 @@ function ProjectBoardApp() {
         );
         return result;
       },
-      { backlog: [], done: [], in_progress: [], review: [], test: [], todo: [] },
+      {},
     );
-  }, [filteredTickets, sortOption]);
+  }, [boardColumns, filteredTickets, sortOption]);
   const showInitialBoardLoadingOverlay =
     activeSurfaceTab === "board" && loadState === "loading" && !hasCompletedInitialBoardLoad;
 
@@ -1464,7 +1486,7 @@ function ProjectBoardApp() {
         ...ticket,
         ...issue,
         ...mergedIssue,
-        boardStatus: beadsStatusToBoardStatus(issue.status ?? ticket.status),
+        boardStatus: beadsStatusToBoardStatus(issue.status ?? ticket.status, boardColumns),
         displayId: ticket.displayId,
       };
       setDetail({
@@ -1487,7 +1509,7 @@ function ProjectBoardApp() {
   };
 
   const moveTicket = async (ticketId: string, statusKey: BoardStatusKey) => {
-    const column = BOARD_COLUMNS.find((candidate) => candidate.key === statusKey);
+    const column = boardColumns.find((candidate) => candidate.key === statusKey);
     const ticket = tickets.find((candidate) => candidate.id === ticketId);
     if (!column || !ticket || ticket.boardStatus === statusKey) {
       return;
@@ -1689,7 +1711,7 @@ function ProjectBoardApp() {
             dependency.depends_on_id === parentId && dependency.type === "parent-child",
         ),
       )
-      .filter((issue) => beadsStatusToBoardStatus(issue.status) !== "done")
+      .filter((issue) => beadsStatusToBoardStatus(issue.status, boardColumns) !== "done")
       .map((issue) => issue.id);
   }
 
@@ -1759,7 +1781,7 @@ function ProjectBoardApp() {
       await runBeads({
         action: "updateStatus",
         issueId: draft.ticket.id,
-        status: boardStatusBeadsValue(draft.status),
+        status: boardStatusBeadsValue(draft.status, boardColumns),
       });
     }
     if (trimmedComment) {
@@ -1799,7 +1821,7 @@ function ProjectBoardApp() {
       ...(estimate !== undefined ? { estimate } : {}),
       labels: draft.labels.length > 0 ? draft.labels : draft.ticket.labels,
       priority: Number.isFinite(parsedPriority) ? parsedPriority : draft.ticket.priority,
-      status: boardStatusBeadsValue(draft.status),
+      status: boardStatusBeadsValue(draft.status, boardColumns),
       title: draft.title.trim(),
     };
     setDeleteConfirmingTicketId("");
@@ -1971,7 +1993,7 @@ function ProjectBoardApp() {
         throw new Error("Created ticket was not found after create.");
       }
 
-      const targetBeadsStatus = boardStatusBeadsValue(draft.status);
+      const targetBeadsStatus = boardStatusBeadsValue(draft.status, boardColumns);
       const parsedPriority = Number.parseInt(draft.priority, 10);
       let pendingCreateStatusToken: number | undefined;
       if (!startAfterCreate && draft.status !== "todo") {
@@ -1996,7 +2018,7 @@ function ProjectBoardApp() {
       setKnownLabels((current) => mergeKnownLabels(current, createdIssue?.labels ?? draft.labels));
 
       if (startAfterCreate) {
-        const createdTicket = toCreatedBoardTicket(createdIssue, allIssues, displayKey);
+        const createdTicket = toCreatedBoardTicket(createdIssue, allIssues, displayKey, boardColumns);
         if (!createdTicket) {
           throw new Error("Created ticket was not available for start.");
         }
@@ -3065,7 +3087,7 @@ function ProjectBoardApp() {
                 staying crisp.
               */}
               <section className="project-board-lanes horizontal-scroll-fade-mask" aria-label="Project issue board">
-                {BOARD_COLUMNS.map((column) => (
+                {boardColumns.map((column) => (
                   <BoardLane
                     column={column}
                     conversationAction={conversationAction}
@@ -3543,6 +3565,7 @@ function ProjectBoardApp() {
               assignee={detail.ticket?.assignee}
               blockedByIds={detail.blockedByIds}
               blockingIds={detail.blockingIds}
+              boardColumns={boardColumns}
               createdBy={detail.ticket?.created_by}
               knownLabels={knownLabels}
               labels={detail.labels}
@@ -3762,7 +3785,7 @@ function ProjectBoardApp() {
             <DialogTitle>New Ticket</DialogTitle>
             <DialogDescription>
               Leave the title empty to auto-generate it from the prompt. Creates in{" "}
-              {boardStatusLabel(newTicket.status)}.
+              {boardStatusLabel(newTicket.status, boardColumns)}.
             </DialogDescription>
           </DialogHeader>
           <div
@@ -3772,6 +3795,7 @@ function ProjectBoardApp() {
             <TicketMetaFields
               blockedByIds={newTicket.blockedByIds}
               blockingIds={newTicket.blockingIds}
+              boardColumns={boardColumns}
               knownLabels={knownLabels}
               labels={newTicket.labels}
               onBlockedByChange={(blockedByIds) =>
@@ -3956,6 +3980,7 @@ function TicketMetaFields({
   assignee,
   blockedByIds,
   blockingIds,
+  boardColumns,
   createdBy,
   knownLabels,
   labels,
@@ -3974,6 +3999,7 @@ function TicketMetaFields({
   assignee?: string;
   blockedByIds: string[];
   blockingIds: string[];
+  boardColumns: ReadonlyArray<BoardColumn>;
   createdBy?: string;
   knownLabels: string[];
   labels: string[];
@@ -3992,6 +4018,10 @@ function TicketMetaFields({
   const [labelDraft, setLabelDraft] = useState("");
   const labelSuggestions = knownLabels.filter((label) => !labels.includes(label));
   const creator = ticketCreatorName(createdBy, assignee);
+  const statusSelectItems = useMemo(
+    () => boardColumns.map((column) => ({ label: column.label, value: column.key })),
+    [boardColumns],
+  );
 
   return (
     <div className="project-ticket-meta-grid">
@@ -3999,7 +4029,7 @@ function TicketMetaFields({
         <label className="project-ticket-field project-ticket-field-inline">
           <span>Status</span>
           <Select
-            items={PROJECT_BOARD_STATUS_SELECT_ITEMS}
+            items={statusSelectItems}
             onValueChange={(value) => onStatusChange(value as BoardStatusKey)}
             value={status}
           >
@@ -4007,7 +4037,7 @@ function TicketMetaFields({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {BOARD_COLUMNS.map((column) => (
+              {boardColumns.map((column) => (
                 <SelectItem key={column.key} value={column.key}>
                   {column.label}
                 </SelectItem>
@@ -4561,7 +4591,7 @@ function BoardLane({
   onOpenTicket,
   tickets,
 }: {
-  column: (typeof BOARD_COLUMNS)[number];
+  column: BoardColumn;
   conversationAction: ConversationActionState;
   linksByBeadKey: Map<string, ProjectBoardConversationLinkView[]>;
   onAddTicket: (status: BoardStatusKey) => void;
@@ -6328,9 +6358,10 @@ function toCreatedBoardTicket(
   issue: BeadsIssue,
   knownIssues: BeadsIssue[],
   displayKey: string,
+  columns: ReadonlyArray<BoardColumn>,
 ): BoardTicket | undefined {
   const issues = [...knownIssues.filter((candidate) => candidate.id !== issue.id), issue];
-  return toBoardTickets(issues, displayKey).find((ticket) => ticket.id === issue.id);
+  return toBoardTickets(issues, displayKey, columns).find((ticket) => ticket.id === issue.id);
 }
 
 function resolveCreatedIssueFromRefresh(
@@ -7836,10 +7867,19 @@ styleElement.textContent = `
      * The lane bar is the scroller's own scrollbar now, so it lives inside the
      * mask and fades at the very ends of its travel like the ticket dialog's
      * scrollbar already does.
+     *
+     * CDXC:ProjectBoardCustomColumns 2026-08-21:
+     * The board renders one lane per configured Beads status, so the track count
+     * cannot be a fixed six: an explicit six-track template auto-places a
+     * seventh lane into an implicit second row, which overflow-y: hidden then
+     * clips out of sight. Flowing into implicit columns keeps every rendered
+     * lane on the one horizontally scrolling row whatever the board's status
+     * list holds, at the same minimum lane width as before.
      */
     --edge-fade-distance: 18px;
     gap: 0;
-    grid-template-columns: repeat(6, minmax(218px, 1fr));
+    grid-auto-columns: minmax(218px, 1fr);
+    grid-auto-flow: column;
     min-height: 0;
     overflow-x: auto;
     overflow-y: hidden;

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -109,6 +109,7 @@ import {
   priorityLabel,
   prioritySelectValue,
   projectBoardRawProjectIdFromUrlParam,
+  readWorkflowStatuses,
   removeDescriptionImageReference,
   resolveAssignedAgentId,
   isDescriptionImageSource,
@@ -1184,10 +1185,14 @@ function ProjectBoardApp() {
       setErrorMessage("");
     }
     try {
+      let customStatusConfig: string;
       if (mode === "initial" || mode === "manual") {
         await ensureIssuePrefix(runBeads, issuePrefix);
+        customStatusConfig = await ensureWorkflowStatuses(runBeads);
+      } else {
+        customStatusConfig = await readWorkflowStatuses(runBeads);
       }
-      const nextColumns = buildBoardColumns(await ensureWorkflowStatuses(runBeads));
+      const nextColumns = buildBoardColumns(customStatusConfig);
       if (boardColumnsSignature(nextColumns) !== boardColumnsSignature(boardColumnsRef.current)) {
         boardColumnsRef.current = nextColumns;
         setBoardColumns(nextColumns);

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -1186,11 +1186,11 @@ function ProjectBoardApp() {
     try {
       if (mode === "initial" || mode === "manual") {
         await ensureIssuePrefix(runBeads, issuePrefix);
-        const nextColumns = buildBoardColumns(await ensureWorkflowStatuses(runBeads));
-        if (boardColumnsSignature(nextColumns) !== boardColumnsSignature(boardColumnsRef.current)) {
-          boardColumnsRef.current = nextColumns;
-          setBoardColumns(nextColumns);
-        }
+      }
+      const nextColumns = buildBoardColumns(await ensureWorkflowStatuses(runBeads));
+      if (boardColumnsSignature(nextColumns) !== boardColumnsSignature(boardColumnsRef.current)) {
+        boardColumnsRef.current = nextColumns;
+        setBoardColumns(nextColumns);
       }
       const payload = await runBeads({ action: "listIssues" });
       const rawIssues = normalizeBeadsPayload<BeadsIssue[]>(payload, Array.isArray(payload) ? payload : []);


### PR DESCRIPTION
## What

The board hardcoded six lanes and quietly rendered any unknown status as **Todo**. Beads has supported custom statuses for a while, so a card parked in one (for example `needs_sven`) looked like fresh work sitting in Todo.

This makes the board draw what bd actually knows: the six built-in lanes first, unchanged, then one column per extra status from `bd config get status.custom`.

## Behaviour

- `BOARD_COLUMNS` becomes `buildBoardColumns(config)`. The config is the existing comma list (`backlog,review,test,needs_sven:wip`); the optional `:category` suffix is bd's own concern and is left untouched in the config.
- Extra columns render with a muted tone and the raw status name titlecased.
- Drag-and-drop, the edit-ticket status select, and the per-lane create button all accept the extra columns, because they read the same column list.
- Creating, renaming, reordering and deleting columns is deliberately **not** in this PR. This only renders what bd already knows.

## Two fixes worth calling out

**Grid track count.** `.project-board-lanes` had `grid-template-columns: repeat(6, …)` with `overflow-y: hidden`. A seventh lane auto-placed into an implicit second row and was clipped — present in the DOM and a valid drop target, but invisible. Now `grid-auto-flow: column` with `grid-auto-columns: minmax(218px, 1fr)`, so the track count follows the rendered lanes. Six-lane sizing is unchanged.

**gxserver rejected custom statuses.** `normalize_beads_status` matched against a hardcoded list of the six built-ins and returned a 400 before bd ever saw the request, so dragging into a custom lane failed server-side. It now validates the shape of the status and leaves bd as the authority on which statuses exist — bd already returns a clear error for a name it does not know, and args are passed to the process without a shell, so this was never a safety gate.

## Testing

- `bun run typecheck` — clean
- `bunx vitest run native/sidebar/` — 42 files, all passing
- `cargo check` in `gxserver-rs` — clean
- Built and exercised in the running app against a board with one custom status: the extra lane renders on the same scrolling row and a card dragged into it persists across a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project boards now support custom workflow statuses with dynamically generated lanes.
  * Custom statuses appear in ticket status selectors and support movement between lanes.
  * Boards adapt to any number of configured statuses and refresh them automatically.
  * Valid custom statuses may contain letters, numbers, underscores, and hyphens, up to 64 bytes.

* **Bug Fixes**
  * Tickets with statuses lacking configured lanes now fall back to the Todo lane.
  * Built-in and custom lane handling remains consistent across board views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->