### PR TITLE
fix(desktop): let every CEF first responder own the paste hotkey

### DIFF
--- a/apps/desktop/src/app/focus.rs
+++ b/apps/desktop/src/app/focus.rs
@@ -402,12 +402,21 @@ impl GhostexGpuiApp {
         &self,
         cx: &mut gpui::Context<Self>,
     ) -> bool {
+        /*
+        CDXC:GPUICefFirstResponderPastePassthrough 2026-08-27:
+        Every CEF surface qualifies, not just the editable Source/Manage/Chat
+        renderers: `shell_focus` keeps naming a terminal pane while a modal,
+        the sidebar, a Kanban page, a titlebar popup, or a browser tab holds
+        AppKit's first responder, so without this gate the Cmd+V binding
+        shadow-pastes the same clipboard into that pane's hidden terminal
+        composer. That phantom draft is what a later chat send's
+        draft-preservation step sweeps into Saved Prompts. A Chromium first
+        responder always owns its own paste.
+        */
         #[cfg(target_os = "macos")]
         let renderer_edit_cef_owns_native_focus = matches!(
             self.first_responder_target,
-            FirstResponderTarget::CefSurface(FirstResponderCefSurface::ProjectWorkarea(
-                ProjectWorkareaCefSurfaceSlotKey::Source | ProjectWorkareaCefSurfaceSlotKey::Manage
-            )) | FirstResponderTarget::CefSurface(FirstResponderCefSurface::SessionChat(_))
+            FirstResponderTarget::CefSurface(_)
         );
         #[cfg(not(target_os = "macos"))]
         let renderer_edit_cef_owns_native_focus = false;


### PR DESCRIPTION
Complements the renderer-edit CEF passthrough (7a70ed42) by widening it from Source/Manage/SessionChat to **every** CEF first responder.

## Why

`shell_focus` keeps naming a terminal pane while an app modal, the sidebar, a Kanban/Automate page, a titlebar popup, a browser tab, or the editor companion holds AppKit's first responder — so the app-wide Cmd+V binding still resolves a hidden terminal and pastes the same clipboard into its composer alongside the CEF view's own paste. The next chat send's draft-preservation step then sweeps that phantom composer draft into Saved Prompts as a prompt the user never saved.

We hit this in the wild today: image pastes into session chat were written to disk twice ~45ms apart (native terminal path first, chat composer second) and the terminal copy surfaced as an untagged Saved Prompt after the send. 7a70ed42 fixes the chat/Docs/Source cases; this covers the remaining Chromium surfaces, which shadow-paste through exactly the same mechanism. A Chromium first responder always owns its own paste, so the enumeration doesn't need to grow case by case.

`cargo check` clean (no new warnings in focus.rs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS paste handling across embedded browser surfaces.
  * Prevented clipboard content from being unintentionally pasted into hidden terminal input when dialogs, sidebars, popups, or browser tabs are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix paste hotkey passthrough for all CEF surfaces on macOS
> - Updates `propagate_renderer_edit_cef_hotkey_passthrough` in [focus.rs](https://github.com/maddada/Ghostex/pull/110/files#diff-1fe23f3268eb35e7a4b081815568bcd0b76fde9a91cc8b99ac483518bbad7118) to match any `FirstResponderTarget::CefSurface` on macOS, instead of only Source, Manage, and Session Chat surfaces.
> - Non-macOS platforms remain unchanged, still returning `false`.
> - Behavioral Change: all CEF surfaces on macOS now own the paste hotkey.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cae150.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->