### PR TITLE
fix(board): start-work puts the worker in the named project, not the newest one

### DIFF
--- a/docs/2026-08-31/pr-116-board-start-work-project-selection.md
+++ b/docs/2026-08-31/pr-116-board-start-work-project-selection.md
@@ -13,7 +13,8 @@ Feature: Start Project Board work in the intended project
     Given several projects share one global Beads board
     When the caller selects a project by path or project ID
     Then Ghostex starts or reuses the worker only in that selected project
-    When the caller does not select a project
-    Then Ghostex uses the project that owns the shared Beads directory
-    And repeated dispatches remain idempotent without crossing explicit project boundaries
+    When the caller does not select a project and no usable worker is already linked
+    Then Ghostex creates the worker in the project that owns the shared Beads directory
+    But an existing usable worker may be reused from any project sharing that board
+    And explicit project selections never reuse a worker across project boundaries
 ```

--- a/docs/2026-08-31/pr-116-board-start-work-project-selection.md
+++ b/docs/2026-08-31/pr-116-board-start-work-project-selection.md
@@ -1,0 +1,19 @@
+# PR #116: Project-aware board worker dispatch
+
+```gherkin
+Feature: Start Project Board work in the intended project
+
+  Scenario: Current behavior before this change
+    Given several projects share one global Beads board
+    When a user or automation starts work without a project selector
+    Then the worker can open in whichever project was updated most recently
+    And an explicit project request can still reuse a linked worker from a sibling project
+
+  Scenario: Expected behavior after this change
+    Given several projects share one global Beads board
+    When the caller selects a project by path or project ID
+    Then Ghostex starts or reuses the worker only in that selected project
+    When the caller does not select a project
+    Then Ghostex uses the project that owns the shared Beads directory
+    And repeated dispatches remain idempotent without crossing explicit project boundaries
+```

--- a/server/src/board_start_work.rs
+++ b/server/src/board_start_work.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -278,9 +277,12 @@ pub fn associate_board_session(
 /*
 Board-project resolution mirrors the shared-mount link-store contract in
 packages/shared/bead-conversation-links.ts: rows that mount the same Beads directory
-(projectBoardConfig.beadsDirectory, else the project path) are one board. An
-explicit projectId wins; otherwise every distinct store is probed with
-`bd show` and the bead must live on exactly one of them.
+(projectBoardConfig.beadsDirectory, else the global default, else the project path)
+are one board. An explicit projectId or projectPath wins - that is how a dispatcher
+puts the worker in the repo the card is about. Otherwise every distinct store is
+probed with `bd show` and the bead must live on exactly one of them; a store that
+several projects mount is represented by the project whose own path IS the store,
+never by whichever sibling happens to sort first.
 */
 fn resolve_board_project_and_bead(
     projects: &[Value],
@@ -299,36 +301,56 @@ fn resolve_board_project_and_bead(
             .ok_or_else(|| {
                 DomainStateError::not_found(format!("Project {project_id} does not exist."))
             })?;
-        let store = link_store_key(&project, global_beads_directory);
-        if store.is_empty() {
-            return Err(DomainStateError::bad_request(format!(
-                "Project {project_id} has no Beads directory."
-            )));
-        }
-        let bead = run_bd_show(bd_executable_path, &store, bead_id)?.ok_or_else(|| {
-            DomainStateError::not_found(format!(
-                "Bead {bead_id} was not found on the {project_id} project board."
-            ))
-        })?;
-        return Ok((project, bead));
+        return resolve_bead_on_project(
+            project,
+            &project_id,
+            bead_id,
+            bd_executable_path,
+            global_beads_directory,
+        );
     }
-    let mut matches: Vec<(Value, Value)> = Vec::new();
-    let mut probed: HashMap<String, bool> = HashMap::new();
+    if let Some(project_path) = read_trimmed(params, "projectPath") {
+        let wanted = normalize_project_path(&project_path);
+        let project = projects
+            .iter()
+            .find(|candidate| normalized_project_path(candidate).as_deref() == Some(wanted.as_str()))
+            .cloned()
+            .ok_or_else(|| {
+                DomainStateError::not_found(format!(
+                    "No project is registered at {project_path}. Add it with `ghostex add-project` first."
+                ))
+            })?;
+        return resolve_bead_on_project(
+            project,
+            &project_path,
+            bead_id,
+            bd_executable_path,
+            global_beads_directory,
+        );
+    }
+    let mut stores: Vec<(String, Value)> = Vec::new();
     for project in projects {
         let store = link_store_key(project, global_beads_directory);
-        if store.is_empty() || probed.contains_key(&store) {
+        if store.is_empty() {
             continue;
         }
+        match stores.iter_mut().find(|(key, _)| *key == store) {
+            Some((_, chosen)) => {
+                if !project_owns_store(chosen, &store) && project_owns_store(project, &store) {
+                    *chosen = project.clone();
+                }
+            }
+            None => stores.push((store, project.clone())),
+        }
+    }
+    let mut matches: Vec<(Value, Value)> = Vec::new();
+    for (store, project) in stores {
         if !Path::new(&store).join(".beads").is_dir() {
-            probed.insert(store, false);
             continue;
         }
-        let bead = run_bd_show(bd_executable_path, &store, bead_id)?;
-        let found = bead.is_some();
-        if let Some(bead) = bead {
-            matches.push((project.clone(), bead));
+        if let Some(bead) = run_bd_show(bd_executable_path, &store, bead_id)? {
+            matches.push((project, bead));
         }
-        probed.insert(store, found);
     }
     match matches.len() {
         0 => Err(DomainStateError::not_found(format!(
@@ -336,9 +358,48 @@ fn resolve_board_project_and_bead(
         ))),
         1 => Ok(matches.remove(0)),
         _ => Err(DomainStateError::bad_request(format!(
-            "Bead {bead_id} exists on multiple project boards. Pass --project-id to choose one."
+            "Bead {bead_id} exists on multiple project boards. Pass --project-path or --project-id to choose one."
         ))),
     }
+}
+
+/// Resolve `bead_id` on the board of one explicitly named project.
+fn resolve_bead_on_project(
+    project: Value,
+    project_label: &str,
+    bead_id: &str,
+    bd_executable_path: &str,
+    global_beads_directory: &str,
+) -> Result<(Value, Value), DomainStateError> {
+    let store = link_store_key(&project, global_beads_directory);
+    if store.is_empty() {
+        return Err(DomainStateError::bad_request(format!(
+            "Project {project_label} has no Beads directory."
+        )));
+    }
+    let bead = run_bd_show(bd_executable_path, &store, bead_id)?.ok_or_else(|| {
+        DomainStateError::not_found(format!(
+            "Bead {bead_id} was not found on the {project_label} project board."
+        ))
+    })?;
+    Ok((project, bead))
+}
+
+/// A project's registered path, normalized the way `link_store_key` normalizes stores.
+fn normalized_project_path(project: &Value) -> Option<String> {
+    project
+        .get("path")
+        .and_then(Value::as_str)
+        .map(normalize_project_path)
+}
+
+fn normalize_project_path(path: &str) -> String {
+    path.trim().trim_end_matches('/').to_string()
+}
+
+/// Whether `project` is the store itself rather than a sibling that mounts it.
+fn project_owns_store(project: &Value, store: &str) -> bool {
+    normalized_project_path(project).as_deref() == Some(store)
 }
 
 fn run_bd_show(

--- a/server/src/board_start_work.rs
+++ b/server/src/board_start_work.rs
@@ -59,14 +59,24 @@ pub fn start_board_work(
         &global_beads_directory,
     )?;
     let board_project_id = project_id_of(&board_project)?;
-    let store_projects =
-        select_link_store_projects(&board_project, &projects, &global_beads_directory);
+    let has_explicit_project_selector = read_trimmed(params, "projectId").is_some()
+        || read_trimmed(params, "projectPath").is_some();
+    let store_projects = if has_explicit_project_selector {
+        vec![board_project.clone()]
+    } else {
+        select_link_store_projects(&board_project, &projects, &global_beads_directory)
+    };
 
     // Redline 2: any usable linked conversation — live, sleeping, or
     // restorable — is an idempotent success, never a second worker.
-    if let Some((existing_project_id, existing_session_id)) =
-        find_usable_linked_session(repository, db, server_id, &store_projects, &bead_id)?
-    {
+    if let Some((existing_project_id, existing_session_id)) = find_usable_linked_session(
+        repository,
+        db,
+        server_id,
+        &store_projects,
+        &bead_id,
+        has_explicit_project_selector.then_some(board_project_id.as_str()),
+    )? {
         return Ok(StartBoardWorkOutcome {
             created: false,
             created_session: None,
@@ -284,6 +294,7 @@ probed with `bd show` and the bead must live on exactly one of them; a store tha
 several projects mount is represented by the project whose own path IS the store,
 never by whichever sibling happens to sort first.
 */
+/// Resolve the requested bead and the project that should own its worker.
 fn resolve_board_project_and_bead(
     projects: &[Value],
     params: &Map<String, Value>,
@@ -393,6 +404,7 @@ fn normalized_project_path(project: &Value) -> Option<String> {
         .map(normalize_project_path)
 }
 
+/// Normalize a registered project path without resolving symlinks.
 fn normalize_project_path(path: &str) -> String {
     path.trim().trim_end_matches('/').to_string()
 }
@@ -768,10 +780,10 @@ fn percent_decode(value: &str) -> String {
 
 /*
 Redline 2's "usable" definition, evaluated daemon-side: a linked conversation
-whose session row still exists (live or sleeping, in any project) is reused
-directly; a link whose row is gone is still usable when the daemon's
-previous-session history can restore it — the same restore contract the board's
-resumable-link affordance reads.
+whose session row still exists (live or sleeping) is reused directly; a link
+whose row is gone is still usable when the daemon's previous-session history can
+restore it. Unqualified requests may reuse a worker from any project sharing the
+board, while an explicit selector restricts reuse to that selected project.
 */
 fn find_usable_linked_session(
     repository: &DomainRepository<'_>,
@@ -779,8 +791,12 @@ fn find_usable_linked_session(
     server_id: &str,
     store_projects: &[Value],
     bead_id: &str,
+    required_project_id: Option<&str>,
 ) -> Result<Option<(String, String)>, DomainStateError> {
     for reference in read_active_bead_links(store_projects, bead_id) {
+        if required_project_id.is_some_and(|project_id| reference.project_id != project_id) {
+            continue;
+        }
         if repository
             .get_session(&reference.project_id, &reference.session_id)?
             .is_some()

--- a/server/src/ghostex_cli/board.rs
+++ b/server/src/ghostex_cli/board.rs
@@ -34,6 +34,7 @@ pub fn board_command(args: &[String]) -> CliResult<()> {
     }
 }
 
+/// Parse and dispatch `board start-work` through gxserver.
 fn start_work_command(args: &[String]) -> CliResult<()> {
     if matches!(
         args.first().map(String::as_str),

--- a/server/src/ghostex_cli/board.rs
+++ b/server/src/ghostex_cli/board.rs
@@ -73,6 +73,17 @@ fn start_work_command(args: &[String]) -> CliResult<()> {
     {
         payload.insert("projectId".to_string(), Value::String(project_id));
     }
+    if let Some(project_path) = parsed
+        .flags
+        .text("projectPath")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        payload.insert(
+            "projectPath".to_string(),
+            Value::String(absolute_project_path(&project_path)),
+        );
+    }
     let result = call_gxserver_rpc(
         "/api/startBoardWork",
         &Value::Object(payload),
@@ -83,6 +94,15 @@ fn start_work_command(args: &[String]) -> CliResult<()> {
         crate::ghostex_cli::set_exit_code(1);
     }
     Ok(())
+}
+
+/// `--project-path` the way gxserver registers project paths: absolute, resolved
+/// against the caller's cwd when given relative, and never canonicalized because a
+/// registered path may legitimately go through a symlink.
+fn absolute_project_path(path: &str) -> String {
+    std::path::absolute(path)
+        .map(|absolute| absolute.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string())
 }
 
 /*

--- a/server/src/ghostex_cli/usage.rs
+++ b/server/src/ghostex_cli/usage.rs
@@ -135,7 +135,7 @@ pub fn usage() -> String {
             "Create and start a configured agent session; --first-input-draft stages text in its input without sending",
         ),
         format_help_command(
-            "board start-work <bead-id> [--agent id] [--project-id id] [--json]",
+            "board start-work <bead-id> [--agent id] [--project-path path|--project-id id] [--json]",
             "Dispatch a Project Board bead: reuse its usable linked session or create the worker",
         ),
         format_help_command(
@@ -658,7 +658,7 @@ Inspect:
 pub fn board_usage() -> String {
     let commands = [
         format_help_command(
-            "board start-work <bead-id> [--agent id] [--project-id id] [--json]",
+            "board start-work <bead-id> [--agent id] [--project-path path|--project-id id] [--json]",
             "Dispatch a Project Board bead through gxserver",
         ),
         format_help_command(
@@ -676,7 +676,7 @@ pub fn board_usage() -> String {
         "Ghostex Project Board - dispatch bead work through gxserver
 
 Usage:
-  ghostex board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]
+  ghostex board start-work <bead-id> [--agent <agentId>] [--project-path <path>|--project-id <id>] [--json]
   ghostex board associate <bead-id> [--session-id <alias|id|title>] [--project-id <id>] [--json]
   gx board start-work <bead-id>
   gx board associate <bead-id>
@@ -691,6 +691,10 @@ Behavior:
   is returned as {{ \"projectId\": ..., \"sessionId\": ..., \"created\": false }} instead of creating a second worker.
   Without --agent, the bead assignee is matched case-insensitively against configured agents,
   falling back to the default prompt agent.
+  Pass --project-path <repo> (or --project-id) to start the worker in the project the card is
+  about; the bead is still looked up on that project's board. Without either, the worker starts
+  in the project whose own path is the Beads directory - the board itself - never in a sibling
+  project that merely mounts the same board.
 
   associate is for an agent that was already asked to work a bead - by hand, or in a session
   someone else started - rather than dispatched from the card. It creates no session: it links the

--- a/skills/ghostex-manage-beads/SKILL.md
+++ b/skills/ghostex-manage-beads/SKILL.md
@@ -90,12 +90,15 @@ not for an agent that is already doing the bead's work.
 To dispatch a bead through Ghostex, run:
 
 ```bash
-gx board start-work <bead-id> [--agent <agentId>] [--project-id <id>] [--json]
+gx board start-work <bead-id> [--agent <agentId>] [--project-path <path>|--project-id <id>] [--json]
 ```
 
 - **The command is the dispatch.** It creates and starts the visible worker
-  session in the bead's board project, sends the canonical bead work prompt,
-  and links the conversation to the card. Call it _instead of_ launching a
+  session, sends the canonical bead work prompt, and links the conversation to
+  the card. Pass `--project-path <repo>` (or `--project-id`) so the worker
+  starts in the project the card is about; without it the worker starts in the
+  project whose own path is the Beads directory — the board itself — never in
+  a sibling project that merely mounts the same board. Call it _instead of_ launching a
   worker session yourself — it is not a preparation step before separately
   starting another worker. Calling it and then starting your own worker puts
   two workers on the same card.


### PR DESCRIPTION
## Problem
`ghostex board start-work <bead>` without `--project-id` created the worker in whichever sidebar project was touched most recently. With a global Beads directory (Settings → Global Defaults) every project resolves to the same board store; `resolve_board_project_and_bead` deduped by store and kept the first project from `list_projects()`, which is `ORDER BY updatedAt DESC`. The Kanban "Start work" button never misfired because it passes the clicked project's id — only CLI/automation dispatch did.

## Fix
- A store several projects mount is represented by the project whose own path *is* the Beads directory (the board itself), never by whichever sibling sorts first.
- New `--project-path <repo>` on `board start-work` (server param `projectPath`, accepted alongside `projectId`) so dispatchers can name the repo the card is about without looking up an opaque project id. Relative paths resolve against the caller's cwd; nothing is canonicalized, so registered symlinked paths still match.
- Help text and the bundled `ghostex-manage-beads` skill describe the rule.

## Verification
- `cd server && cargo test --lib board_start_work` → 10 passed, 0 failed.
- `cargo build --bins` → exit 0; the built `ghostex board --help` shows the new flag.
- Live, on an 83-project sidebar with a global Beads directory:
  - `gx board start-work <bead> --agent claude --project-path /Users/sven/code/oss/Ghostex --json` → `"projectId": "P1ivv"` (the Ghostex project).
  - `gx board start-work <bead> --agent claude --json` → `"projectId": "P3mjq"` (the board project); before this change it landed in the most-recently-updated project.

No tests added per repo policy. CHANGELOG untouched since it is written at release time — suggested Minor line: "`gx board start-work` gains `--project-path`, and a bare call starts the worker on the board project instead of the most recently touched one."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phc4WyZkX3MA33aKrAh2Aq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--project-path` to `board start-work` for selecting a project by path.
  * Relative project paths are resolved from the caller’s current directory.
  * Beads are looked up on the selected project’s board.

* **Bug Fixes**
  * Improved default project selection when multiple projects share a board.
  * Explicit project selections no longer reuse sessions from other projects.
  * Unqualified requests may reuse compatible sessions across shared-board projects.
  * Updated ambiguity guidance to recommend either project ID or project path.

* **Documentation**
  * Updated command help and usage documentation with the new option and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->