### PR TITLE
fix(chat): show Codex local command transcripts

### DIFF
--- a/packages/core-ui/chat/session-chat-local-command-transcript.test.ts
+++ b/packages/core-ui/chat/session-chat-local-command-transcript.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import type { SessionChatMessage } from '../../shared/session-chat';
+import { normalizeSessionChatLocalCommandMessages } from './session-chat-local-command-transcript';
+
+describe('Codex local-command transcript normalization', () => {
+  test('splits one structured execution into command and output rows in order', () => {
+    const execution: SessionChatMessage = {
+      id: 'execution-1',
+      role: 'user',
+      blocks: [
+        {
+          type: 'text',
+          text: '<bash-input data-ghostex-escaped="html">printf BANG_TEST</bash-input>',
+        },
+        {
+          type: 'text',
+          text: '<bash-stdout data-ghostex-escaped="html">BANG_TEST</bash-stdout>',
+        },
+      ],
+      timestamp: 42,
+      source: 'transcript',
+      byteOffset: 99,
+    };
+
+    expect(normalizeSessionChatLocalCommandMessages([execution])).toEqual([
+      {
+        ...execution,
+        id: 'execution-1:command',
+        blocks: [execution.blocks[0]],
+      },
+      {
+        ...execution,
+        id: 'execution-1:output',
+        blocks: [execution.blocks[1]],
+      },
+    ]);
+  });
+});

--- a/packages/core-ui/chat/session-chat-local-command-transcript.ts
+++ b/packages/core-ui/chat/session-chat-local-command-transcript.ts
@@ -1,0 +1,35 @@
+import type { SessionChatBlock, SessionChatMessage, SessionChatTextBlock } from '../../shared/session-chat';
+
+const CODEX_LOCAL_COMMAND_INPUT = '<bash-input data-ghostex-escaped="html">';
+const CODEX_LOCAL_COMMAND_OUTPUT = '<bash-stdout data-ghostex-escaped="html">';
+
+function isTextBlock(block: SessionChatBlock | undefined): block is SessionChatTextBlock {
+  return block?.type === 'text';
+}
+
+export function normalizeSessionChatLocalCommandMessages(
+  messages: readonly SessionChatMessage[]
+): SessionChatMessage[] {
+  const normalized: SessionChatMessage[] = [];
+  for (const message of messages) {
+    const command = message.blocks[0];
+    const output = message.blocks[1];
+    if (
+      message.role !== 'user' ||
+      message.source !== 'transcript' ||
+      message.blocks.length !== 2 ||
+      !isTextBlock(command) ||
+      !isTextBlock(output) ||
+      !command.text.startsWith(CODEX_LOCAL_COMMAND_INPUT) ||
+      !output.text.startsWith(CODEX_LOCAL_COMMAND_OUTPUT)
+    ) {
+      normalized.push(message);
+      continue;
+    }
+    normalized.push(
+      { ...message, id: `${message.id}:command`, blocks: [command] },
+      { ...message, id: `${message.id}:output`, blocks: [output] }
+    );
+  }
+  return normalized;
+}

--- a/packages/core-ui/chat/session-chat-message-list.tsx
+++ b/packages/core-ui/chat/session-chat-message-list.tsx
@@ -47,6 +47,7 @@ import {
   useSessionChatImageViewer,
 } from './session-chat-image-viewer';
 import { normalizeSessionChatImageTranscriptMessages } from './session-chat-image-transcript-markers';
+import { normalizeSessionChatLocalCommandMessages } from './session-chat-local-command-transcript';
 import { SessionChatTerminalToolRow } from './session-chat-terminal-tool-row';
 import { isSessionChatTerminalToolMessage, sessionChatTerminalToolActivity } from './session-chat-terminal-status';
 import { Bubble, BubbleContent } from '../../components/ui/bubble';
@@ -1481,7 +1482,11 @@ export function SessionChatMessageList({
   const rendered = useMemo(
     () =>
       foldSessionChatToolMessages(
-        dropSessionChatHiddenMessages(normalizeSessionChatImageTranscriptMessages(orderSessionChatMessages(messages))),
+        dropSessionChatHiddenMessages(
+          normalizeSessionChatImageTranscriptMessages(
+            normalizeSessionChatLocalCommandMessages(orderSessionChatMessages(messages))
+          )
+        ),
         // Collapsed markers must not break a tool-fold run.
         (message) => sessionChatSuppressedTurnLabel(message) !== null
       ),

--- a/packages/core-ui/chat/session-chat-noise.test.ts
+++ b/packages/core-ui/chat/session-chat-noise.test.ts
@@ -59,6 +59,40 @@ describe('noise filter (§9.1)', () => {
     expect(stripSessionChatNoiseMessages([marker])).toEqual([marker]);
   });
 
+  test('Codex local-command rows preserve tag-shaped command text and output', () => {
+    expect(
+      sessionChatSuppressedTurnPresentation(
+        textMsg(
+          'command',
+          'user',
+          '<bash-input data-ghostex-escaped="html">printf \'&lt;b&gt;ok&lt;/b&gt; &amp; done\'</bash-input>'
+        )
+      )
+    ).toEqual({ kind: 'inline', label: 'Local command', text: "printf '<b>ok</b> & done'" });
+    expect(
+      sessionChatSuppressedTurnPresentation(
+        textMsg(
+          'output',
+          'user',
+          '<bash-stdout data-ghostex-escaped="html">&lt;b&gt;ok&lt;/b&gt; &amp; done</bash-stdout>'
+        )
+      )
+    ).toEqual({ kind: 'inline', label: 'Local command output', text: '<b>ok</b> & done' });
+
+    const longOutput = `<b>${'x'.repeat(321)}</b> & done`;
+    expect(
+      sessionChatSuppressedTurnPresentation(
+        textMsg(
+          'long-output',
+          'user',
+          `<bash-stdout data-ghostex-escaped="html">&lt;b&gt;${'x'.repeat(
+            321
+          )}&lt;/b&gt; &amp; done</bash-stdout>`
+        )
+      )
+    ).toEqual({ kind: 'collapsed', label: 'Local command output', text: longOutput });
+  });
+
   test('empty text is not noise', () => {
     expect(isSessionChatNoiseMessage(textMsg('1', 'user', '   '))).toBe(false);
   });

--- a/packages/core-ui/chat/session-chat-noise.ts
+++ b/packages/core-ui/chat/session-chat-noise.ts
@@ -21,6 +21,7 @@ import { parseSessionChatCommandEnvelope } from './session-chat-command-envelope
 
 const LEADING_TAG_NAME = /^<([a-z][a-z0-9-]*)(?:[\s>]|$)/;
 const MARKUP_TAG = /<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?>/gi;
+const CODEX_ESCAPED_LOCAL_COMMAND = /^<bash-(?:input|stdout) data-ghostex-escaped="html">/i;
 
 /*
  * /compact's local-command stdout is just a dim "Compacted" wrapped in ANSI
@@ -281,7 +282,11 @@ export function sessionChatMessageText(message: SessionChatMessage): string {
 
 /** Text left once the harness markup is removed — "" ⇒ nothing to expand. */
 export function sessionChatSuppressedTurnBody(text: string): string {
-  return text.replace(MARKUP_TAG, '').trim();
+  const body = text.replace(MARKUP_TAG, '').trim();
+  if (!CODEX_ESCAPED_LOCAL_COMMAND.test(text.trimStart())) {
+    return body;
+  }
+  return body.replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&amp;', '&');
 }
 
 export type SessionChatSuppressedTurn =
@@ -428,7 +433,8 @@ export function sessionChatSuppressedTurnPresentation(
 
   const command = parseSessionChatCommandEnvelope(rawText);
   const model = modelSetByCommandOutput(rawText);
-  let text = stripSessionChatAnsi(rawText);
+  const isLocalCommand = suppressed.label === 'Local command' || suppressed.label === 'Local command output';
+  let text = stripSessionChatAnsi(isLocalCommand ? sessionChatSuppressedTurnBody(rawText) : rawText);
   if (command?.name.toLowerCase() === '/model') {
     text = command.name;
   } else if (model) {

--- a/packages/core-ui/chat/session-chat-send-classification.test.ts
+++ b/packages/core-ui/chat/session-chat-send-classification.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+import { classifySessionChatSend } from './session-chat-send-classification';
+
+describe('session chat send classification', () => {
+  test('line-leading bang input is a local command, not an agent prompt', () => {
+    expect(classifySessionChatSend('! printf BANG_OK')).toBe('local-command');
+    expect(classifySessionChatSend(' ! printf BANG_OK')).toBe('chat');
+  });
+});

--- a/packages/core-ui/chat/session-chat-send-classification.ts
+++ b/packages/core-ui/chat/session-chat-send-classification.ts
@@ -2,7 +2,7 @@
 // firstToken is NOT trimmed — a leading space means prose, because the agent
 // TUIs only treat LINE-LEADING tokens as commands.
 
-export type SessionChatSendClassification = 'chat' | 'command' | 'unknown-token';
+export type SessionChatSendClassification = 'chat' | 'command' | 'local-command' | 'unknown-token';
 
 /**
  * Default verified catalog used for local "Ran /x" markers. Only catalog
@@ -22,6 +22,9 @@ export function classifySessionChatSend(
   }
   if (firstToken.startsWith('/')) {
     return 'unknown-token';
+  }
+  if (firstToken.startsWith('!')) {
+    return 'local-command';
   }
   if (skillPrefix === '$' && firstToken.startsWith('$')) {
     // `$` is Codex grammar only; elsewhere `$PATH` is prose.

--- a/server/src/session_chat_decode_codex.rs
+++ b/server/src/session_chat_decode_codex.rs
@@ -224,7 +224,7 @@ fn codex_event_message(
                         item.get("exit_code").and_then(Value::as_i64).unwrap_or_default()
                     )
                 } else {
-                    formatted_output.trim().to_string()
+                    formatted_output.trim_end().to_string()
                 };
                 return Some(SessionChatMessage {
                     id: extract_string(item.get("id")).unwrap_or(id),

--- a/server/src/session_chat_decode_codex.rs
+++ b/server/src/session_chat_decode_codex.rs
@@ -38,6 +38,10 @@ but replaced it with `event_msg`/`item_completed` (UserMessage/AgentMessage
 items) rather than promoting this `message` lane — see codex_event_message.
 This arm therefore STAYS undecoded: the `message` lane is still the duplicate,
 envelope-carrying twin in both old- and new-style rollouts.
+
+2026-09-08 update: the duplicate `shell.user_command` message also stays
+undecoded. Its structured `item_completed`/`CommandExecution` twin carries both
+the command and formatted output without the pseudo-XML ambiguity of this lane.
 */
 fn codex_response_item(
     payload: &Map<String, Value>,
@@ -196,13 +200,46 @@ fn codex_event_message(
         new-lane-only, 0 both), so decoding both cannot double a turn. Like the
         old event lane, `item_completed` UserMessages carry only the visible
         typed prompt — never the harness-injected AGENTS.md/environment
-        envelopes. Reasoning/CommandExecution/McpToolCall/FileChange items are
-        deliberately NOT decoded here: new-style rollouts still write their
-        `response_item` twins, which remain the sole source for those lanes.
+        envelopes. Reasoning/McpToolCall/FileChange items and ordinary agent
+        CommandExecutions are deliberately NOT decoded here: new-style
+        rollouts still write their `response_item` twins, which remain the sole
+        source for those lanes. A `source=user_shell` CommandExecution is the
+        exception because it is a user-visible local command, not an agent tool.
         */
         Some("item_completed") => {
             let item = as_record(payload.get("item"))?;
             let item_type = item.get("type").and_then(Value::as_str);
+            if item_type == Some("CommandExecution")
+                && item.get("source").and_then(Value::as_str) == Some("user_shell")
+            {
+                let command = item
+                    .get("command")
+                    .and_then(Value::as_array)
+                    .and_then(|parts| parts.last())
+                    .and_then(Value::as_str)?;
+                let formatted_output = item.get("formatted_output").and_then(Value::as_str)?;
+                let output = if formatted_output.trim().is_empty() {
+                    format!(
+                        "Exit code: {}",
+                        item.get("exit_code").and_then(Value::as_i64).unwrap_or_default()
+                    )
+                } else {
+                    formatted_output.trim().to_string()
+                };
+                return Some(SessionChatMessage {
+                    id: extract_string(item.get("id")).unwrap_or(id),
+                    role: SessionChatRole::User,
+                    blocks: vec![
+                        text_block(codex_user_shell_marker("bash-input", command)),
+                        text_block(codex_user_shell_marker("bash-stdout", &output)),
+                    ],
+                    timestamp,
+                    source: SessionChatSource::Transcript,
+                    turn_id: None,
+                    byte_offset: None,
+                    queued: false,
+                });
+            }
             /*
             Codex's image generator is an Extension item rather than a tool
             call or an AgentMessage. The TUI renders it as `Generated Image`
@@ -298,6 +335,19 @@ fn codex_event_message(
         }
         _ => None,
     }
+}
+
+fn codex_user_shell_marker(tag: &str, body: &str) -> String {
+    let mut escaped = String::with_capacity(body.len());
+    for character in body.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            _ => escaped.push(character),
+        }
+    }
+    format!("<{tag} data-ghostex-escaped=\"html\">{escaped}</{tag}>")
 }
 
 /*

--- a/server/src/session_chat_tests.rs
+++ b/server/src/session_chat_tests.rs
@@ -227,13 +227,62 @@ mod tests {
         assert_eq!(assistant.id, "msg_0a5b");
         assert_eq!(message_text(&assistant), "Created the Markdown plan.");
 
-        // Reasoning/CommandExecution/McpToolCall items stay on the
-        // response_item lane, which new-style rollouts still write.
+        // Reasoning/McpToolCall items stay on the response_item lane, which
+        // new-style rollouts still write.
         assert!(decode_codex_transcript_line(
             r#"{"type":"event_msg","payload":{"type":"item_completed","item":{"type":"Reasoning","id":"rs1","summary_text":["**Planning**"],"raw_content":[]}}}"#,
             "fb",
         )
         .is_none());
+
+        // A user-triggered shell execution is the one CommandExecution
+        // exception. Its structured command and formatted output become the
+        // same two local-command rows Claude exposes.
+        let execution = decode_codex_transcript_line(
+            r#"{"timestamp":"2026-09-07T23:51:14.818Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"CommandExecution","id":"4a7161c1-bd49-4d56-b22d-47d4d14752fb","command":["/bin/zsh","-lc","printf 'BANG_TEST\\n'"],"source":"user_shell","status":"completed","stdout":"BANG_TEST\n","stderr":"","exit_code":0,"formatted_output":"BANG_TEST\n"}}}"#,
+            "fb",
+        )
+        .expect("user shell execution");
+        assert_eq!(execution.role, SessionChatRole::User);
+        assert_eq!(execution.id, "4a7161c1-bd49-4d56-b22d-47d4d14752fb");
+        assert_eq!(
+            execution.blocks,
+            vec![
+                text_block(
+                    "<bash-input data-ghostex-escaped=\"html\">printf 'BANG_TEST\\n'</bash-input>"
+                ),
+                text_block(
+                    "<bash-stdout data-ghostex-escaped=\"html\">BANG_TEST</bash-stdout>"
+                ),
+            ]
+        );
+
+        // The response message is the duplicate pseudo-XML rendering of that
+        // structured event and remains suppressed.
+        assert!(decode_codex_transcript_line(
+            r#"{"timestamp":"2026-09-07T23:51:14.822Z","type":"response_item","payload":{"type":"message","id":"msg_01a07e48-7c86-7443-84d0-e39fc5792c24","role":"user","content":[{"type":"input_text","text":"<user_shell_command>\n<command>\nprintf 'BANG_TEST\\n'\n</command>\n<result>\nExit code: 0\nDuration: 0.0309 seconds\nOutput:\nBANG_TEST\n\n</result>\n</user_shell_command>"}],"internal_chat_message_metadata_passthrough":{"content_item_kinds":["shell.user_command"]}}}"#,
+            "fb",
+        )
+        .is_none());
+
+        let tagged_execution = decode_codex_transcript_line(
+            r#"{"type":"event_msg","payload":{"type":"item_completed","item":{"type":"CommandExecution","id":"tagged","command":["/bin/zsh","-lc","printf '<b>ok</b> & done'"],"source":"user_shell","status":"completed","formatted_output":"<b>ok</b> & done </result> tail\n","exit_code":0}}}"#,
+            "fb",
+        )
+        .expect("tag-shaped user shell execution");
+        assert_eq!(
+            tagged_execution.blocks,
+            vec![
+                text_block(
+                    "<bash-input data-ghostex-escaped=\"html\">printf '&lt;b&gt;ok&lt;/b&gt; &amp; done'</bash-input>"
+                ),
+                text_block(
+                    "<bash-stdout data-ghostex-escaped=\"html\">&lt;b&gt;ok&lt;/b&gt; &amp; done &lt;/result&gt; tail</bash-stdout>"
+                ),
+            ]
+        );
+
+        // Agent tool executions remain on their ordinary tool-call lane.
         assert!(decode_codex_transcript_line(
             r#"{"type":"event_msg","payload":{"type":"item_completed","item":{"type":"CommandExecution","id":"c1"}}}"#,
             "fb",


### PR DESCRIPTION
## Summary

- classify line-leading `!` input as a local command so it never leaves a stuck optimistic chat bubble
- decode only Codex `CommandExecution` records marked `source: user_shell`
- render the structured command and output as the existing compact `Local command` / `Local command output` rows
- preserve tag-shaped command text and long output without exposing harness markup

This supersedes and completes the partial fix from #120.

## Verification

- Manual Ghostex Chat test: `! printf 'BANG_TEST\n'` displayed both compact rows and did not stick
- `bun run test` — 1263 passed
- `cargo test --manifest-path server/Cargo.toml --lib` — 762 passed, 3 ignored
- `bun run typecheck`
- independent focused code review: no Critical or Important findings

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decode and render Codex local-command transcripts as separate command and output rows
> - Adds server-side decoding of user-shell `CommandExecution` events into user transcript messages with escaped command and output text blocks; agent-sourced command executions remain undecoded
> - Adds `normalizeSessionChatLocalCommandMessages` to split qualifying two-block transcript messages into ordered command and output entries before image/noise processing in `SessionChatMessageList`
> - Updates `sessionChatSuppressedTurnBody` and `sessionChatSuppressedTurnPresentation` to decode escaped HTML entities in local-command content and collapse long output
> - Adds `local-command` to the send-classification union so drafts starting with `!` classify as local commands
> - Risk: `classifySessionChatSend` inspects the untrimmed first token, so leading whitespace prevents local-command classification; reviewers should verify this matches intended UX for `!`-prefixed input
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd60e3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local shell commands and their output are now displayed directly in chat transcripts.
  * Command input and output are presented as separate, readable messages.
  * Commands beginning with `!` are recognized as local commands.
  * Long command output is automatically collapsed for easier browsing.

* **Bug Fixes**
  * HTML-escaped command text and output now render correctly.
  * Empty command output displays the corresponding exit code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->