### PR TITLE
fix(chat): recognize Hermes composers with a profile-name prompt

### DIFF
--- a/docs/2026-08-31/pr-114-hermes-profiled-composer.md
+++ b/docs/2026-08-31/pr-114-hermes-profiled-composer.md
@@ -1,0 +1,20 @@
+# PR #114: Hermes profile-aware Chat composer detection
+
+```gherkin
+Feature: Send Chat messages to Hermes sessions that use a named profile
+
+  Scenario: Current behavior before this change
+    Given a Hermes agent is launched with a named profile
+    And its input prompt displays the profile name before the prompt symbol
+    When the user sends a message from Chat
+    Then Ghostex reports that the Hermes input box is not on screen
+    And the visible terminal composer receives nothing
+
+  Scenario: Expected behavior after this change
+    Given a Hermes agent uses either the default profile or one named profile
+    And its normal framed composer is visible
+    When the user sends a message from Chat
+    Then Ghostex recognizes the composer as ready
+    And delivers the message to Hermes
+    But prompt-like prose and numbered option dialogs remain excluded
+```

--- a/server/src/session_chat_composer.rs
+++ b/server/src/session_chat_composer.rs
@@ -220,6 +220,7 @@ got to them:
     custom agent were not measured. An unmeasured guess would be the same
     failure as pi's, so they read Unknown until someone captures them.
 */
+/// Return the measured composer chrome signature for a normalized agent id.
 fn composer_signature(agent: &str) -> Option<ComposerSignature> {
     Some(match agent {
         // `❯` between two full-width rules, statusline below.
@@ -474,6 +475,7 @@ codex transcript echoes each submitted prompt with the same `›` the composer
 draws — the lowest match is the live one. Both would answer "ready", so this is
 about picking the honest witness rather than about correctness of the verdict.
 */
+/// Whether the captured non-blank lines contain the requested composer shape.
 fn signature_matches(signature: ComposerSignature, lines: &[String]) -> bool {
     match signature {
         // In both sandwiches the BOTTOM rule stays strict (it is always solid

--- a/server/src/session_chat_composer.rs
+++ b/server/src/session_chat_composer.rs
@@ -161,6 +161,15 @@ enum ComposerSignature {
     /// composer is found by the sandwich and never by counting rows up from the
     /// bottom.
     RuleSandwich { marker: char },
+    /// hermes's rule sandwich. Same frame, but the marker line carries the
+    /// active profile name when one is selected: `hermes -p harry` prompts
+    /// with `harry ❯`, the default profile with a bare `❯` (its
+    /// `_get_tui_prompt_symbols` prepends any non-default profile). The
+    /// 2026-08-29 measurement ran the default profile and missed this, so
+    /// every profiled session read NotReady with its composer on screen.
+    /// At most ONE leading word is accepted: profile names are single CLI
+    /// tokens, and prose that happens to contain the marker has more.
+    ProfiledRuleSandwich { marker: char },
     /// An empty input row between two full-width `─` rules. Blank rows are
     /// removed before matching, so the two rules are adjacent in `lines`.
     EmptyRuleSandwich,
@@ -217,9 +226,10 @@ fn composer_signature(agent: &str) -> Option<ComposerSignature> {
         "claude" | "openclaude" => ComposerSignature::RuleSandwich { marker: '\u{276f}' },
         // Identical shape to claude's, measured independently.
         "copilot" => ComposerSignature::RuleSandwich { marker: '\u{276f}' },
-        // `❯` between two full-width rules, statusline above the top rule
-        // (measured 2026-08-29, Hermes Agent v0.20.4).
-        "hermes-agent" => ComposerSignature::RuleSandwich { marker: '\u{276f}' },
+        // `❯` (or `<profile> ❯`) between two full-width rules, statusline
+        // above the top rule (measured 2026-08-29, Hermes Agent v0.20.4;
+        // profile prefix confirmed against v0.20.5 source on 2026-08-30).
+        "hermes-agent" => ComposerSignature::ProfiledRuleSandwich { marker: '\u{276f}' },
         // `› ` with no frame.
         "codex" => ComposerSignature::BareMarker { marker: '\u{203a}' },
         // Empty row bounded by two full-width rules, statusline below.
@@ -426,6 +436,24 @@ fn is_marker_line(line: &str, marker: char) -> bool {
     !is_numbered_option(rest)
 }
 
+/// The marker test that admits hermes's profile prefix: `harry ❯ hi` matches,
+/// `❯ hi` matches, and anything with two or more words before the marker is
+/// prose quoting the glyph rather than a prompt.
+fn is_profiled_marker_line(line: &str, marker: char) -> bool {
+    if is_marker_line(line, marker) {
+        return true;
+    }
+    let trimmed = line.trim();
+    let mut words = trimmed.splitn(2, char::is_whitespace);
+    let Some(_profile) = words.next().filter(|word| !word.is_empty()) else {
+        return false;
+    };
+    words
+        .next()
+        .map(str::trim_start)
+        .is_some_and(|tail| is_marker_line(tail, marker))
+}
+
 /// The same test for a row drawn inside a `│ … │` box: the marker follows the
 /// left border rather than the start of the line.
 fn is_boxed_marker_line(line: &str, marker: char) -> bool {
@@ -455,6 +483,13 @@ fn signature_matches(signature: ComposerSignature, lines: &[String]) -> bool {
             (0..lines.len().saturating_sub(2)).rev().any(|index| {
                 is_horizontal_rule(&lines[index + 2])
                     && is_marker_line(&lines[index + 1], marker)
+                    && is_titled_horizontal_rule(&lines[index])
+            })
+        }
+        ComposerSignature::ProfiledRuleSandwich { marker } => {
+            (0..lines.len().saturating_sub(2)).rev().any(|index| {
+                is_horizontal_rule(&lines[index + 2])
+                    && is_profiled_marker_line(&lines[index + 1], marker)
                     && is_titled_horizontal_rule(&lines[index])
             })
         }


### PR DESCRIPTION
## What was failing

Chat sends to a Hermes Agent session launched with a profile (`hermes -p harry`) were always refused with *"The hermes-agent input box is not on screen yet"* — with the input box plainly visible in the terminal.

## Why

Hermes prepends the active profile name to its prompt symbol for any non-default profile: the composer line is `harry ❯`, not `❯` (its `_get_tui_prompt_symbols` does this; confirmed against v0.20.5 source). The `RuleSandwich` signature was measured on the default profile, and `is_marker_line` requires the line to **start** with the marker — so profiled sessions never matched.

## Fix

A `ProfiledRuleSandwich` variant for hermes-agent: same top-rule / marker / bottom-rule frame, but the marker line may carry **at most one leading word** (the profile name). Two-plus words before the glyph is prose and still rejected, and the numbered-option dialog filter still applies.

Verified live: sends from Chat View now deliver into a `-p harry` session's composer and submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU3indbyE1upH8vfsXh3L4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes session detection when rule-sandwich messages include an optional profile name before the marker.
  * Hermes sessions now recognize both standard and profile-prefixed marker lines.
  * Messages can be delivered successfully to Hermes sessions using named profiles.
  * Prompt-like prose and numbered option dialogs continue to be excluded from composer detection.

* **Documentation**
  * Added coverage describing profile-aware Hermes composer detection and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->