### PR TITLE
fix(chat): stop bang commands from sticking in composing

### DIFF
--- a/packages/core-ui/chat/session-chat-send-classification.test.ts
+++ b/packages/core-ui/chat/session-chat-send-classification.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { classifySessionChatSend } from './session-chat-send-classification';
+
+describe('session chat send classification', () => {
+  test('line-leading bang input is a local command, not an agent prompt', () => {
+    expect(classifySessionChatSend('! printf BANG_OK')).toBe('local-command');
+    expect(classifySessionChatSend(' ! printf BANG_OK')).toBe('chat');
+  });
+});

--- a/packages/core-ui/chat/session-chat-send-classification.ts
+++ b/packages/core-ui/chat/session-chat-send-classification.ts
@@ -2,7 +2,7 @@
 // firstToken is NOT trimmed — a leading space means prose, because the agent
 // TUIs only treat LINE-LEADING tokens as commands.
 
-export type SessionChatSendClassification = 'chat' | 'command' | 'unknown-token';
+export type SessionChatSendClassification = 'chat' | 'command' | 'local-command' | 'unknown-token';
 
 /**
  * Default verified catalog used for local "Ran /x" markers. Only catalog
@@ -22,6 +22,9 @@ export function classifySessionChatSend(
   }
   if (firstToken.startsWith('/')) {
     return 'unknown-token';
+  }
+  if (firstToken.startsWith('!')) {
+    return 'local-command';
   }
   if (skillPrefix === '$' && firstToken.startsWith('$')) {
     // `$` is Codex grammar only; elsewhere `$PATH` is prose.


### PR DESCRIPTION
## Summary

- classify line-leading ! input as a local command instead of an agent prompt
- let the authoritative Local command transcript rows own display without an optimistic pending turn
- preserve leading-whitespace ! text as ordinary chat and add regression coverage

## Root cause

Claude records shell escapes as bash-input rows without the leading !. Chat previously classified the submitted text as an ordinary prompt, so its optimistic pending entry could never match the authoritative transcript and kept Composing active after the command finished.

## Verification

- bunx vitest run packages/core-ui/chat/session-chat-send-classification.test.ts packages/core-ui/chat/session-chat-pending.test.ts packages/core-ui/chat/session-chat-session-options.test.ts (45 passed)
- bun run typecheck
- bun run test (137 files, 1261 tests passed)
- bunx vite build --config apps/desktop/vite.config.ts
- independent code review: ready to merge, no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing messages beginning with `!` as local commands.

- **Bug Fixes**
  - Improved message classification so local commands are handled separately from regular chat messages.
  - Preserved chat classification for messages with leading spaces before `!`.

- **Tests**
  - Added coverage for local command and leading-space classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bang commands sticking in composing by classifying `!` input as local-command
> Adds a `local-command` case to the `SessionChatSendClassification` union and updates `classifySessionChatSend` to return it when the first untrimmed token starts with `!`. Inputs where `!` is preceded by whitespace still classify as chat input. A Vitest case in [session-chat-send-classification.test.ts](https://github.com/maddada/Ghostex/pull/120/files#diff-88ddb723e45447bf18e34708eab6313705bbf7cb877e55e35ff8b8f39bcbdfb9) covers both paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca99976.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->