### PR TITLE
fix(desktop): render gpui-component's dialog layer so alert dialogs appear

### DIFF
--- a/apps/desktop/src/app/core.rs
+++ b/apps/desktop/src/app/core.rs
@@ -2247,6 +2247,16 @@ impl Render for GhostexGpuiApp {
                     }),
             )
             .child(self.render_gpui_status_pet_presentation(cx))
+            /*
+            gpui-component's `Root` does not draw its dialog layer; the app view
+            must render it. Without this every `open_alert_dialog` (the paste
+            protection confirmation, the terminal close confirmation) still
+            pushed an active dialog and moved keyboard focus onto it, but drew
+            nothing: the pending paste was silently held, Cmd+V and typing
+            went dead until focus moved elsewhere. Last child so it paints
+            above the workspace.
+            */
+            .children(gpui_component::Root::render_dialog_layer(window, cx))
             .into_any_element();
 
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Problem

Pasting text that contains a newline into a freshly created terminal (before the shell has enabled bracketed paste) sometimes did nothing: Cmd+V and right-click Paste were dead, and pasting only worked again after dragging the tab to split it. Not reproducible every time.

## Cause

Paste protection correctly asked for confirmation via `open_alert_dialog`, but gpui-component's `Root` does not draw its dialog layer. The app view has to render `Root::render_dialog_layer`, and Ghostex never did. So the dialog was pushed and took keyboard focus, but was never drawn. The pending paste was held invisibly and the terminal went dead until focus moved elsewhere. Splitting re-focused the terminal, and by then the shell had bracketed paste on, so no confirmation was needed.

Diagnosed from `gpui-terminal-focus-debug.log`: paste accepted with a pending confirmation, terminal loses focus 3 ms later, the next two Cmd+V presses reach only the AppKit menu route.

## Fix

Render `gpui_component::Root::render_dialog_layer(window, cx)` as the last child of the root view in `apps/desktop/src/app/core.rs`. One hunk, 10 lines.

This also un-breaks the terminal close-confirm dialog, which used the same invisible path.

## Verified

- `cargo check -p ghostex-gpui` passes.
- Tested in the running app: the "Paste potentially unsafe text?" dialog now appears; Enter pastes, Esc cancels; the existing Settings → Terminal Behavior → "Paste protection" toggle bypasses it.

## Not in this PR

`push_notification` toasts in workspace reconcile are also never rendered for the same reason (`render_notification_layer` is not called). Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSCzKUVAYQye82PCXceAx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert dialogs now appear correctly above the workspace.
  * Paste protection and terminal close confirmations are visible when triggered, allowing you to respond as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->