### PR TITLE
Kanban: manage custom columns from the board

### DIFF
--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -5,8 +5,16 @@ import {
   beadsStatusToBoardStatus,
   boardStatusBeadsValue,
   boardStatusLabel,
+  addBoardColumn,
+  boardColumnNameError,
   buildAgentWorkPrompt,
   buildBoardColumns,
+  managedBoardColumnNames,
+  moveBoardColumn,
+  parseBoardColumnConfig,
+  removeBoardColumn,
+  renameBoardColumn,
+  serializeBoardColumnConfig,
   DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   extractDescriptionImagePreviews,
   extractDescriptionImageReferences,
@@ -673,5 +681,87 @@ describe("project board assigned agent resolution", () => {
         { agentId: "custom-mf1k2j-77c1aa", label: "codex" },
       ]),
     ).toBe("codex");
+  });
+});
+
+describe("board column management", () => {
+  const config = "backlog,test,review,needs_input:wip,parked";
+
+  test("parses entries and keeps each bd category suffix", () => {
+    expect(parseBoardColumnConfig(config)).toEqual([
+      { name: "backlog", suffix: "" },
+      { name: "test", suffix: "" },
+      { name: "review", suffix: "" },
+      { name: "needs_input", suffix: ":wip" },
+      { name: "parked", suffix: "" },
+    ]);
+    expect(serializeBoardColumnConfig(parseBoardColumnConfig(config))).toBe(config);
+  });
+
+  test("ignores blanks and duplicate names", () => {
+    expect(parseBoardColumnConfig(" a , ,a, b ")).toEqual([
+      { name: "a", suffix: "" },
+      { name: "b", suffix: "" },
+    ]);
+  });
+
+  test("only non built-in statuses are manageable", () => {
+    expect(managedBoardColumnNames(config)).toEqual(["needs_input", "parked"]);
+  });
+
+  test("adds a column at the end", () => {
+    expect(addBoardColumn(config, " blocked ")).toBe(`${config},blocked`);
+  });
+
+  test("renaming preserves the category suffix", () => {
+    expect(renameBoardColumn(config, "needs_input", "waiting")).toBe(
+      "backlog,test,review,waiting:wip,parked",
+    );
+  });
+
+  test("renaming refuses to touch a built-in entry", () => {
+    expect(renameBoardColumn(config, "review", "nope")).toBe(config);
+  });
+
+  test("removing drops only the named managed entry", () => {
+    expect(removeBoardColumn(config, "needs_input")).toBe("backlog,test,review,parked");
+    expect(removeBoardColumn(config, "backlog")).toBe(config);
+  });
+
+  test("reordering swaps managed columns without disturbing built-ins", () => {
+    expect(moveBoardColumn(config, "parked", -1)).toBe("backlog,test,review,parked,needs_input:wip");
+    expect(moveBoardColumn(config, "needs_input", 1)).toBe("backlog,test,review,parked,needs_input:wip");
+  });
+
+  test("reordering past either end is a no-op", () => {
+    expect(moveBoardColumn(config, "needs_input", -1)).toBe(config);
+    expect(moveBoardColumn(config, "parked", 1)).toBe(config);
+    expect(moveBoardColumn(config, "absent", -1)).toBe(config);
+  });
+
+  test("name validation covers empty, shape, built-ins and duplicates", () => {
+    expect(boardColumnNameError("", config)).toBe("Enter a column name.");
+    expect(boardColumnNameError("9lives", config)).toContain("starting with a letter");
+    expect(boardColumnNameError("has space", config)).toContain("starting with a letter");
+    expect(boardColumnNameError("with:colon", config)).toContain("starting with a letter");
+    expect(boardColumnNameError("review", config)).toContain("built-in lane");
+    expect(boardColumnNameError("parked", config)).toBe("That column already exists.");
+    expect(boardColumnNameError("a".repeat(65), config)).toContain("64 characters");
+    expect(boardColumnNameError("waiting_on_ci", config)).toBe("");
+  });
+
+  test("a new column becomes a real lane", () => {
+    const next = addBoardColumn(config, "waiting");
+    expect(buildBoardColumns(next).map((column) => column.key)).toEqual([
+      "backlog",
+      "todo",
+      "in_progress",
+      "test",
+      "review",
+      "done",
+      "needs_input",
+      "parked",
+      "waiting",
+    ]);
   });
 });

--- a/native/sidebar/project-board-shared.test.ts
+++ b/native/sidebar/project-board-shared.test.ts
@@ -13,7 +13,7 @@ import {
   moveBoardColumn,
   parseBoardColumnConfig,
   removeBoardColumn,
-  renameBoardColumn,
+  beginBoardColumnRename,
   serializeBoardColumnConfig,
   DEFAULT_PROJECT_BOARD_VIEW_PREFERENCES,
   extractDescriptionImagePreviews,
@@ -713,14 +713,24 @@ describe("board column management", () => {
     expect(addBoardColumn(config, " blocked ")).toBe(`${config},blocked`);
   });
 
-  test("renaming preserves the category suffix", () => {
-    expect(renameBoardColumn(config, "needs_input", "waiting")).toBe(
-      "backlog,test,review,waiting:wip,parked",
+  test("renaming keeps both names live and carries the category onto the new one", () => {
+    // the old entry must survive this step: a bead may not hold a status the config does not list
+    expect(beginBoardColumnRename(config, "needs_input", "waiting")).toBe(
+      "backlog,test,review,needs_input:wip,parked,waiting:wip",
     );
   });
 
   test("renaming refuses to touch a built-in entry", () => {
-    expect(renameBoardColumn(config, "review", "nope")).toBe(config);
+    expect(beginBoardColumnRename(config, "review", "nope")).toBe(config);
+  });
+
+  test("renaming an absent column changes nothing", () => {
+    expect(beginBoardColumnRename(config, "ghost", "nope")).toBe(config);
+  });
+
+  test("the finished rename drops the old entry and keeps the category", () => {
+    const both = beginBoardColumnRename(config, "needs_input", "waiting");
+    expect(removeBoardColumn(both, "needs_input")).toBe("backlog,test,review,parked,waiting:wip");
   });
 
   test("removing drops only the named managed entry", () => {

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -271,14 +271,22 @@ export function addBoardColumn(config: string, name: string): string {
   return serializeBoardColumnConfig(entries);
 }
 
-export function renameBoardColumn(config: string, from: string, to: string): string {
-  return serializeBoardColumnConfig(
-    parseBoardColumnConfig(config).map((entry) =>
-      entry.name === from && isManagedBoardColumnName(entry.name)
-        ? { name: to.trim(), suffix: entry.suffix }
-        : entry,
-    ),
-  );
+/*
+  CDXC:ProjectBoardColumnManagement 2026-08-21:
+  Renaming cannot be one config write. A bead may not hold a status the config does not list, so the
+  new name has to exist alongside the old one while the beads move across, and only then can the old
+  entry go. This builds that intermediate config, carrying the old entry's bd category onto the new
+  name — an earlier version appended the new name with no suffix and silently dropped a `:wip`
+  category off a real board, which is what this comment exists to stop happening again.
+*/
+export function beginBoardColumnRename(config: string, from: string, to: string): string {
+  const entries = parseBoardColumnConfig(config);
+  const source = entries.find((entry) => entry.name === from);
+  if (!source || !isManagedBoardColumnName(from)) {
+    return serializeBoardColumnConfig(entries);
+  }
+  entries.push({ name: to.trim(), suffix: source.suffix });
+  return serializeBoardColumnConfig(entries);
 }
 
 export function removeBoardColumn(config: string, name: string): string {

--- a/native/sidebar/project-board-shared.ts
+++ b/native/sidebar/project-board-shared.ts
@@ -193,6 +193,124 @@ function boardStatusNameToLabel(name: string): string {
     .join(" ");
 }
 
+/*
+  CDXC:ProjectBoardColumnManagement 2026-08-21:
+  Column management edits the same `status.custom` comma list that buildBoardColumns reads, so both directions share one parse.
+  An entry's optional `:<bd category>` suffix is bd's own concern: this module never sets one, and every write preserves whatever bd already put there, because dropping a category silently changes how bd treats that status.
+  Only entries that are not built-in lanes are manageable. The required entries (backlog, test, review) back real Ghostex lanes and are reconciled by ensureWorkflowStatuses, so offering them for rename or delete would just fight that reconciliation on the next load.
+*/
+export type BoardColumnConfigEntry = {
+  name: string;
+  suffix: string;
+};
+
+export function parseBoardColumnConfig(config: string): BoardColumnConfigEntry[] {
+  const entries: BoardColumnConfigEntry[] = [];
+  const seen = new Set<string>();
+  for (const raw of config.split(",")) {
+    const entry = raw.trim();
+    if (!entry) {
+      continue;
+    }
+    const separatorIndex = entry.indexOf(":");
+    const name = (separatorIndex === -1 ? entry : entry.slice(0, separatorIndex)).trim();
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    entries.push({ name, suffix: separatorIndex === -1 ? "" : entry.slice(separatorIndex) });
+  }
+  return entries;
+}
+
+export function serializeBoardColumnConfig(entries: ReadonlyArray<BoardColumnConfigEntry>): string {
+  return entries.map((entry) => `${entry.name}${entry.suffix}`).join(",");
+}
+
+export function isManagedBoardColumnName(name: string): boolean {
+  return !BUILTIN_BOARD_STATUS_NAMES.has(name);
+}
+
+export function managedBoardColumnNames(config: string): string[] {
+  return parseBoardColumnConfig(config)
+    .map((entry) => entry.name)
+    .filter(isManagedBoardColumnName);
+}
+
+/*
+  CDXC:ProjectBoardColumnManagement 2026-08-21:
+  The name rule matches what gxserver accepts for a status value, so a name that passes here can never be rejected later by the transport that has to carry it.
+*/
+export function boardColumnNameError(name: string, config: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "Enter a column name.";
+  }
+  if (trimmed.length > 64) {
+    return "Column names are limited to 64 characters.";
+  }
+  if (
+    !trimmed.split("").every((ch, index) =>
+      index === 0 ? /[A-Za-z]/u.test(ch) : /[A-Za-z0-9_-]/u.test(ch),
+    )
+  ) {
+    return "Use letters, numbers, hyphens and underscores, starting with a letter.";
+  }
+  if (!isManagedBoardColumnName(trimmed)) {
+    return `${boardStatusNameToLabel(trimmed)} is a built-in lane.`;
+  }
+  if (parseBoardColumnConfig(config).some((entry) => entry.name === trimmed)) {
+    return "That column already exists.";
+  }
+  return "";
+}
+
+export function addBoardColumn(config: string, name: string): string {
+  const entries = parseBoardColumnConfig(config);
+  entries.push({ name: name.trim(), suffix: "" });
+  return serializeBoardColumnConfig(entries);
+}
+
+export function renameBoardColumn(config: string, from: string, to: string): string {
+  return serializeBoardColumnConfig(
+    parseBoardColumnConfig(config).map((entry) =>
+      entry.name === from && isManagedBoardColumnName(entry.name)
+        ? { name: to.trim(), suffix: entry.suffix }
+        : entry,
+    ),
+  );
+}
+
+export function removeBoardColumn(config: string, name: string): string {
+  return serializeBoardColumnConfig(
+    parseBoardColumnConfig(config).filter(
+      (entry) => !(entry.name === name && isManagedBoardColumnName(entry.name)),
+    ),
+  );
+}
+
+/*
+  CDXC:ProjectBoardColumnManagement 2026-08-21:
+  Reordering swaps a column with its neighbour among the managed entries only, then writes the whole list back in place.
+  Built-in entries keep their positions in the config because they are not part of the swap, which matters because the six built-in lanes always render first regardless of config order and moving them would change nothing on screen while still churning the stored value.
+*/
+export function moveBoardColumn(config: string, name: string, delta: -1 | 1): string {
+  const entries = parseBoardColumnConfig(config);
+  const managedIndexes = entries
+    .map((entry, index) => (isManagedBoardColumnName(entry.name) ? index : -1))
+    .filter((index) => index !== -1);
+  const position = managedIndexes.findIndex((index) => entries[index].name === name);
+  const target = position + delta;
+  if (position === -1 || target < 0 || target >= managedIndexes.length) {
+    return serializeBoardColumnConfig(entries);
+  }
+  const left = managedIndexes[position];
+  const right = managedIndexes[target];
+  const swapped = [...entries];
+  [swapped[left], swapped[right]] = [swapped[right], swapped[left]];
+  return serializeBoardColumnConfig(swapped);
+}
+
 export const PRIORITY_OPTIONS = [
   /*
     CDXC:ProjectBoard 2026-05-28-09:18:

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -81,6 +81,7 @@ import {
   TSHIRT_OPTIONS,
   addBoardColumn,
   appendImageMarkdownToDescription,
+  beginBoardColumnRename,
   beadsErrorMessage,
   beadsStatusToBoardStatus,
   boardColumnNameError,
@@ -1788,7 +1789,7 @@ function ProjectBoardApp() {
    */
   const applyBoardColumnRename = async (from: string, to: string) => {
     const nextName = to.trim();
-    const bothConfig = addBoardColumn(boardColumnConfigRef.current, nextName);
+    const bothConfig = beginBoardColumnRename(boardColumnConfigRef.current, from, nextName);
     await runBeads({ action: "configSet", value: bothConfig });
     boardColumnConfigRef.current = bothConfig;
     for (const ticket of tickets.filter((candidate) => candidate.boardStatus === from)) {

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -1792,8 +1792,19 @@ function ProjectBoardApp() {
     const bothConfig = beginBoardColumnRename(boardColumnConfigRef.current, from, nextName);
     await runBeads({ action: "configSet", value: bothConfig });
     boardColumnConfigRef.current = bothConfig;
-    for (const ticket of tickets.filter((candidate) => candidate.boardStatus === from)) {
-      await runBeads({ action: "updateStatus", issueId: ticket.id, status: nextName });
+    setBoardColumnConfig(bothConfig);
+    const ticketsToMove = tickets.filter((candidate) => candidate.boardStatus === from);
+    for (const [index, ticket] of ticketsToMove.entries()) {
+      try {
+        await runBeads({ action: "updateStatus", issueId: ticket.id, status: nextName });
+      } catch (error) {
+        const unmovedIds = ticketsToMove.slice(index).map((ticket) => ticket.id);
+        await loadTickets({ mode: "manual" });
+        const failure = beadsErrorMessage(error instanceof Error ? error.message : "");
+        throw new Error(
+          `Could not finish renaming ${from} to ${nextName}. ${unmovedIds.length === 1 ? "Ticket" : "Tickets"} ${unmovedIds.join(", ")} did not move. ${failure}`,
+        );
+      }
     }
     await writeBoardColumnConfig(removeBoardColumn(bothConfig, from));
   };

--- a/native/sidebar/tasks-placeholder.tsx
+++ b/native/sidebar/tasks-placeholder.tsx
@@ -79,13 +79,18 @@ import {
   PRIORITY_OPTIONS,
   PROJECT_BOARD_VIEW_PREFERENCES_STORAGE_KEY,
   TSHIRT_OPTIONS,
+  addBoardColumn,
   appendImageMarkdownToDescription,
   beadsErrorMessage,
   beadsStatusToBoardStatus,
+  boardColumnNameError,
   boardStatusBeadsValue,
   boardStatusLabel,
   buildAgentWorkPrompt,
   buildBoardColumns,
+  managedBoardColumnNames,
+  moveBoardColumn,
+  removeBoardColumn,
   conversationLinkActionKind,
   conversationLinkLabel,
   conversationLinkStatusText,
@@ -628,6 +633,15 @@ function ProjectBoardApp() {
    */
   const boardColumnsRef = useRef<BoardColumn[]>(buildBoardColumns(""));
   const [boardColumns, setBoardColumns] = useState<BoardColumn[]>(boardColumnsRef.current);
+  /*
+   * CDXC:ProjectBoardColumnManagement 2026-08-21:
+   * Column management writes the same config string it read, so the raw value is kept rather than
+   * rebuilt from the derived columns: the derived list has already dropped each entry's bd category
+   * suffix, and regenerating the config from it would silently strip categories the board relies on.
+   */
+  const boardColumnConfigRef = useRef("");
+  const [boardColumnConfig, setBoardColumnConfig] = useState("");
+  const [columnsDialogOpen, setColumnsDialogOpen] = useState(false);
   const [tickets, setTickets] = useState<BoardTicket[]>([]);
   const [allIssues, setAllIssues] = useState<BeadsIssue[]>([]);
   const [knownLabels, setKnownLabels] = useState<string[]>([]);
@@ -1186,7 +1200,12 @@ function ProjectBoardApp() {
     try {
       if (mode === "initial" || mode === "manual") {
         await ensureIssuePrefix(runBeads, issuePrefix);
-        const nextColumns = buildBoardColumns(await ensureWorkflowStatuses(runBeads));
+        const nextConfig = await ensureWorkflowStatuses(runBeads);
+        if (nextConfig !== boardColumnConfigRef.current) {
+          boardColumnConfigRef.current = nextConfig;
+          setBoardColumnConfig(nextConfig);
+        }
+        const nextColumns = buildBoardColumns(nextConfig);
         if (boardColumnsSignature(nextColumns) !== boardColumnsSignature(boardColumnsRef.current)) {
           boardColumnsRef.current = nextColumns;
           setBoardColumns(nextColumns);
@@ -1724,6 +1743,58 @@ function ProjectBoardApp() {
     if (ticketId && statusKey) {
       void moveTicket(ticketId, statusKey);
     }
+  };
+
+  /*
+   * CDXC:ProjectBoardColumnManagement 2026-08-21:
+   * Every column edit is one config write followed by a manual reload, so the lanes the user sees
+   * always come back from bd rather than from optimistic local state — a board config write is rare
+   * and cheap, and guessing at the result would drift from whatever bd actually stored.
+   */
+  const writeBoardColumnConfig = async (value: string) => {
+    await runBeads({ action: "configSet", value });
+    boardColumnConfigRef.current = value;
+    setBoardColumnConfig(value);
+    await loadTickets({ mode: "manual" });
+  };
+
+  const createBoardColumn = async (name: string) => {
+    await writeBoardColumnConfig(addBoardColumn(boardColumnConfigRef.current, name));
+  };
+
+  const reorderBoardColumn = async (name: string, delta: -1 | 1) => {
+    await writeBoardColumnConfig(moveBoardColumn(boardColumnConfigRef.current, name, delta));
+  };
+
+  /*
+   * CDXC:ProjectBoardColumnManagement 2026-08-21:
+   * Deleting is refused while the column still holds beads, so this never has to decide where an
+   * orphan goes. That is deliberate: an unconfigured status resolves to Todo, so silently emptying a
+   * parked lane would make parked work read as fresh work, which is the bug custom columns fixed.
+   */
+  const deleteBoardColumn = async (name: string) => {
+    if (tickets.some((ticket) => ticket.boardStatus === name)) {
+      return;
+    }
+    await writeBoardColumnConfig(removeBoardColumn(boardColumnConfigRef.current, name));
+  };
+
+  /*
+   * CDXC:ProjectBoardColumnManagement 2026-08-21:
+   * Renaming is not a config edit alone: every bead still holding the old status has to move, and a
+   * bead may not carry a status the config does not list. So the new name is added alongside the old
+   * one first, the beads are moved onto it, and only then is the old entry dropped — no point in the
+   * sequence leaves a bead on a status the board does not know.
+   */
+  const applyBoardColumnRename = async (from: string, to: string) => {
+    const nextName = to.trim();
+    const bothConfig = addBoardColumn(boardColumnConfigRef.current, nextName);
+    await runBeads({ action: "configSet", value: bothConfig });
+    boardColumnConfigRef.current = bothConfig;
+    for (const ticket of tickets.filter((candidate) => candidate.boardStatus === from)) {
+      await runBeads({ action: "updateStatus", issueId: ticket.id, status: nextName });
+    }
+    await writeBoardColumnConfig(removeBoardColumn(bothConfig, from));
   };
 
   const syncDependencies = async (issueId: string, blockedByIds: string[], blockingIds: string[]) => {
@@ -2899,6 +2970,19 @@ function ProjectBoardApp() {
               </option>
             ))}
           </select>
+          {/*
+           * CDXC:ProjectBoardColumnManagement 2026-08-21:
+           * Columns sits with the filters because it changes what the board shows, and it is the only
+           * control here that writes to the board rather than to this client's view preferences.
+           */}
+          <Button
+            className="project-board-columns-button"
+            onClick={() => setColumnsDialogOpen(true)}
+            size="sm"
+            variant="outline"
+          >
+            Columns
+          </Button>
         </section>
       ) : null}
 
@@ -3541,6 +3625,17 @@ function ProjectBoardApp() {
       </Dialog>
       ) : null}
 
+      <BoardColumnsDialog
+        columns={boardColumns}
+        config={boardColumnConfig}
+        onClose={() => setColumnsDialogOpen(false)}
+        onCreate={createBoardColumn}
+        onDelete={deleteBoardColumn}
+        onRename={applyBoardColumnRename}
+        onReorder={reorderBoardColumn}
+        open={columnsDialogOpen}
+        tickets={tickets}
+      />
       <Dialog
         open={Boolean(detail.ticket)}
         onOpenChange={(open) => {
@@ -7749,6 +7844,60 @@ styleElement.textContent = `
     min-width: 0;
   }
 
+  .project-board-columns-button {
+    flex: 0 0 auto;
+  }
+
+  .project-board-columns-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .project-board-columns-row {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    display: flex;
+    gap: 8px;
+    padding: 6px 8px;
+  }
+
+  .project-board-columns-row[data-locked="true"] {
+    opacity: 0.55;
+  }
+
+  .project-board-columns-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .project-board-columns-note {
+    color: rgba(244, 244, 245, 0.46);
+    flex: 0 0 auto;
+    font-size: 12px;
+  }
+
+  .project-board-columns-add {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  .project-board-columns-error {
+    color: rgba(248, 113, 113, 0.92);
+    font-size: 12px;
+    margin: 8px 0 0;
+  }
+
   .project-board-search {
     align-items: center;
     display: flex;
@@ -8919,3 +9068,215 @@ styleElement.textContent = `
 document.head.append(styleElement);
 
 createRoot(document.getElementById("root")!).render(<ProjectBoardApp />);
+
+/*
+  CDXC:ProjectBoardColumnManagement 2026-08-21:
+  The dialog only ever offers the board's own extra statuses. The six built-in lanes are listed but
+  locked, because they are reconciled into the config by ensureWorkflowStatuses on every load and
+  renaming or removing one here would simply be undone on the next refresh.
+  Deleting is disabled while a column still holds beads and says how many are in the way, rather than
+  moving them somewhere on the user's behalf: an unconfigured status renders as Todo, so an automatic
+  sweep would turn parked work into work that looks fresh.
+*/
+function BoardColumnsDialog({
+  columns,
+  config,
+  onClose,
+  onCreate,
+  onDelete,
+  onRename,
+  onReorder,
+  open,
+  tickets,
+}: {
+  columns: BoardColumn[];
+  config: string;
+  onClose: () => void;
+  onCreate: (name: string) => Promise<void>;
+  onDelete: (name: string) => Promise<void>;
+  onRename: (from: string, to: string) => Promise<void>;
+  onReorder: (name: string, delta: -1 | 1) => Promise<void>;
+  open: boolean;
+  tickets: BoardTicket[];
+}) {
+  const [draftName, setDraftName] = useState("");
+  const [renamingName, setRenamingName] = useState("");
+  const [renameDraft, setRenameDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const managedNames = useMemo(() => managedBoardColumnNames(config), [config]);
+  const builtinColumns = useMemo(
+    () => columns.filter((column) => !managedNames.includes(String(column.key))),
+    [columns, managedNames],
+  );
+  const ticketCountByStatus = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const ticket of tickets) {
+      const key = String(ticket.boardStatus);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+  }, [tickets]);
+
+  const closeDialog = () => {
+    setDraftName("");
+    setRenamingName("");
+    setRenameDraft("");
+    setErrorMessage("");
+    onClose();
+  };
+
+  const run = async (action: () => Promise<void>) => {
+    setBusy(true);
+    setErrorMessage("");
+    try {
+      await action();
+    } catch (error) {
+      setErrorMessage(beadsErrorMessage(error instanceof Error ? error.message : ""));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const createError = draftName.trim() ? boardColumnNameError(draftName, config) : "";
+  const renameError =
+    renamingName && renameDraft.trim() && renameDraft.trim() !== renamingName
+      ? boardColumnNameError(renameDraft, config)
+      : "";
+
+  return (
+    <Dialog onOpenChange={(next) => (next ? undefined : closeDialog())} open={open}>
+      <DialogContent className="project-ticket-dialog project-board-columns-dialog">
+        <DialogHeader>
+          <DialogTitle>Board columns</DialogTitle>
+          <DialogDescription>
+            Extra columns come from this board&apos;s Beads status config. The six built-in lanes are fixed.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="project-ticket-dialog-body vertical-scroll-fade-mask">
+          <ul className="project-board-columns-list">
+            {builtinColumns.map((column) => (
+              <li className="project-board-columns-row" data-locked="true" key={String(column.key)}>
+                <span className="project-board-columns-name">{column.label}</span>
+                <span className="project-board-columns-note">Built-in</span>
+              </li>
+            ))}
+            {managedNames.map((name, index) => {
+              const ticketCount = ticketCountByStatus.get(name) ?? 0;
+              const isRenaming = renamingName === name;
+              return (
+                <li className="project-board-columns-row" key={name}>
+                  {isRenaming ? (
+                    <>
+                      <Input
+                        aria-label={`Rename ${name}`}
+                        autoFocus
+                        onChange={(event) => setRenameDraft(event.currentTarget.value)}
+                        value={renameDraft}
+                      />
+                      <Button
+                        disabled={busy || Boolean(renameError) || !renameDraft.trim()}
+                        onClick={() =>
+                          void run(async () => {
+                            if (renameDraft.trim() !== name) {
+                              await onRename(name, renameDraft);
+                            }
+                            setRenamingName("");
+                          })
+                        }
+                        size="sm"
+                      >
+                        Save
+                      </Button>
+                      <Button onClick={() => setRenamingName("")} size="sm" variant="ghost">
+                        Cancel
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <span className="project-board-columns-name">{boardStatusLabel(name, columns)}</span>
+                      <span className="project-board-columns-note">
+                        {ticketCount === 1 ? "1 card" : `${ticketCount} cards`}
+                      </span>
+                      <Button
+                        aria-label={`Move ${name} up`}
+                        disabled={busy || index === 0}
+                        onClick={() => void run(() => onReorder(name, -1))}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        ↑
+                      </Button>
+                      <Button
+                        aria-label={`Move ${name} down`}
+                        disabled={busy || index === managedNames.length - 1}
+                        onClick={() => void run(() => onReorder(name, 1))}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        ↓
+                      </Button>
+                      <Button
+                        disabled={busy}
+                        onClick={() => {
+                          setRenamingName(name);
+                          setRenameDraft(name);
+                        }}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        Rename
+                      </Button>
+                      <Button
+                        disabled={busy || ticketCount > 0}
+                        onClick={() => void run(() => onDelete(name))}
+                        size="sm"
+                        title={
+                          ticketCount > 0
+                            ? `Move its ${ticketCount === 1 ? "card" : "cards"} out first.`
+                            : undefined
+                        }
+                        variant="ghost"
+                      >
+                        Delete
+                      </Button>
+                    </>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+          {renameError ? <p className="project-board-columns-error">{renameError}</p> : null}
+          <div className="project-board-columns-add">
+            <Input
+              aria-label="New column name"
+              onChange={(event) => setDraftName(event.currentTarget.value)}
+              placeholder="New column name"
+              value={draftName}
+            />
+            <Button
+              disabled={busy || Boolean(createError) || !draftName.trim()}
+              onClick={() =>
+                void run(async () => {
+                  await onCreate(draftName);
+                  setDraftName("");
+                })
+              }
+              size="sm"
+            >
+              Add column
+            </Button>
+          </div>
+          {createError ? <p className="project-board-columns-error">{createError}</p> : null}
+          {errorMessage ? <p className="project-board-columns-error">{errorMessage}</p> : null}
+        </div>
+        <DialogFooter>
+          <Button onClick={closeDialog} variant="outline">
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
> Stacked on #105. Base will be retargeted to `main` once that merges.

## What

Adds a **Columns** button to the board toolbar. It opens a dialog for managing the board's custom bd statuses — create, rename, reorder, delete — instead of requiring `bd config set status.custom` in a terminal.

#105 made the board *render* whatever bd already knew. This makes that set editable from the board.

## Behaviour

- **Built-in lanes are listed but locked.** `ensureWorkflowStatuses` reconciles them into the config on every load, so editing them here would just be undone on the next refresh.
- **Create** appends to `status.custom`. Names are validated against the same rule gxserver accepts for a status value, so a name that passes here cannot be rejected later by the transport that has to carry it.
- **Reorder** uses up/down controls rather than drag — nesting a drag list inside the board's own drag-and-drop is not worth it for a rare action.
- **Rename** is not a pure config edit: every bead holding the old status has to move. It runs as *add the new status → move the beads → drop the old entry*, so no point in the sequence leaves a bead on a status the config does not list.
- **Delete is refused while the column still holds beads**, and says how many are in the way. Nothing is moved on the user's behalf: an unconfigured status resolves to Todo, so an automatic sweep would turn parked work into work that looks fresh — the exact problem #105 set out to fix.

Every write round-trips through `parseBoardColumnConfig` / `serializeBoardColumnConfig`, which preserve each entry's optional `:<bd category>` suffix. This module never sets one, and dropping a category bd had set would silently change how bd treats that status.

## Testing

- `bun run typecheck` — clean
- `bunx vitest run native/sidebar/` — 42 files, 210 tests passing
- Exercised in the running app against a real board: created a column, reordered it, renamed one holding cards and confirmed the cards followed, and confirmed delete stays disabled until the lane is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable project-board columns based on workflow statuses.
  * Added a Columns dialog for creating, reordering, renaming, and deleting custom columns.
  * Built-in columns are protected from modification.
  * Prevented deleting columns that still contain cards.
  * Improved board-column layout and styling.
* **Tests**
  * Added coverage for column configuration, validation, and management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->