### PR TITLE
fix(chat): skip the draft handoff for agents launched through a user hop

### DIFF
--- a/docs/2026-08-31/pr-113-chat-user-hop-draft-handoff.md
+++ b/docs/2026-08-31/pr-113-chat-user-hop-draft-handoff.md
@@ -1,0 +1,20 @@
+# PR #113: Chat draft handoff across user or host hops
+
+```gherkin
+Feature: Keep Chat usable for agents launched through another user or host
+
+  Scenario: Current behavior before this change
+    Given an agent session is launched through SSH or another user or host hop
+    And the user opens Chat while a draft may still be in the terminal
+    When Ghostex tries to transfer the terminal draft through the remote agent's editor
+    Then the remote terminal can open the wrong editor and become stuck
+    And later Chat messages are rejected because the agent input is no longer ready
+
+  Scenario: Expected behavior after this change
+    Given an agent session's effective launch command uses a user or host hop
+    When the user opens Chat
+    Then Ghostex skips the unsupported terminal draft transfer
+    And leaves the draft safely in the terminal
+    And keeps the agent available for normal Chat messages
+    But local agent sessions continue to transfer terminal drafts into Chat
+```

--- a/server/src/session_chat_send.rs
+++ b/server/src/session_chat_send.rs
@@ -2616,9 +2616,11 @@ Nothing about such a session can answer the handshake, so the capture is
 skipped up front and the draft stays in the parked terminal, the documented
 loss-safe failure mode of this endpoint.
 */
+/// Whether the effective agent command transfers control to another user or host.
 fn session_chat_agent_command_is_user_hop(session: &Value) -> bool {
+    let runtime_settings = session.get("runtimeSettings").and_then(Value::as_object);
     let launch_settings = session.get("launchSettings").and_then(Value::as_object);
-    let command = launch_settings
+    let command = runtime_settings
         .and_then(|settings| settings.get("agentCommand"))
         .and_then(Value::as_str)
         .filter(|command| !command.trim().is_empty())
@@ -2628,6 +2630,13 @@ fn session_chat_agent_command_is_user_hop(session: &Value) -> bool {
                 .and_then(Value::as_object)
                 .and_then(|plan| plan.get("command"))
                 .and_then(Value::as_str)
+                .filter(|command| !command.trim().is_empty())
+        })
+        .or_else(|| {
+            launch_settings
+                .and_then(|settings| settings.get("agentCommand"))
+                .and_then(Value::as_str)
+                .filter(|command| !command.trim().is_empty())
         })
         .unwrap_or_default();
     let Some(first_word) = command.split_whitespace().next() else {
@@ -2637,6 +2646,7 @@ fn session_chat_agent_command_is_user_hop(session: &Value) -> bool {
     matches!(program, "ssh" | "autossh" | "mosh" | "et")
 }
 
+/// Transfer a terminal draft into Chat when the session can answer the editor handshake.
 pub(crate) async fn handle_handoff_session_chat_draft_http(
     state: &AppState,
     endpoint_path: String,

--- a/server/src/session_chat_send.rs
+++ b/server/src/session_chat_send.rs
@@ -2601,6 +2601,42 @@ a transfer leaves no residue in the user's Saved Prompts list.
 Grok Build binds Ctrl+G to its Tasks pane, so its capture opens the editor from
 the command palette with Ctrl+P, `editor`, Enter instead.
 */
+
+/*
+CDXC:SessionChatDraftHandoff 2026-08-30:
+The prompt-editor handshake only works when the agent CLI inherits the session
+shell's environment, where the launch script points $EDITOR/$VISUAL at
+`ghostex prompt-editor`. An agent command that hops to another user or host
+(`ssh -tt qawwi@localhost … hermes`, seen live 2026-08-30) starts the CLI
+outside that environment: the CLI resolves its own editor instead (on current
+macOS the prompt_toolkit fallback chain lands in pico via /usr/bin/nano), the
+response file is never written, and the 16s wait ends with the TUI wedged
+inside that editor — which then makes every send fail composer detection.
+Nothing about such a session can answer the handshake, so the capture is
+skipped up front and the draft stays in the parked terminal, the documented
+loss-safe failure mode of this endpoint.
+*/
+fn session_chat_agent_command_is_user_hop(session: &Value) -> bool {
+    let launch_settings = session.get("launchSettings").and_then(Value::as_object);
+    let command = launch_settings
+        .and_then(|settings| settings.get("agentCommand"))
+        .and_then(Value::as_str)
+        .filter(|command| !command.trim().is_empty())
+        .or_else(|| {
+            launch_settings
+                .and_then(|settings| settings.get("agentLaunchPlan"))
+                .and_then(Value::as_object)
+                .and_then(|plan| plan.get("command"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or_default();
+    let Some(first_word) = command.split_whitespace().next() else {
+        return false;
+    };
+    let program = first_word.rsplit('/').next().unwrap_or(first_word);
+    matches!(program, "ssh" | "autossh" | "mosh" | "et")
+}
+
 pub(crate) async fn handle_handoff_session_chat_draft_http(
     state: &AppState,
     endpoint_path: String,
@@ -2615,6 +2651,13 @@ pub(crate) async fn handle_handoff_session_chat_draft_http(
         Ok(target) => target,
         Err(error) => return domain_error_response(endpoint_path, request_id, error),
     };
+    if session_chat_agent_command_is_user_hop(&target.session) {
+        return routed_json(
+            Some(endpoint_path),
+            StatusCode::OK,
+            rpc_success(request_id, json!({ "content": "", "transferred": false })),
+        );
+    }
     let agent = session_chat_agent_for_session(&target.session);
     let captured = match crate::session_chat_send::capture_session_chat_terminal_draft(
         &state.paths.app_state_dir,


### PR DESCRIPTION
## What was failing

Opening Chat View on a Hermes session launched as `ssh -tt qawwi@localhost '...hermes -p harry'` wedged the terminal inside **pico** and every chat send was then refused with *"The agent's input box is not ready yet"*.

## Why

The draft handoff sends a BEL so the agent CLI opens `$EDITOR`, which the session launch script points at `ghostex prompt-editor`. That contract lives in the session shell's **environment — and ssh drops it**. The CLI on the far side of the hop resolves its own editor instead (prompt_toolkit's fallback chain lands in pico via `/usr/bin/nano` on current macOS), the handshake response file is never written, the 16s wait times out, and the TUI is left sitting in pico — which then correctly fails composer detection for every subsequent send.

## Fix

`handle_handoff_session_chat_draft_http` now answers `transferred:false` up front when the session's agent command is a user/host hop (ssh/autossh/mosh/et), leaving the terminal untouched — the endpoint's documented loss-safe failure mode. Local agents are unaffected.

Verified live on the affected setup: chat view no longer wedges the hermes TUI, and local Claude sessions still transfer terminal drafts into chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU3indbyE1upH8vfsXh3L4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal draft handoffs now skip prompt capture when the session command transfers control to another user or host.
  * Drafts remain in the terminal, keeping the agent available for subsequent Chat messages.
  * Local agent sessions continue transferring terminal drafts into Chat normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->