### PR TITLE
feat(chat): show slash commands sent from chat, with their output, after a reload

### DIFF
--- a/packages/core-ui/chat/session-chat-command-envelope.ts
+++ b/packages/core-ui/chat/session-chat-command-envelope.ts
@@ -7,9 +7,15 @@
 // transcript records must be converted back into readable user turns.
 
 import type { SessionChatMessage } from '../../shared/session-chat';
+import {
+  decodeSessionChatEscapedMarkup,
+  SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE,
+} from './session-chat-local-command-transcript';
 
-const COMMAND_NAME = /<command-name>([\s\S]*?)<\/command-name>/;
-const COMMAND_ARGS = /<command-args>([\s\S]*?)<\/command-args>/;
+// The optional attribute list is gxserver's replayed envelope (see
+// session-chat-local-command-transcript.ts): same tags, marked escaped.
+const COMMAND_NAME = /<command-name(?:\s[^>]*)?>([\s\S]*?)<\/command-name>/;
+const COMMAND_ARGS = /<command-args(?:\s[^>]*)?>([\s\S]*?)<\/command-args>/;
 
 export interface SessionChatCommandEnvelope {
   name: string;
@@ -26,7 +32,10 @@ export function parseSessionChatCommandEnvelope(text: string): SessionChatComman
   if (!name) {
     return null;
   }
-  return { args: COMMAND_ARGS.exec(trimmed)?.[1]?.trim() ?? '', name };
+  const decode = trimmed.includes(SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE)
+    ? decodeSessionChatEscapedMarkup
+    : (value: string): string => value;
+  return { args: decode(COMMAND_ARGS.exec(trimmed)?.[1]?.trim() ?? ''), name: decode(name) };
 }
 
 export function surfaceSkillInvocationUserTurns(

--- a/packages/core-ui/chat/session-chat-local-command-transcript.test.ts
+++ b/packages/core-ui/chat/session-chat-local-command-transcript.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from 'vitest';
 import type { SessionChatMessage } from '../../shared/session-chat';
-import { normalizeSessionChatLocalCommandMessages } from './session-chat-local-command-transcript';
+import { parseSessionChatCommandEnvelope } from './session-chat-command-envelope';
+import {
+  normalizeSessionChatLocalCommandMessages,
+  sessionChatLocalCommandTexts,
+} from './session-chat-local-command-transcript';
+import { isSessionChatCommandTurn, sessionChatSuppressedTurnPresentation } from './session-chat-noise';
+import {
+  retireSessionChatMarkersCoveredByLocalCommands,
+  sessionChatAppCommandsAsMessages,
+} from './session-chat-pending';
 
 describe('Codex local-command transcript normalization', () => {
   test('splits one structured execution into command and output rows in order', () => {
@@ -34,5 +43,135 @@ describe('Codex local-command transcript normalization', () => {
         blocks: [execution.blocks[1]],
       },
     ]);
+  });
+});
+
+describe('archived slash commands', () => {
+  const textMessage = (id: string, text: string): SessionChatMessage => ({
+    id,
+    role: 'user',
+    blocks: [{ type: 'text', text }],
+    timestamp: 1,
+    source: 'transcript',
+  });
+
+  test('replayed rows read as a slash command and its output', () => {
+    const [command, output] = sessionChatLocalCommandTexts(
+      '/rename pilot <game> work',
+      'Session renamed to: pilot <game> work'
+    );
+
+    // The same envelope gxserver replays from its archive, so both halves of
+    // the contract are asserted against one presentation.
+    expect(sessionChatSuppressedTurnPresentation(textMessage('c', command ?? ''))).toEqual({
+      kind: 'inline',
+      label: 'Slash command',
+      text: '/rename pilot <game> work',
+    });
+    expect(sessionChatSuppressedTurnPresentation(textMessage('o', output ?? ''))).toEqual({
+      kind: 'inline',
+      label: 'Local command output',
+      text: 'Session renamed to: pilot <game> work',
+    });
+  });
+
+  test('a command with no output replays as one row', () => {
+    expect(sessionChatLocalCommandTexts('/context')).toHaveLength(1);
+    expect(sessionChatLocalCommandTexts('/context', '')).toHaveLength(1);
+  });
+
+  test('the model command keeps its status pill', () => {
+    const [command] = sessionChatLocalCommandTexts('/model opus', 'Set model to Opus 5');
+    // Hidden: the output row owns the one user-facing result row.
+    expect(sessionChatSuppressedTurnPresentation(textMessage('m', command ?? ''))).toBeNull();
+    expect(parseSessionChatCommandEnvelope(command ?? '')).toEqual({ name: '/model', args: 'opus' });
+  });
+
+  test('the live acknowledgement renders as those rows and retires against the archive', () => {
+    const appCommand = {
+      id: 'a1',
+      command: '/rename pilot game work',
+      output: 'Session renamed to: pilot game work',
+      localCommand: true,
+      sentAt: '2026-09-10T00:00:00.000Z',
+    };
+
+    const live = sessionChatAppCommandsAsMessages([appCommand], []);
+    expect(live.map((message) => message.id)).toEqual([
+      'app-command-local:a1',
+      'app-command-local:a1:output',
+    ]);
+    expect(
+      live.map((message) => (message.blocks[0]?.type === 'text' ? message.blocks[0].text : ''))
+    ).toEqual(sessionChatLocalCommandTexts(appCommand.command, appCommand.output));
+
+    // Once the archived envelope reaches the messages, the live row IS that
+    // row: showing both would render one command twice.
+    const archived = textMessage('local-command:1-0', sessionChatLocalCommandTexts(appCommand.command)[0] ?? '');
+    expect(sessionChatAppCommandsAsMessages([appCommand], [archived])).toEqual([]);
+  });
+});
+
+describe('client markers for archived commands', () => {
+  const marker = (command: string): SessionChatMessage => ({
+    id: `command:${command}`,
+    role: 'user',
+    blocks: [{ type: 'text', text: command }],
+    timestamp: 5,
+    source: 'client',
+  });
+
+  test('retire once the live local-command row covers them', () => {
+    const live = [{ id: 'a1', command: '/context', localCommand: true, sentAt: '2026-09-10T00:00:00.000Z' }];
+    expect(
+      retireSessionChatMarkersCoveredByLocalCommands([marker('/context'), marker('/help')], live, []).map(
+        (message) => message.id
+      )
+    ).toEqual(['command:/help']);
+  });
+
+  test('retire once the archived envelope is replayed after a read', () => {
+    const archived: SessionChatMessage = {
+      id: 'local-command:1-0',
+      role: 'user',
+      blocks: [{ type: 'text', text: sessionChatLocalCommandTexts('/rename pilot game work')[0] ?? '' }],
+      timestamp: 4,
+      source: 'transcript',
+    };
+    expect(
+      retireSessionChatMarkersCoveredByLocalCommands([marker('/rename pilot game work')], [], [archived])
+    ).toEqual([]);
+  });
+
+  test("an agent's own envelope does not retire them", () => {
+    // Claude's `/compact` envelope is not ours; its marker retires on the
+    // compaction record instead.
+    const claudeEnvelope: SessionChatMessage = {
+      id: 't1',
+      role: 'user',
+      blocks: [{ type: 'text', text: '<command-name>/compact</command-name><command-args></command-args>' }],
+      timestamp: 4,
+      source: 'transcript',
+    };
+    expect(retireSessionChatMarkersCoveredByLocalCommands([marker('/compact')], [], [claudeEnvelope])).toHaveLength(1);
+  });
+});
+
+describe('command rows in the turn summary', () => {
+  const row = (text: string): SessionChatMessage => ({
+    id: text,
+    role: 'user',
+    blocks: [{ type: 'text', text }],
+    timestamp: 1,
+    source: 'transcript',
+  });
+
+  test('a visible slash command starts its own turn; its output and hidden commands do not', () => {
+    const [command, output] = sessionChatLocalCommandTexts('/rename x', 'Session renamed to: x');
+    expect(isSessionChatCommandTurn(row(command ?? ''))).toBe(true);
+    expect(isSessionChatCommandTurn(row(output ?? ''))).toBe(false);
+    // `/model` keeps its status pill and never becomes a turn of its own.
+    expect(isSessionChatCommandTurn(row(sessionChatLocalCommandTexts('/model opus')[0] ?? ''))).toBe(false);
+    expect(isSessionChatCommandTurn(row('an ordinary prompt'))).toBe(false);
   });
 });

--- a/packages/core-ui/chat/session-chat-local-command-transcript.ts
+++ b/packages/core-ui/chat/session-chat-local-command-transcript.ts
@@ -1,7 +1,50 @@
 import type { SessionChatBlock, SessionChatMessage, SessionChatTextBlock } from '../../shared/session-chat';
 
-const CODEX_LOCAL_COMMAND_INPUT = '<bash-input data-ghostex-escaped="html">';
-const CODEX_LOCAL_COMMAND_OUTPUT = '<bash-stdout data-ghostex-escaped="html">';
+/*
+CDXC:SessionChat 2026-09-10 WHY:
+The escaped-markup contract, one place for both halves of it. gxserver marks a
+harness marker whose payload it escaped (Codex's `!` commands, and the slash
+commands it archives and replays in session_chat_local_command.rs), because the
+reader strips markup out of these rows to find their text and would otherwise
+eat a command or an output that contains `<…>`. The attribute string has to
+match gxserver's `ESCAPED_MARKUP_ATTRIBUTE` byte for byte.
+*/
+export const SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE = 'data-ghostex-escaped="html"';
+
+const CODEX_LOCAL_COMMAND_INPUT = `<bash-input ${SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE}>`;
+const CODEX_LOCAL_COMMAND_OUTPUT = `<bash-stdout ${SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE}>`;
+
+/** The escaped marker gxserver writes, for a row this client synthesizes. */
+export function sessionChatEscapedMarker(tag: string, body: string): string {
+  const escaped = body.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  return `<${tag} ${SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE}>${escaped}</${tag}>`;
+}
+
+export function decodeSessionChatEscapedMarkup(text: string): string {
+  return text.replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&amp;', '&');
+}
+
+/**
+ * The two rows one slash command renders as: the command, and its output when
+ * the CLI printed any. Identical text to the rows gxserver replays from its
+ * archive, so the live row and the archived one are the same row twice.
+ */
+export function sessionChatLocalCommandTexts(command: string, output?: string): string[] {
+  const [name, ...rest] = command.trim().split(/\s+/);
+  const args = rest.join(' ');
+  // The space between the two markers is load-bearing: readers strip the
+  // markup to get the text, and without it the name and its arguments would
+  // become one word.
+  const texts = [
+    args.length > 0
+      ? `${sessionChatEscapedMarker('command-name', name ?? command)} ${sessionChatEscapedMarker('command-args', args)}`
+      : sessionChatEscapedMarker('command-name', name ?? command),
+  ];
+  if (output !== undefined && output.length > 0) {
+    texts.push(sessionChatEscapedMarker('local-command-stdout', output));
+  }
+  return texts;
+}
 
 function isTextBlock(block: SessionChatBlock | undefined): block is SessionChatTextBlock {
   return block?.type === 'text';

--- a/packages/core-ui/chat/session-chat-message-list.tsx
+++ b/packages/core-ui/chat/session-chat-message-list.tsx
@@ -91,6 +91,7 @@ import { SessionChatGoalCard } from './session-chat-goal-card';
 import { SessionChatAgentMessageCard, parseSessionChatAgentMessage } from './session-chat-agent-message-card';
 import {
   dropSessionChatHiddenMessages,
+  isSessionChatCommandTurn,
   sessionChatSuppressedTurnLabel,
   sessionChatSuppressedTurnPresentation,
   type SessionChatStatusRow,
@@ -1044,7 +1045,8 @@ function summaryModeTurns(
     // not started its own response yet: it stays inside the working turn's
     // activeWork instead of opening a turn whose reply would never come.
     const isGenuineUserMessage =
-      message.role === 'user' && message.queued !== true && sessionChatSuppressedTurnLabel(message) === null;
+      (message.role === 'user' && message.queued !== true && sessionChatSuppressedTurnLabel(message) === null) ||
+      isSessionChatCommandTurn(message);
     if (isGenuineUserMessage) {
       current = { active: false, activeWork: [], final: null, user: message };
       turns.push(current);
@@ -1111,7 +1113,7 @@ function finalAssistantMessageIds(messages: readonly SessionChatMessage[], isWor
     // by the reader: the agent is still mid-response on both sides of it.
     // Ending the turn there put a copy affordance under commentary that the
     // agent then kept building on.
-    if (sessionChatSuppressedTurnLabel(message) !== null) {
+    if (sessionChatSuppressedTurnLabel(message) !== null && !isSessionChatCommandTurn(message)) {
       return;
     }
     if (message.role === 'user') {

--- a/packages/core-ui/chat/session-chat-noise.ts
+++ b/packages/core-ui/chat/session-chat-noise.ts
@@ -20,10 +20,14 @@ import { agentModelCatalogEffortLabel } from '../../shared/agent-model-catalog';
 import { currentAgentModelCatalog } from '../../shared/agent-model-catalog-store';
 import type { SessionChatMessage } from '../../shared/session-chat';
 import { parseSessionChatCommandEnvelope } from './session-chat-command-envelope';
+import { decodeSessionChatEscapedMarkup } from './session-chat-local-command-transcript';
 
 const LEADING_TAG_NAME = /^<([a-z][a-z0-9-]*)(?:[\s>]|$)/;
 const MARKUP_TAG = /<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?>/gi;
-const CODEX_ESCAPED_LOCAL_COMMAND = /^<bash-(?:input|stdout) data-ghostex-escaped="html">/i;
+// Any marker whose payload gxserver escaped: Codex's `!` commands, and the
+// slash commands it archives and replays (session-chat-local-command-transcript).
+const ESCAPED_HARNESS_MARKER =
+  /^<(?:bash-(?:input|stdout)|command-name|local-command-stdout) data-ghostex-escaped="html">/i;
 
 /*
  * /compact's local-command stdout is just a dim "Compacted" wrapped in ANSI
@@ -285,10 +289,10 @@ export function sessionChatMessageText(message: SessionChatMessage): string {
 /** Text left once the harness markup is removed — "" ⇒ nothing to expand. */
 export function sessionChatSuppressedTurnBody(text: string): string {
   const body = text.replace(MARKUP_TAG, '').trim();
-  if (!CODEX_ESCAPED_LOCAL_COMMAND.test(text.trimStart())) {
+  if (!ESCAPED_HARNESS_MARKER.test(text.trimStart())) {
     return body;
   }
-  return body.replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&amp;', '&');
+  return decodeSessionChatEscapedMarkup(body);
 }
 
 export type SessionChatSuppressedTurn =
@@ -400,6 +404,17 @@ export function isSessionChatHiddenMessage(message: SessionChatMessage): boolean
 export function sessionChatSuppressedTurnLabel(message: SessionChatMessage): string | null {
   const suppressed = classifySessionChatSuppressedTurn(message);
   return suppressed?.kind === 'collapsed' || suppressed?.kind === 'status' ? suppressed.label : null;
+}
+
+/**
+ * CDXC:SessionChat 2026-09-10 DECISION:
+ * User: a slash command the reader sent starts its own turn in the chat summary.
+ * Claude answers each intercepted command with "No response requested.", and
+ * while a command row only continued the turn before it, that reply became the
+ * turn's final message and folded the real answer away under "Worked for".
+ */
+export function isSessionChatCommandTurn(message: SessionChatMessage): boolean {
+  return message.role === 'user' && sessionChatSuppressedTurnLabel(message) === 'Slash command';
 }
 
 export interface SessionChatSuppressedTurnPresentation {

--- a/packages/core-ui/chat/session-chat-pending.ts
+++ b/packages/core-ui/chat/session-chat-pending.ts
@@ -4,6 +4,10 @@
 
 import type { SessionChatAppCommand, SessionChatMessage } from '../../shared/session-chat';
 import { parseSessionChatCommandEnvelope } from './session-chat-command-envelope';
+import {
+  SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE,
+  sessionChatLocalCommandTexts,
+} from './session-chat-local-command-transcript';
 
 export const SESSION_CHAT_PENDING_SEND_LIMIT = 8;
 export const SESSION_CHAT_COMMAND_MARKER_LIMIT = 8;
@@ -553,6 +557,34 @@ export function sessionChatAppCommandsAsMessages(
     })
   );
   return commands.flatMap((entry) => {
+    /*
+     * CDXC:SessionChat 2026-09-10 WHY:
+     * Checked before the output rows, not only after them. gxserver archives
+     * every slash command the user sends and replays it into the messages as a
+     * `<command-name>` envelope, so from the first read carrying the archived
+     * row onwards this live acknowledgement IS that row — rendering both would
+     * show one command twice.
+     */
+    if (recorded.has(normalizeSessionChatPendingText(entry.command))) {
+      return [];
+    }
+    /*
+     * A command the user sent from chat renders as the same two rows the
+     * archive replays. Ghostex's own sends and Codex's dialog answers keep the
+     * surfaces below: those are not commands the reader typed.
+     */
+    if (entry.localCommand) {
+      const rows: SessionChatMessage[] = sessionChatLocalCommandTexts(entry.command, entry.output).map(
+        (text, index) => ({
+          blocks: [{ text, type: 'text' }],
+          id: index === 0 ? `app-command-local:${entry.id}` : `app-command-local:${entry.id}:output`,
+          role: 'user',
+          source: 'client',
+          timestamp: (Date.parse(entry.sentAt) || 0) + index,
+        })
+      );
+      return rows;
+    }
     if (entry.goal) {
       return [
         {
@@ -582,9 +614,6 @@ export function sessionChatAppCommandsAsMessages(
           timestamp: Date.parse(entry.sentAt) || null,
         },
       ];
-    }
-    if (recorded.has(normalizeSessionChatPendingText(entry.command))) {
-      return [];
     }
     const commandMatch = entry.command.trim().match(/^\/(?:rename|name|title)(?:\s+(.+))?$/is);
     if (commandMatch) {
@@ -617,6 +646,41 @@ export function sessionChatAppCommandsAsMessages(
         timestamp: Date.parse(entry.sentAt) || null,
       },
     ];
+  });
+}
+
+/*
+ * CDXC:SessionChat 2026-09-10 WHY:
+ * A command typed from chat still gets its instant client marker: the composer
+ * cannot know whether the daemon it talks to archives commands. Once the
+ * daemon's own row for that command is on screen — the live local-command
+ * acknowledgement, or the archived envelope a read replays — the marker is the
+ * same fact twice, drawn as a user bubble beside a `Slash command` row.
+ */
+export function retireSessionChatMarkersCoveredByLocalCommands(
+  markerMessages: readonly SessionChatMessage[],
+  appCommands: readonly SessionChatAppCommand[],
+  messages: readonly SessionChatMessage[]
+): SessionChatMessage[] {
+  const covered = new Set(
+    appCommands.filter((entry) => entry.localCommand).map((entry) => normalizeSessionChatPendingText(entry.command))
+  );
+  for (const message of messages) {
+    const text = message.blocks.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
+    if (!text.includes(SESSION_CHAT_ESCAPED_MARKUP_ATTRIBUTE)) {
+      continue;
+    }
+    const envelope = parseSessionChatCommandEnvelope(text);
+    if (envelope) {
+      covered.add(normalizeSessionChatPendingText(`${envelope.name} ${envelope.args}`));
+    }
+  }
+  if (covered.size === 0) {
+    return [...markerMessages];
+  }
+  return markerMessages.filter((message) => {
+    const text = message.blocks.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
+    return message.role !== 'user' || !covered.has(normalizeSessionChatPendingText(text));
   });
 }
 

--- a/packages/core-ui/chat/use-session-chat.ts
+++ b/packages/core-ui/chat/use-session-chat.ts
@@ -71,6 +71,7 @@ import {
   nextSessionChatPendingSendId,
   normalizeSessionChatPendingText,
   pruneSessionChatPendingSends,
+  retireSessionChatMarkersCoveredByLocalCommands,
   SESSION_CHAT_PENDING_SEND_LIMIT,
   sessionChatAppCommandsAsMessages,
   sessionChatCommandMarkersAsMessages,
@@ -1389,10 +1390,14 @@ export function useSessionChat(options: UseSessionChatOptions): UseSessionChatRe
         .map(normalizedSessionChatText)
         .filter(Boolean)
     );
-    const markerMessages = sessionChatCommandMarkersAsMessages(
-      retireSessionChatInterruptMarkers(markers, boundaried),
-      compactionRecords
-    ).filter((message) => message.role !== 'user' || !authoritativeText.has(normalizedSessionChatText(message)));
+    const markerMessages = retireSessionChatMarkersCoveredByLocalCommands(
+      sessionChatCommandMarkersAsMessages(
+        retireSessionChatInterruptMarkers(markers, boundaried),
+        compactionRecords
+      ).filter((message) => message.role !== 'user' || !authoritativeText.has(normalizedSessionChatText(message))),
+      appCommands,
+      boundaried
+    );
     const visibleTerminalStatuses = unreconciledSessionChatTerminalStatuses(terminalStatusMessages, boundaried);
     const tail: SessionChatMessage[] = [
       ...visibleTerminalStatuses,

--- a/packages/shared/session-chat.ts
+++ b/packages/shared/session-chat.ts
@@ -606,6 +606,13 @@ export interface SessionChatAppCommand {
   command: string;
   /** Assigned session title; arrives after agent metadata resolves a bare `/rename`. */
   title?: string;
+  /**
+   * The live half of a slash command the USER sent from chat, which gxserver
+   * also archives and replays on the next read. Rendered as the same rows that
+   * archive produces, so the look does not change under the reader when the
+   * replay takes over.
+   */
+  localCommand?: boolean;
   /** ISO-8601 millis. */
   sentAt: string;
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -74,6 +74,7 @@ pub mod session_chat_grok_blocking;
 pub mod session_chat_hermes;
 pub mod session_chat_hermes_blocking;
 pub mod session_chat_interactive;
+pub mod session_chat_local_command;
 mod session_chat_model_selection;
 pub mod session_chat_notice;
 mod session_chat_notice_progress;

--- a/server/src/session_chat_app_command.rs
+++ b/server/src/session_chat_app_command.rs
@@ -19,9 +19,16 @@ So the app records what IT sent. This is deliberately a short-lived
 ACKNOWLEDGEMENT, not an archive entry: the point is "Ghostex just did this",
 which stops being worth a row once the agent's own record shows up (the client
 drops ours when it finds the matching transcript envelope) or once enough time
-has passed that nobody is still wondering. That also keeps the two agents from
-disagreeing about history — nothing here is ever persisted, so a reload shows
-the transcript and only the transcript.
+has passed that nobody is still wondering. Nothing here is persisted, so a
+reload shows the transcript and only the transcript, and the two agents cannot
+disagree about history.
+
+CDXC:SessionChat 2026-09-10 WHY:
+That last sentence is now true of THIS store only. Commands the user sends from
+chat are archived by session_chat_local_command.rs and replayed into the
+messages on every read, because the user asked for those to survive a reload;
+this store still holds only the live half, including the live half of those
+(`local_command`), and still expires.
 
 The store is keyed by (project, session) and swept lazily on read, the same
 shape as the terminal-notice watchdog map in session_chat_notice.rs.
@@ -58,6 +65,18 @@ pub struct SessionChatAppCommand {
     pub output: Option<String>,
     /// The parsed goal cell behind a Codex `/goal` command's output.
     pub goal: Option<crate::session_chat_codex_goal::SessionChatCodexGoal>,
+    /*
+    CDXC:SessionChat 2026-09-10 WHY:
+    The row is the live half of a command the USER sent from chat, which is
+    archived in session_chat_local_command.rs and replays from there on the next
+    read. Clients render this one as the same two rows the archive produces, so
+    the look does not change under the reader when the archive takes over, and
+    the archived id travels with it so the settled output lands on the same row.
+    */
+    pub local_command: bool,
+    durable_id: Option<String>,
+    /// Whose screen the baseline was captured from, for the output diff.
+    screen_agent: Option<String>,
     screen_baseline: Option<String>,
     /// RFC3339 millis, for display ordering only.
     pub sent_at: String,
@@ -79,6 +98,9 @@ impl SessionChatAppCommand {
         }
         if let Some(title) = self.title.as_deref() {
             map.insert("title".to_string(), json!(title));
+        }
+        if self.local_command {
+            map.insert("localCommand".to_string(), json!(true));
         }
         map.insert("sentAt".to_string(), json!(self.sent_at));
         Value::Object(map)
@@ -150,6 +172,9 @@ fn record_session_chat_app_command_inner(
         title: app_command_title(command),
         output: None,
         goal: None,
+        local_command: false,
+        durable_id: None,
+        screen_agent: None,
         screen_baseline: None,
         sent_at,
         title_metadata_baseline,
@@ -172,10 +197,19 @@ fn app_command_title(command: &str) -> Option<String> {
 /// CDXC:SessionChat 2026-09-05 WHY:
 /// Codex's local commands do not enter its transcript, and asynchronous commands such as /mcp repaint after their initial loading line.
 /// Retain one command's screen baseline until the next send so the shared screen probe can update the same result row.
-pub(crate) fn begin_codex_command_output(
+///
+/// CDXC:SessionChat 2026-09-10 WHY:
+/// Every agent now takes this path, not only Codex: Claude records a transcript
+/// envelope for a handful of its commands and nothing at all for the rest
+/// (`/rename` included), so the screen is the only place its result exists.
+/// `durable_id` is the archived row in session_chat_local_command.rs that this
+/// capture's settled output belongs to.
+pub(crate) fn begin_local_command_output(
     project_id: &str,
     session_id: &str,
+    agent: Option<&str>,
     command: &str,
+    durable_id: Option<String>,
     screen: String,
 ) {
     let Ok(mut guard) = store().lock() else {
@@ -200,6 +234,9 @@ pub(crate) fn begin_codex_command_output(
         title: None,
         output: Some(String::new()),
         goal: None,
+        local_command: durable_id.is_some(),
+        durable_id,
+        screen_agent: agent.map(str::to_string),
         screen_baseline: Some(screen),
         sent_at,
         title_metadata_baseline: None,
@@ -209,7 +246,7 @@ pub(crate) fn begin_codex_command_output(
     prune(rows, now);
 }
 
-pub(crate) fn stop_codex_command_output(project_id: &str, session_id: &str) {
+pub(crate) fn stop_local_command_output(project_id: &str, session_id: &str) {
     if let Ok(mut guard) = store().lock() {
         if let Some(rows) = guard.get_mut(&(project_id.to_string(), session_id.to_string())) {
             for row in rows {
@@ -219,21 +256,61 @@ pub(crate) fn stop_codex_command_output(project_id: &str, session_id: &str) {
     }
 }
 
-pub(crate) fn refresh_codex_command_output(project_id: &str, session_id: &str, screen: &str) {
-    let Ok(mut guard) = store().lock() else {
-        return;
-    };
-    let Some(rows) = guard.get_mut(&(project_id.to_string(), session_id.to_string())) else {
-        return;
-    };
-    prune(rows, Instant::now());
+pub(crate) fn refresh_local_command_output(project_id: &str, session_id: &str, screen: &str) {
+    let mut settled: Vec<(String, String)> = Vec::new();
+    {
+        let Ok(mut guard) = store().lock() else {
+            return;
+        };
+        let Some(rows) = guard.get_mut(&(project_id.to_string(), session_id.to_string())) else {
+            return;
+        };
+        prune(rows, Instant::now());
+        refresh_rows(rows, screen, &mut settled);
+    }
+    // Outside the store lock: the archive writes to disk.
+    for (durable_id, output) in settled {
+        crate::session_chat_local_command::attach_session_chat_local_command_output(
+            project_id,
+            session_id,
+            &durable_id,
+            &output,
+        );
+    }
+}
+
+fn refresh_rows(
+    rows: &mut [SessionChatAppCommand],
+    screen: &str,
+    settled: &mut Vec<(String, String)>,
+) {
     for row in rows.iter_mut().filter(|row| row.screen_baseline.is_some()) {
-        let Some(output) = crate::session_chat_codex_dialog::codex_command_output(
+        let Some(output) = crate::session_chat_local_command::session_chat_local_command_output(
+            row.screen_agent.as_deref(),
+            &row.command,
             row.screen_baseline.as_deref().unwrap_or_default(),
             screen,
         ) else {
             continue;
         };
+        /*
+        CDXC:SessionChat 2026-09-10 WHY:
+        Outside Codex a later capture may only GROW the result. Claude's panels
+        (`/status`) close into a one-line dismissal and its notices repaint under
+        the result, so "the newest diff wins" replaced a full status panel with a
+        stray footer line. Codex keeps last-wins: its `/mcp` repaints in place.
+        */
+        if row.screen_agent.as_deref() != Some("codex")
+            && row
+                .output
+                .as_deref()
+                .is_some_and(|current| !current.is_empty() && !output.starts_with(current))
+        {
+            continue;
+        }
+        if let Some(durable_id) = row.durable_id.as_deref() {
+            settled.push((durable_id.to_string(), output.clone()));
+        }
         if crate::session_chat_codex_goal::command_is_codex_goal(&row.command) {
             if let Some(cell) = crate::session_chat_codex_goal::parse_codex_goal_cell(&output) {
                 row.output = Some(cell.text);

--- a/server/src/session_chat_codex_dialog.rs
+++ b/server/src/session_chat_codex_dialog.rs
@@ -636,8 +636,10 @@ pub(crate) async fn answer_codex_dialog(
         &target.zmx_name,
         "session-chat-dialog",
         vec![
-            SessionChatSendStep::BeginCodexCommandOutput {
+            SessionChatSendStep::BeginLocalCommandOutput {
+                agent: Some("codex".to_string()),
                 command: dialog.title,
+                durable_id: None,
             },
             SessionChatSendStep::VerifyTerminalDialog {
                 agent: "codex".to_string(),
@@ -645,7 +647,7 @@ pub(crate) async fn answer_codex_dialog(
             },
             SessionChatSendStep::Write(payload),
             SessionChatSendStep::SleepMs(150),
-            SessionChatSendStep::FinishCodexCommandOutput,
+            SessionChatSendStep::FinishLocalCommandOutput,
         ],
     )
     .await
@@ -772,26 +774,8 @@ pub fn codex_command_output(before: &str, after: &str) -> Option<String> {
     }
     let before = history_without_composer(before);
     let after = history_without_composer(after);
-    // Codex repaints old /status cells with refreshed rate-limit timestamps.
-    // Locate the transcript's ending text, rather than requiring its entire
-    // historical prefix to remain byte-identical after a local command.
-    let boundary = (before.len().saturating_sub(16)..before.len()).find_map(|start| {
-        let anchor = &before[start..];
-        if !anchor
-            .iter()
-            .any(|line| line.chars().any(char::is_alphanumeric))
-            || after.len() < anchor.len()
-        {
-            return None;
-        }
-        after
-            .windows(anchor.len())
-            .enumerate()
-            .filter(|(_, window)| *window == anchor)
-            .min_by_key(|(index, _)| index.abs_diff(start))
-            .map(|(index, _)| index + anchor.len())
-    })?;
-    let output = after[boundary..].join("\n").trim().to_string();
+    let output =
+        crate::session_chat_local_command::newly_printed_lines(&before, &after)?.join("\n");
     // A submitted terminal prompt belongs to the JSONL transcript, not this local command.
     let output = output
         .lines()

--- a/server/src/session_chat_decode_codex.rs
+++ b/server/src/session_chat_decode_codex.rs
@@ -338,16 +338,9 @@ fn codex_event_message(
 }
 
 fn codex_user_shell_marker(tag: &str, body: &str) -> String {
-    let mut escaped = String::with_capacity(body.len());
-    for character in body.chars() {
-        match character {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            _ => escaped.push(character),
-        }
-    }
-    format!("<{tag} data-ghostex-escaped=\"html\">{escaped}</{tag}>")
+    // Same escaped-markup contract the archived slash commands replay with, so
+    // one client rule decodes both.
+    crate::session_chat_local_command::escaped_marker(tag, body)
 }
 
 /*

--- a/server/src/session_chat_local_command.rs
+++ b/server/src/session_chat_local_command.rs
@@ -1,0 +1,1067 @@
+/*
+CDXC:SessionChat 2026-09-10 DECISION:
+User: a slash command sent from chat has to appear IN chat, the way PR #121's
+`!` local commands do, and it has to still be there after a reload.
+
+The agent CLIs cannot supply that. Claude records a `<command-name>` envelope
+for only a handful of its commands (`/model`, `/effort`, `/compact`, `/mcp`,
+`/plan`, `/usage`, `/login`); Codex records nothing for any of them; and
+`/rename` — the command that prompted this — writes no transcript row at all.
+So the durable record is ours, and it is the ONE exception to
+session_chat_app_command.rs's "nothing here is ever persisted": that store is a
+five-minute acknowledgement of what Ghostex typed, this file is the archive of
+what the USER typed.
+
+Each row replays as the envelope the CLI would have written, which is what buys
+these rows their whole presentation for free: the client's noise classifier
+already renders `<command-name>` as a `Slash command` row and
+`<local-command-stdout>` as `Local command output`, already folds `/model` and
+`/effort` into their status pills, and already retires the live app-command
+acknowledgement when a matching envelope reaches the messages. Nothing new
+renders them.
+
+SEE-ALSO: server/src/session_chat_app_command.rs (the live acknowledgement
+these retire), server/src/session_chat_read.rs (the merge into a page),
+packages/core-ui/chat/session-chat-local-command-transcript.ts (the client's
+half of the escaped-markup contract).
+*/
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use serde_json::{json, Map, Value};
+
+use crate::session_chat::{
+    SessionChatBlock, SessionChatMessage, SessionChatRole, SessionChatSource,
+};
+
+/// Rows replayed per session. Deep history is the transcript's job; this is the
+/// command trail beside it, and a session that ran more than this many local
+/// commands does not need its oldest ones back.
+const LOCAL_COMMAND_LIMIT: usize = 200;
+/// Output is appended as a second record under the same id, so the file holds
+/// more lines than rows. Compaction rewrites it once it passes this.
+const LOCAL_COMMAND_LINE_LIMIT: usize = 600;
+/// Same ceiling `codex_command_output` applies to a screen diff.
+const LOCAL_COMMAND_OUTPUT_CHARS: usize = 24_000;
+
+/// The marker attribute PR #121 introduced for Codex's `!` commands: it tells
+/// the client the payload is HTML-escaped, so a command or an output carrying
+/// `<…>` survives the markup strip instead of being eaten by it.
+pub(crate) const ESCAPED_MARKUP_ATTRIBUTE: &str = "data-ghostex-escaped=\"html\"";
+
+#[derive(Clone, Debug)]
+pub struct SessionChatLocalCommand {
+    /// `<sent_at_ms>-<sequence>`: unique per session and stable once written,
+    /// so the output record can find its row and the client can dedupe.
+    pub id: String,
+    /// Command token including the slash, e.g. `/rename`.
+    pub command: String,
+    /// Everything after the token, verbatim. Empty for a bare command.
+    pub args: String,
+    /// What the CLI printed, once the screen diff settled. `None` until then.
+    pub output: Option<String>,
+    pub sent_at_ms: i64,
+}
+
+impl SessionChatLocalCommand {
+    fn from_value(value: &Value) -> Option<Self> {
+        let record = value.as_object()?;
+        let id = record.get("id").and_then(Value::as_str)?.to_string();
+        let command = record.get("command").and_then(Value::as_str)?.to_string();
+        if id.is_empty() || command.is_empty() {
+            return None;
+        }
+        Some(Self {
+            id,
+            command,
+            args: record
+                .get("args")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            output: record
+                .get("output")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            sent_at_ms: record.get("sentAt").and_then(Value::as_i64).unwrap_or(0),
+        })
+    }
+
+    fn to_value(&self) -> Value {
+        let mut map = Map::new();
+        map.insert("id".to_string(), json!(self.id));
+        map.insert("command".to_string(), json!(self.command));
+        map.insert("args".to_string(), json!(self.args));
+        if let Some(output) = self.output.as_deref() {
+            map.insert("output".to_string(), json!(output));
+        }
+        map.insert("sentAt".to_string(), json!(self.sent_at_ms));
+        Value::Object(map)
+    }
+
+    /// `/rename pilot game work` — what the user typed, for the client's
+    /// dedupe against the live app-command row.
+    pub fn text(&self) -> String {
+        if self.args.is_empty() {
+            self.command.clone()
+        } else {
+            format!("{} {}", self.command, self.args)
+        }
+    }
+}
+
+/*
+The line-leading slash law, matching `classifySessionChatSend` on the client:
+untrimmed, so a leading space is prose, and the token has to look like a
+command name rather than an absolute path — `/Users/sven/notes.md` pasted as a
+whole message is a path, and archiving it as a command would put a permanent
+lie in the trail. `/plugin:deploy` and `/ghostex-auto-rename-session` pass.
+*/
+pub fn parse_session_chat_local_command(text: &str) -> Option<(String, String)> {
+    let (token, args) = match text.find(char::is_whitespace) {
+        Some(at) => (&text[..at], text[at..].trim()),
+        None => (text, ""),
+    };
+    let name = token.strip_prefix('/')?;
+    if name.is_empty() || !name.starts_with(|ch: char| ch.is_ascii_alphanumeric()) {
+        return None;
+    }
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, ':' | '_' | '-' | '.'))
+    {
+        return None;
+    }
+    Some((token.to_string(), args.to_string()))
+}
+
+/// Commands whose one result row the CLI's own transcript already carries:
+/// Claude's `/model`, `/effort` and `/fast` status pills, and the compaction row
+/// for `/compact` (Codex's `ContextCompaction` record). Archiving them would add
+/// a second, screen-scraped result under the authoritative one.
+pub fn transcript_records_command_result(command: &str) -> bool {
+    matches!(
+        command.to_ascii_lowercase().as_str(),
+        "/model" | "/effort" | "/fast" | "/compact"
+    )
+}
+
+fn session_file(project_id: &str, session_id: &str) -> Option<PathBuf> {
+    let project = sanitize_id(project_id)?;
+    let session = sanitize_id(session_id)?;
+    Some(
+        ghostex_paths::GhostexPaths::resolve()
+            .gxserver_state_dir()
+            .join("session-commands")
+            .join(project)
+            .join(format!("{session}.jsonl")),
+    )
+}
+
+fn sanitize_id(id: &str) -> Option<String> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-') {
+                    ch
+                } else {
+                    '_'
+                }
+            })
+            .collect(),
+    )
+}
+
+fn append(project_id: &str, session_id: &str, row: &SessionChatLocalCommand) -> Option<()> {
+    let path = session_file(project_id, session_id)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).ok()?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    writeln!(file, "{}", row.to_value()).ok()?;
+    Some(())
+}
+
+/// Archive one command the user sent from chat. Returns the row id, which the
+/// caller carries so the settled output can be attached to the same row.
+pub fn record_session_chat_local_command(
+    project_id: &str,
+    session_id: &str,
+    text: &str,
+) -> Option<String> {
+    let (command, args) = parse_session_chat_local_command(text)?;
+    let sent_at_ms = chrono::Utc::now().timestamp_millis();
+    let existing = load_session_chat_local_commands(project_id, session_id);
+    let sequence = existing
+        .iter()
+        .filter(|row| row.sent_at_ms == sent_at_ms)
+        .count();
+    let row = SessionChatLocalCommand {
+        id: format!("{sent_at_ms}-{sequence}"),
+        command,
+        args,
+        output: None,
+        sent_at_ms,
+    };
+    append(project_id, session_id, &row)?;
+    compact_if_needed(project_id, session_id, existing.len() + 1);
+    Some(row.id)
+}
+
+/// Attach (or replace) the output of an archived command. Called every time the
+/// screen probe refines a result, so the last record for an id wins.
+pub fn attach_session_chat_local_command_output(
+    project_id: &str,
+    session_id: &str,
+    id: &str,
+    output: &str,
+) {
+    let rows = load_session_chat_local_commands(project_id, session_id);
+    let Some(row) = rows.iter().find(|row| row.id == id) else {
+        return;
+    };
+    let output: String = output.chars().take(LOCAL_COMMAND_OUTPUT_CHARS).collect();
+    if row.output.as_deref() == Some(output.as_str()) {
+        return;
+    }
+    let updated = SessionChatLocalCommand {
+        output: Some(output),
+        ..row.clone()
+    };
+    append(project_id, session_id, &updated);
+}
+
+/// Archived rows, oldest first, one per id with the last record's output.
+pub fn load_session_chat_local_commands(
+    project_id: &str,
+    session_id: &str,
+) -> Vec<SessionChatLocalCommand> {
+    let Some(path) = session_file(project_id, session_id) else {
+        return Vec::new();
+    };
+    let Ok(file) = fs::File::open(&path) else {
+        return Vec::new();
+    };
+    let mut rows: Vec<SessionChatLocalCommand> = Vec::new();
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let Some(row) = serde_json::from_str::<Value>(&line)
+            .ok()
+            .as_ref()
+            .and_then(SessionChatLocalCommand::from_value)
+        else {
+            continue;
+        };
+        match rows.iter_mut().find(|existing| existing.id == row.id) {
+            Some(existing) => *existing = row,
+            None => rows.push(row),
+        }
+    }
+    rows.sort_by(|left, right| {
+        left.sent_at_ms
+            .cmp(&right.sent_at_ms)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    if rows.len() > LOCAL_COMMAND_LIMIT {
+        rows.drain(..rows.len() - LOCAL_COMMAND_LIMIT);
+    }
+    rows
+}
+
+/// Rewrite the file as one line per surviving row once appended updates have
+/// made it longer than its rows justify.
+fn compact_if_needed(project_id: &str, session_id: &str, row_count: usize) {
+    let Some(path) = session_file(project_id, session_id) else {
+        return;
+    };
+    let Ok(file) = fs::File::open(&path) else {
+        return;
+    };
+    let lines = BufReader::new(file).lines().map_while(Result::ok).count();
+    if lines <= LOCAL_COMMAND_LINE_LIMIT && row_count <= LOCAL_COMMAND_LIMIT {
+        return;
+    }
+    let rows = load_session_chat_local_commands(project_id, session_id);
+    let body = rows
+        .iter()
+        .map(|row| row.to_value().to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let temporary = path.with_extension("jsonl.tmp");
+    if fs::write(&temporary, format!("{body}\n")).is_ok() {
+        let _ = fs::rename(&temporary, &path);
+    }
+}
+
+/// One archived command as the transcript rows the CLI would have written.
+fn local_command_messages(row: &SessionChatLocalCommand) -> Vec<SessionChatMessage> {
+    let mut command = escaped_marker("command-name", &row.command);
+    if !row.args.is_empty() {
+        // The space is load-bearing: the client reads these rows by stripping
+        // their markup, and without it the name and its arguments would be
+        // concatenated into one word.
+        command.push(' ');
+        command.push_str(&escaped_marker("command-args", &row.args));
+    }
+    let mut messages = vec![message(
+        format!("local-command:{}", row.id),
+        command,
+        row.sent_at_ms,
+    )];
+    if let Some(output) = row.output.as_deref().filter(|output| !output.is_empty()) {
+        messages.push(message(
+            format!("local-command:{}:output", row.id),
+            escaped_marker("local-command-stdout", output),
+            // One millisecond later so the result can never sort above the
+            // command that produced it.
+            row.sent_at_ms.saturating_add(1),
+        ));
+    }
+    messages
+}
+
+fn message(id: String, text: String, timestamp: i64) -> SessionChatMessage {
+    SessionChatMessage {
+        id,
+        role: SessionChatRole::User,
+        blocks: vec![SessionChatBlock::Text { text }],
+        timestamp: Some(timestamp),
+        source: SessionChatSource::Transcript,
+        turn_id: None,
+        byte_offset: None,
+        queued: false,
+    }
+}
+
+/*
+CDXC:SessionChat 2026-09-10 WHY:
+The lines a local command added to the screen, found by anchoring on the tail of
+the pre-send capture rather than by requiring the whole historical prefix to
+stay byte-identical: Codex repaints old `/status` cells with refreshed
+rate-limit timestamps, and Claude repaints its own footer, so a strict prefix
+comparison reported the entire screen as new. Shared by both extractors below
+so one proven anchor search serves every agent.
+*/
+pub(crate) fn newly_printed_lines(before: &[String], after: &[String]) -> Option<Vec<String>> {
+    let boundary = (before.len().saturating_sub(16)..before.len()).find_map(|start| {
+        let anchor = &before[start..];
+        if !anchor
+            .iter()
+            .any(|line| line.chars().any(char::is_alphanumeric))
+            || after.len() < anchor.len()
+        {
+            return None;
+        }
+        after
+            .windows(anchor.len())
+            .enumerate()
+            .filter(|(_, window)| *window == anchor)
+            .min_by_key(|(index, _)| index.abs_diff(start))
+            .map(|(index, _)| index + anchor.len())
+    })?;
+    Some(after[boundary..].to_vec())
+}
+
+/// What one local command printed, for the agent whose screen this is. Codex
+/// keeps its own extractor: its dialogs own the screen and get their own card.
+pub fn session_chat_local_command_output(
+    agent: Option<&str>,
+    command: &str,
+    before: &str,
+    after: &str,
+) -> Option<String> {
+    if agent == Some("codex") {
+        return crate::session_chat_codex_dialog::codex_command_output(before, after);
+    }
+    let before_history = screen_history(before);
+    let after_history = screen_history(after);
+    let mut cut_off = false;
+    /*
+    Claude echoes the command it intercepted onto its own composer line and
+    hangs the result under it as an indented `⎿` branch, so the diff reads
+    [blank, echo, result…] — the opposite of Codex, where a composer line means
+    a prompt was submitted and everything after it belongs to the transcript.
+    Take what the echo owns: the branch under it, ending at the first line that
+    starts a new column, which is where an agent turn the transcript already
+    records would begin. With no echo in the diff there is nothing to attribute
+    it to, so the whole diff is the result.
+    */
+    let result: Vec<String> = match newly_printed_lines(&before_history, &after_history) {
+        Some(printed) => match printed.iter().rposition(|line| is_composer_line(line)) {
+            Some(echo) => result_branch(&printed[echo + 1..]),
+            None => printed,
+        },
+        /*
+        CDXC:SessionChat 2026-09-10 DECISION:
+        User: output taller than the chat-view grid shows the part still on
+        screen rather than nothing, inside the same expandable row.
+        Claude draws on the alternate screen, which keeps no scrollback, and
+        chat view shrinks that grid to ~24 rows, so a 35-line `/context` pushes
+        the pre-send lines the anchor needs off the top. Its own echo still
+        attributes the result while it is visible; once even the echo is gone
+        and none of the pre-send tail survives anywhere, everything left on the
+        grid was printed after the send, so it is this command's output with
+        its top cut off, and it says so. Any other anchor miss — a repaint that
+        kept the old lines — attributes nothing.
+        */
+        None => {
+            if let Some(echo) = after_history
+                .iter()
+                .rposition(|line| is_echo_of(line, command))
+            {
+                result_branch(&after_history[echo + 1..])
+            } else if scrolled_past(&before_history, &after_history) {
+                cut_off = true;
+                after_history
+            } else {
+                return None;
+            }
+        }
+    };
+    let mut lines: Vec<String> = result
+        .iter()
+        .map(|line| strip_result_gutter(line))
+        .filter(|line| !is_rule_line(line))
+        .collect();
+    // A panel still open when captured (`/status`) ends in its own key hint.
+    if lines.last().is_some_and(|line| is_key_hint(line)) {
+        lines.pop();
+    }
+    let output = lines.join("\n");
+    let output = output.trim();
+    if output.is_empty() {
+        return None;
+    }
+    let output = if cut_off {
+        format!("…\n{output}")
+    } else {
+        output.to_string()
+    };
+    Some(output.chars().take(LOCAL_COMMAND_OUTPUT_CHARS).collect())
+}
+
+fn result_branch(lines: &[String]) -> Vec<String> {
+    lines
+        .iter()
+        .take_while(|line| is_result_branch(line))
+        .cloned()
+        .collect()
+}
+
+/// This command's own echo on a composer line, e.g. `❯ /context`.
+fn is_echo_of(line: &str, command: &str) -> bool {
+    if !is_composer_line(line) {
+        return false;
+    }
+    let cleaned = line
+        .trim()
+        .trim_matches(['│', '┃', '▌'])
+        .trim()
+        .trim_start_matches(['❯', '›', '>'])
+        .trim();
+    !command.trim().is_empty() && cleaned == command.trim()
+}
+
+/// None of the last pre-send lines survive anywhere on the new grid, so every
+/// line on it was printed after the send.
+fn scrolled_past(before: &[String], after: &[String]) -> bool {
+    let tail: Vec<&String> = before
+        .iter()
+        .rev()
+        .filter(|line| line.chars().any(char::is_alphanumeric))
+        .take(16)
+        .collect();
+    !after.is_empty() && !tail.is_empty() && !tail.iter().any(|line| after.contains(line))
+}
+
+/// The screen as comparable lines, with the composer and everything the CLI
+/// paints below it (rules, statusline, hints) removed — that chrome repaints on
+/// its own schedule and is not output.
+fn screen_history(text: &str) -> Vec<String> {
+    let mut lines: Vec<String> = text
+        .lines()
+        .map(|line| {
+            crate::session_chat_options::normalize_spaces(
+                &crate::session_chat_options::strip_ansi_sgr(line),
+            )
+            .trim_end()
+            .to_string()
+        })
+        .collect();
+    if let Some(composer) = lines.iter().rposition(|line| is_composer_line(line)) {
+        lines.truncate(composer);
+    }
+    while lines.last().is_some_and(|line| {
+        line.trim().is_empty() || is_frame_line(line) || is_right_aligned_notice(line)
+    }) {
+        lines.pop();
+    }
+    lines
+}
+
+/*
+CDXC:SessionChat 2026-09-10 WHY:
+Claude paints a right-aligned notice directly above its composer ("● high ·
+/effort", "You've used 82% of your weekly limit") and swaps it between any two
+captures. Left in the history it became the last line of every anchor, so a
+`/rename` whose result was plainly on screen diffed to nothing, and a later
+probe archived the notice itself as `/status`'s output. It is chrome: a result
+line is indented by a gutter, never pushed to the right edge.
+*/
+fn is_right_aligned_notice(line: &str) -> bool {
+    let indent = line.len() - line.trim_start().len();
+    indent >= 40 && !line.trim().is_empty()
+}
+
+/// A composer input line: `❯` for Claude and most CLIs, `›` for Codex, and the
+/// `>` of a box-drawn composer — matched only inside its box, because a bare
+/// `>` at the start of a line is a markdown quote in the agent's own answer.
+fn is_composer_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    let cleaned = trimmed.trim_matches(['│', '┃', '▌']).trim();
+    cleaned.starts_with('❯')
+        || cleaned.starts_with('›')
+        || (trimmed.contains('│') && cleaned.starts_with('>'))
+}
+
+/// A rule or box edge the CLI draws around its composer. Claude's top rule
+/// carries the session title, so this cannot require the line to be pure
+/// box-drawing.
+fn is_frame_line(line: &str) -> bool {
+    line.trim().starts_with(['─', '━', '╭', '╮', '╰', '╯'])
+}
+
+/// A panel's drawn edge (`▔▔▔`, `───`): drawing, not output.
+fn is_rule_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|ch| matches!(ch, '▔' | '▁' | '─' | '━' | '═'))
+}
+
+fn is_key_hint(line: &str) -> bool {
+    line.trim().to_ascii_lowercase().starts_with("esc to ")
+}
+
+/// A line hanging off the echoed command: blank, gutter-drawn, or indented.
+fn is_result_branch(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.is_empty() || trimmed.starts_with(['⎿', '└', '├']) || line.starts_with([' ', '\t'])
+}
+
+/// Claude prints a command's result under a gutter glyph (`⎿`). The glyph is
+/// the terminal's tree drawing, not part of the sentence.
+fn strip_result_gutter(line: &str) -> String {
+    let trimmed = line.trim_start();
+    for glyph in ['⎿', '└', '├', '⏺'] {
+        if let Some(rest) = trimmed.strip_prefix(glyph) {
+            return rest.trim_start().to_string();
+        }
+    }
+    line.to_string()
+}
+
+pub(crate) fn escaped_marker(tag: &str, body: &str) -> String {
+    let mut escaped = String::with_capacity(body.len());
+    for character in body.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            _ => escaped.push(character),
+        }
+    }
+    format!("<{tag} {ESCAPED_MARKUP_ATTRIBUTE}>{escaped}</{tag}>")
+}
+
+/*
+Which archived rows belong to the page being answered. A row is anchored to the
+transcript message it FOLLOWS, never to raw time: pages are contiguous, so
+"the last message at or before this row" identifies one page exactly, and a row
+after the page's final message belongs to the live tail (there is nothing after
+it anywhere) or to the next page up. The oldest page owns anything older than
+the transcript itself, which is where a command sent before the CLI first
+flushed lands.
+*/
+pub fn select_session_chat_local_commands(
+    rows: Vec<SessionChatLocalCommand>,
+    messages: &[SessionChatMessage],
+    is_tail_page: bool,
+    has_more: bool,
+) -> Vec<SessionChatLocalCommand> {
+    if rows.is_empty() {
+        return Vec::new();
+    }
+    let stamps: Vec<i64> = messages
+        .iter()
+        .filter_map(|message| message.timestamp)
+        .collect();
+    let recorded = recorded_command_texts(messages);
+    rows.into_iter()
+        .filter(|row| !recorded.contains(&row.text()))
+        .filter(|row| {
+            let Some(&first) = stamps.first() else {
+                // No timestamped transcript row to anchor against: the tail
+                // page carries the trail, a pagination page never invents it.
+                return is_tail_page;
+            };
+            if row.sent_at_ms < first {
+                return !has_more;
+            }
+            let last = stamps.last().copied().unwrap_or(first);
+            row.sent_at_ms < last || is_tail_page
+        })
+        .collect()
+}
+
+/*
+The agent's own record wins. Claude writes a `<command-name>` envelope for the
+commands it does record, and that row renders from the transcript; replaying
+ours beside it would show the same command twice.
+*/
+fn recorded_command_texts(messages: &[SessionChatMessage]) -> Vec<String> {
+    messages
+        .iter()
+        .filter(|message| message.role == SessionChatRole::User)
+        .filter_map(|message| {
+            let text = crate::session_chat_decode_claude::message_text(message);
+            let name = between(&text, "<command-name>", "</command-name>")?;
+            let args = between(&text, "<command-args>", "</command-args>").unwrap_or_default();
+            Some(if args.is_empty() {
+                name
+            } else {
+                format!("{name} {args}")
+            })
+        })
+        .collect()
+}
+
+fn between(text: &str, open: &str, close: &str) -> Option<String> {
+    let start = text.find(open)? + open.len();
+    let end = text[start..].find(close)? + start;
+    Some(text[start..end].trim().to_string())
+}
+
+/// Merge the selected rows into a page, keeping it ordered oldest first.
+pub fn merge_session_chat_local_commands(
+    messages: Vec<SessionChatMessage>,
+    rows: &[SessionChatLocalCommand],
+) -> Vec<SessionChatMessage> {
+    if rows.is_empty() {
+        return messages;
+    }
+    let mut merged = messages;
+    for row in rows {
+        for synthesized in local_command_messages(row) {
+            let at = merged
+                .iter()
+                .rposition(|message| {
+                    message.timestamp.unwrap_or(i64::MIN)
+                        <= synthesized.timestamp.unwrap_or(i64::MIN)
+                })
+                .map(|index| index + 1)
+                .unwrap_or(0);
+            merged.insert(at, synthesized);
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shape a Claude screen capture has: scroll-back, then the composer
+    /// rule, the input line, another rule, and the status footer.
+    fn claude_screen(history: &[&str]) -> String {
+        let mut lines: Vec<String> = history.iter().map(|line| line.to_string()).collect();
+        lines.push("──────────────────────────────── pilot game work ─".to_string());
+        lines.push("❯ ".to_string());
+        lines.push("──────────────────────────────────────────────────".to_string());
+        lines.push("   📁 Ghostex · 🤖 Opus 5 (1M context)/high · 🧠 21%".to_string());
+        lines.push("  ⏵⏵ bypass permissions on (shift+tab to cycle)".to_string());
+        lines.join("\n")
+    }
+
+    fn row(
+        id: &str,
+        command: &str,
+        args: &str,
+        output: Option<&str>,
+        sent_at_ms: i64,
+    ) -> SessionChatLocalCommand {
+        SessionChatLocalCommand {
+            id: id.to_string(),
+            command: command.to_string(),
+            args: args.to_string(),
+            output: output.map(str::to_string),
+            sent_at_ms,
+        }
+    }
+
+    fn transcript_row(id: &str, text: &str, timestamp: i64) -> SessionChatMessage {
+        SessionChatMessage {
+            id: id.to_string(),
+            role: SessionChatRole::User,
+            blocks: vec![SessionChatBlock::Text {
+                text: text.to_string(),
+            }],
+            timestamp: Some(timestamp),
+            source: SessionChatSource::Transcript,
+            turn_id: None,
+            byte_offset: None,
+            queued: false,
+        }
+    }
+
+    #[test]
+    fn parses_only_line_leading_command_tokens() {
+        assert_eq!(
+            parse_session_chat_local_command("/rename pilot game work"),
+            Some(("/rename".to_string(), "pilot game work".to_string()))
+        );
+        assert_eq!(
+            parse_session_chat_local_command("/context"),
+            Some(("/context".to_string(), String::new()))
+        );
+        assert_eq!(
+            parse_session_chat_local_command("/plugin:deploy prod"),
+            Some(("/plugin:deploy".to_string(), "prod".to_string()))
+        );
+        // A pasted path is not a command, and archiving it would put a
+        // permanent lie in the trail.
+        assert_eq!(
+            parse_session_chat_local_command("/Users/sven/code/notes.md"),
+            None
+        );
+        // Untrimmed, exactly like the client's send classification.
+        assert_eq!(parse_session_chat_local_command(" /rename x"), None);
+        assert_eq!(
+            parse_session_chat_local_command("what does /rename do"),
+            None
+        );
+        assert_eq!(parse_session_chat_local_command("! printf hi"), None);
+    }
+
+    #[test]
+    fn reads_a_claude_command_result_off_the_screen() {
+        let before = claude_screen(&["⏺ Earlier answer.", ""]);
+        let after = claude_screen(&[
+            "⏺ Earlier answer.",
+            "",
+            "❯ /rename pilot game work",
+            "  ⎿ Session renamed to: pilot game work",
+            "",
+        ]);
+        assert_eq!(
+            session_chat_local_command_output(Some("claude"), "/rename", &before, &after)
+                .as_deref(),
+            Some("Session renamed to: pilot game work")
+        );
+    }
+
+    #[test]
+    fn a_command_that_printed_nothing_has_no_output() {
+        let before = claude_screen(&["⏺ Earlier answer."]);
+        // Only the echo, and a repainted footer.
+        let after = claude_screen(&["⏺ Earlier answer.", "❯ /diff"]);
+        assert_eq!(
+            session_chat_local_command_output(Some("claude"), "/rename", &before, &after),
+            None
+        );
+    }
+
+    #[test]
+    fn replays_a_row_as_the_envelope_the_cli_would_have_written() {
+        let messages = merge_session_chat_local_commands(
+            Vec::new(),
+            &[row(
+                "1-0",
+                "/rename",
+                "pilot <game> work",
+                Some("Session renamed to: pilot <game> work"),
+                1_000,
+            )],
+        );
+        let text = |index: usize| match &messages[index].blocks[0] {
+            SessionChatBlock::Text { text } => text.clone(),
+            _ => panic!("expected text"),
+        };
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            text(0),
+            "<command-name data-ghostex-escaped=\"html\">/rename</command-name> \
+             <command-args data-ghostex-escaped=\"html\">pilot &lt;game&gt; work</command-args>"
+        );
+        assert_eq!(
+            text(1),
+            "<local-command-stdout data-ghostex-escaped=\"html\">Session renamed to: pilot &lt;game&gt; work</local-command-stdout>"
+        );
+        // The result can never sort above the command that produced it.
+        assert!(messages[0].timestamp < messages[1].timestamp);
+    }
+
+    #[test]
+    fn merges_a_row_after_the_message_it_followed() {
+        let messages = vec![
+            transcript_row("t1", "first prompt", 100),
+            transcript_row("t2", "second prompt", 300),
+        ];
+        let merged =
+            merge_session_chat_local_commands(messages, &[row("1-0", "/context", "", None, 200)]);
+        let ids: Vec<&str> = merged.iter().map(|message| message.id.as_str()).collect();
+        assert_eq!(ids, vec!["t1", "local-command:1-0", "t2"]);
+    }
+
+    #[test]
+    fn a_page_only_claims_the_rows_anchored_inside_it() {
+        let messages = vec![
+            transcript_row("t1", "first prompt", 100),
+            transcript_row("t2", "second prompt", 300),
+        ];
+        let inside = row("1-0", "/context", "", None, 200);
+        let after_end = row("2-0", "/diff", "", None, 400);
+        let before_start = row("0-0", "/rename", "early", None, 50);
+
+        // Live tail: owns everything from its first message onwards.
+        let tail = select_session_chat_local_commands(
+            vec![inside.clone(), after_end.clone(), before_start.clone()],
+            &messages,
+            true,
+            true,
+        );
+        assert_eq!(
+            tail.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+            vec!["1-0", "2-0"]
+        );
+
+        // A pagination page keeps the row anchored inside it and leaves the one
+        // past its end to the page above, so neither is shown twice.
+        let older = select_session_chat_local_commands(
+            vec![inside.clone(), after_end.clone(), before_start.clone()],
+            &messages,
+            false,
+            true,
+        );
+        assert_eq!(
+            older.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+            vec!["1-0"]
+        );
+
+        // The oldest page owns what predates the transcript itself.
+        let oldest =
+            select_session_chat_local_commands(vec![before_start.clone()], &messages, false, false);
+        assert_eq!(
+            oldest.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+            vec!["0-0"]
+        );
+    }
+
+    #[test]
+    fn the_agents_own_record_wins() {
+        let messages = vec![transcript_row(
+            "t1",
+            "<command-name>/model</command-name>\n<command-message>model</command-message>\n<command-args>opus</command-args>",
+            100,
+        )];
+        let selected = select_session_chat_local_commands(
+            vec![
+                row("1-0", "/model", "opus", None, 150),
+                row("1-1", "/context", "", None, 160),
+            ],
+            &messages,
+            true,
+            false,
+        );
+        assert_eq!(
+            selected
+                .iter()
+                .map(|row| row.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1-1"]
+        );
+    }
+
+    #[test]
+    fn archives_and_replays_across_a_reload() {
+        let project = format!("test-{}", std::process::id());
+        let session = "archive-roundtrip";
+        let path = session_file(&project, session).expect("path");
+        let _ = fs::remove_file(&path);
+
+        let id = record_session_chat_local_command(&project, session, "/rename pilot game work")
+            .expect("recorded");
+        attach_session_chat_local_command_output(
+            &project,
+            session,
+            &id,
+            "Session renamed to: pilot game work",
+        );
+        // A refinement replaces the output rather than adding a second row.
+        attach_session_chat_local_command_output(
+            &project,
+            session,
+            &id,
+            "Session renamed to: final",
+        );
+
+        let rows = load_session_chat_local_commands(&project, session);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].text(), "/rename pilot game work");
+        assert_eq!(rows[0].output.as_deref(), Some("Session renamed to: final"));
+
+        let _ = fs::remove_file(&path);
+        // The per-project directory is this test's debris too.
+        if let Some(parent) = path.parent() {
+            let _ = fs::remove_dir(parent);
+        }
+    }
+
+    fn notice(text: &str) -> String {
+        format!("{}{text}", " ".repeat(120))
+    }
+
+    fn claude_screen_with_notice(history: &[&str], notice_text: &str) -> String {
+        let mut lines: Vec<String> = history.iter().map(|line| line.to_string()).collect();
+        lines.push(String::new());
+        lines.push(notice(notice_text));
+        lines.push("──────────────────────────────── probe one ─".to_string());
+        lines.push("❯ ".to_string());
+        lines.push("──────────────────────────────────────────────────".to_string());
+        lines.push("  ⏵⏵ bypass permissions on (shift+tab to cycle)".to_string());
+        lines.join("\n")
+    }
+
+    /// The shape captured live on 2026-09-10: the notice above the composer
+    /// changed between the two captures, which used to break the anchor.
+    #[test]
+    fn ignores_the_notice_claude_repaints_above_its_composer() {
+        let before = claude_screen_with_notice(&["⏺ Earlier answer."], "● high · /effort");
+        let after = claude_screen_with_notice(
+            &[
+                "⏺ Earlier answer.",
+                "❯ /rename probe one",
+                "  ⎿  Session renamed to: probe one",
+            ],
+            "You've used 82% of your weekly limit · resets 8pm (Europe/Malta)",
+        );
+        assert_eq!(
+            session_chat_local_command_output(Some("claude"), "/rename", &before, &after)
+                .as_deref(),
+            Some("Session renamed to: probe one")
+        );
+    }
+
+    #[test]
+    fn a_repainted_notice_alone_is_not_output() {
+        let before = claude_screen_with_notice(&["⏺ Earlier answer."], "● high · /effort");
+        let after = claude_screen_with_notice(
+            &["⏺ Earlier answer."],
+            "You've used 82% of your weekly limit",
+        );
+        assert_eq!(
+            session_chat_local_command_output(Some("claude"), "/rename", &before, &after),
+            None
+        );
+    }
+
+    #[test]
+    fn an_open_panel_drops_its_drawing_and_key_hint() {
+        let before = claude_screen_with_notice(&["⏺ Earlier answer."], "● high · /effort");
+        // An open panel replaces the composer, so there is no echo to hang off.
+        let after = [
+            "⏺ Earlier answer.",
+            "▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔",
+            "   Settings  Status   Config",
+            "",
+            "   Version:                 2.1.267",
+            "",
+            "   Esc to cancel",
+        ]
+        .join("\n");
+        let output = session_chat_local_command_output(Some("claude"), "/rename", &before, &after)
+            .expect("panel");
+        assert!(
+            output.contains("Version:                 2.1.267"),
+            "{output}"
+        );
+        assert!(!output.contains('▔'), "{output}");
+        assert!(!output.contains("Esc to cancel"), "{output}");
+    }
+
+    #[test]
+    fn commands_the_transcript_records_are_not_archived() {
+        for command in ["/model", "/Effort", "/fast", "/compact"] {
+            assert!(transcript_records_command_result(command), "{command}");
+        }
+        for command in ["/rename", "/context", "/status"] {
+            assert!(!transcript_records_command_result(command), "{command}");
+        }
+    }
+
+    /// Chat view's 24-row grid: the pre-send lines scrolled off, the echo did not.
+    #[test]
+    fn a_tall_result_is_attributed_by_its_own_echo() {
+        let before = claude_screen_with_notice(&["⏺ Old answer line."], "● high · /effort");
+        let after = claude_screen_with_notice(
+            &[
+                "❯ /context",
+                "  ⎿  Context Usage",
+                "     ⛁ ⛁ ⛶ ⛶   61.6k/1m tokens (6%)",
+                "     Auto-compact window: 1m tokens",
+            ],
+            "● high · /effort",
+        );
+        assert_eq!(
+            session_chat_local_command_output(Some("claude"), "/context", &before, &after).as_deref(),
+            Some("Context Usage\n     ⛁ ⛁ ⛶ ⛶   61.6k/1m tokens (6%)\n     Auto-compact window: 1m tokens")
+        );
+    }
+
+    /// Even the echo scrolled off: what is left is this command's output, cut off.
+    #[test]
+    fn a_result_taller_than_the_grid_says_it_was_cut_off() {
+        let before = claude_screen_with_notice(&["⏺ Old answer line."], "● high · /effort");
+        let after = claude_screen_with_notice(
+            &[
+                "     Auto-compact window: 1m tokens",
+                "     Suggestions",
+                "       Read results using 309.7k tokens (31%)",
+            ],
+            "● high · /effort",
+        );
+        let output = session_chat_local_command_output(Some("claude"), "/context", &before, &after)
+            .expect("cut-off output");
+        assert!(output.starts_with("…\n"), "{output}");
+        assert!(
+            output.contains("Read results using 309.7k tokens"),
+            "{output}"
+        );
+    }
+
+    /// The old lines are still on screen, just repainted: nothing to attribute.
+    #[test]
+    fn a_repaint_that_kept_the_old_lines_attributes_nothing() {
+        let before =
+            claude_screen_with_notice(&["⏺ Old answer line.", "  second line"], "● high · /effort");
+        let after = claude_screen_with_notice(
+            &["⏺ Old answer line.", "  second line changed"],
+            "● high · /effort",
+        );
+        assert_eq!(
+            session_chat_local_command_output(Some("claude"), "/context", &before, &after),
+            None
+        );
+    }
+}

--- a/server/src/session_chat_options.rs
+++ b/server/src/session_chat_options.rs
@@ -2136,20 +2136,27 @@ pub fn detect_session_chat_terminal_state(
     let terminal = agent
         .zip(screen)
         .and_then(|(agent, capture)| detect_session_chat_selection(agent, &capture.text));
-    if agent == Some(SessionChatOptionAgent::Codex) {
-        if let Some(capture) = screen {
+    if let Some(capture) = screen {
+        if agent == Some(SessionChatOptionAgent::Codex) {
             crate::session_chat_codex_pager::close_codex_transcript_pager_if_unwatched(
                 repository,
                 project_id,
                 session_id,
                 &capture.text,
             );
-            crate::session_chat_app_command::refresh_codex_command_output(
-                project_id,
-                session_id,
-                &capture.text,
-            );
         }
+        /*
+        CDXC:SessionChat 2026-09-10 WHY:
+        Every agent, not only Codex: a command whose result paints after its
+        first line (a picker, a fetch) has nothing but this shared probe to
+        refine the row. It only diffs sessions holding a live baseline, so a
+        session that ran no local command pays nothing.
+        */
+        crate::session_chat_app_command::refresh_local_command_output(
+            project_id,
+            session_id,
+            &capture.text,
+        );
     }
     let notice = screen.and_then(|capture| {
         crate::session_chat_notice::classify_session_chat_terminal_notice(agent_id, &capture.text)
@@ -3416,6 +3423,14 @@ pub(crate) fn schedule_session_chat_option_redetect(
         let mut published_fleet = cached.fleet;
         let mut published_tasks = cached.tasks;
         let mut published_prompt = cached.prompt;
+        /*
+        CDXC:SessionChat 2026-09-10 WHY:
+        Starts empty so the first probe publishes the rows this send created:
+        the send worker's own capture has usually filled a command's output
+        before this burst begins, and nothing else ever pushes it to an open
+        chat — the row used to appear only when switching views forced a read.
+        */
+        let mut published_app_commands = String::new();
         for delay_ms in crate::session_chat_options::SESSION_CHAT_OPTION_REDETECT_DELAYS_MS {
             tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
             let detection = detector
@@ -3452,6 +3467,11 @@ pub(crate) fn schedule_session_chat_option_redetect(
                 published_tasks.as_ref(),
             );
             let prompt_changed = detection.captured && detection.prompt != published_prompt;
+            let app_commands = crate::session_chat_app_command::session_chat_app_commands_identity(
+                &project_id,
+                &session_id,
+            );
+            let app_commands_changed = app_commands != published_app_commands;
             if !options_changed
                 && !options_refreshed
                 && !notice_changed
@@ -3459,9 +3479,11 @@ pub(crate) fn schedule_session_chat_option_redetect(
                 && !fleet_changed
                 && !tasks_changed
                 && !prompt_changed
+                && !app_commands_changed
             {
                 continue;
             }
+            published_app_commands = app_commands;
             if options_changed || options_refreshed {
                 published = detection.options;
             }
@@ -3552,7 +3574,7 @@ pub(crate) fn emit_session_chat_options_state_frame(
     stream.emit_sequenced(
         |seq| {
             let (epoch, _) = stream.current();
-            crate::session_chat::build_session_chat_prompt_state_frame(
+            let mut frame = crate::session_chat::build_session_chat_prompt_state_frame(
                 project_id,
                 session_id,
                 epoch,
@@ -3566,7 +3588,15 @@ pub(crate) fn emit_session_chat_options_state_frame(
                 detected,
                 screen,
                 Some(&queue),
-            )
+            );
+            // The local-command rows a screen probe just refined ride the same
+            // frame the probe publishes, or an open chat never sees them.
+            if let Value::Object(map) = &mut frame {
+                crate::session_chat_app_command::insert_session_chat_app_commands(
+                    map, project_id, session_id,
+                );
+            }
+            frame
         },
         |frame| event_hub.broadcast(frame),
     );

--- a/server/src/session_chat_queue_runtime.rs
+++ b/server/src/session_chat_queue_runtime.rs
@@ -819,20 +819,50 @@ pub(crate) async fn send_session_chat_message_with_draft(
         image_paths,
         dismiss_claude_settings,
     );
-    let capture_codex_output = terminal_agent.as_deref() == Some("codex")
-        && crate::session_chat_codex_dialog::command_has_local_output(text);
-    crate::session_chat_app_command::stop_codex_command_output(
+    /*
+    CDXC:SessionChat 2026-09-10 DECISION:
+    User: a slash command sent from chat must show up in chat for every agent,
+    with its output, and still be there after a reload.
+
+    Codex keeps its curated list because its commands print into a repainting
+    TUI and the list is what says which ones print at all. Every other agent
+    takes any line-leading slash command: Claude records a transcript envelope
+    for a handful of its own and nothing for the rest, so guessing which ones
+    print would just recreate the gap this closes. The archived row is written
+    before the send, so the trail exists even if the capture finds nothing.
+    Commands whose result the transcript already records are left out: their
+    status pill (or compaction row) is the one result row they get.
+    */
+    let local_command = crate::session_chat_local_command::parse_session_chat_local_command(text)
+        .filter(|(command, _)| {
+            !crate::session_chat_local_command::transcript_records_command_result(command)
+        });
+    let capture_local_output = if terminal_agent.as_deref() == Some("codex") {
+        crate::session_chat_codex_dialog::command_has_local_output(text)
+    } else {
+        local_command.is_some()
+    };
+    let durable_id = local_command.as_ref().and_then(|_| {
+        crate::session_chat_local_command::record_session_chat_local_command(
+            &target.project_id,
+            &target.session_id,
+            text,
+        )
+    });
+    crate::session_chat_app_command::stop_local_command_output(
         &target.project_id,
         &target.session_id,
     );
-    if capture_codex_output {
+    if capture_local_output {
         steps.insert(
             0,
-            crate::session_chat_send::SessionChatSendStep::BeginCodexCommandOutput {
+            crate::session_chat_send::SessionChatSendStep::BeginLocalCommandOutput {
+                agent: terminal_agent.clone(),
                 command: text.to_string(),
+                durable_id,
             },
         );
-        steps.push(crate::session_chat_send::SessionChatSendStep::FinishCodexCommandOutput);
+        steps.push(crate::session_chat_send::SessionChatSendStep::FinishLocalCommandOutput);
     }
     crate::session_chat_returned_prompt::record_session_chat_send_started(
         &target.project_id,
@@ -1020,7 +1050,7 @@ pub(crate) async fn send_session_chat_message_with_draft(
     // burst covers it for chat-sent and terminal-typed commands alike
     // (CDXC:AgentScreenDetection), and a second publisher of the same
     // activity only let a later follower frame overwrite what this one showed.
-    if is_option_readback_command || capture_codex_output {
+    if is_option_readback_command || capture_local_output {
         schedule_session_chat_option_redetect(
             state,
             &target.project_id,

--- a/server/src/session_chat_read.rs
+++ b/server/src/session_chat_read.rs
@@ -720,7 +720,33 @@ pub(crate) async fn handle_read_session_chat_http(
                     &mut lifecycle,
                 );
             }
-            let status = if before_offset.is_none() && messages.is_empty() && !has_more {
+            /*
+            CDXC:SessionChat 2026-09-10 DECISION:
+            User: the slash commands he sends from chat must still be shown
+            after a reload. They are replayed from gxserver's own archive as the
+            envelope the CLI would have written, anchored to the transcript row
+            they followed so scroll-back puts them where they happened.
+
+            Selected here, merged below the prompt scan: the interactive prompt
+            state and the question card it drives are read off the CLI's own
+            rows, and a replayed command must not be able to look like an answer
+            to a card the agent is still holding open.
+            */
+            let local_commands =
+                crate::session_chat_local_command::select_session_chat_local_commands(
+                    crate::session_chat_local_command::load_session_chat_local_commands(
+                        &project_id,
+                        &session_id,
+                    ),
+                    &messages,
+                    before_offset.is_none(),
+                    has_more,
+                );
+            let status = if before_offset.is_none()
+                && messages.is_empty()
+                && local_commands.is_empty()
+                && !has_more
+            {
                 "empty"
             } else {
                 "ready"
@@ -743,6 +769,10 @@ pub(crate) async fn handle_read_session_chat_http(
             {
                 result.insert("prompt".to_string(), value);
             }
+            let messages = crate::session_chat_local_command::merge_session_chat_local_commands(
+                messages,
+                &local_commands,
+            );
             result.insert(
                 "messages".to_string(),
                 serde_json::to_value(&messages).unwrap_or(json!([])),

--- a/server/src/session_chat_send.rs
+++ b/server/src/session_chat_send.rs
@@ -772,10 +772,15 @@ pub enum SessionChatSendStep {
     GuardCodexInterrupt,
     /// Recheck the transcript pager and cross-client visibility at the front of the queue.
     CloseUnwatchedCodexTranscriptPager,
-    BeginCodexCommandOutput {
+    /// Baseline the screen so the command's own output can be read back off it.
+    /// `durable_id` is set for a slash command the user sent from chat, which is
+    /// archived in `session_chat_local_command.rs`.
+    BeginLocalCommandOutput {
+        agent: Option<String>,
         command: String,
+        durable_id: Option<String>,
     },
-    FinishCodexCommandOutput,
+    FinishLocalCommandOutput,
     /// Revalidate after reaching the front of the send queue, before any dialog input.
     VerifyTerminalDialog {
         agent: String,
@@ -1431,20 +1436,26 @@ async fn run_session_chat_send_worker(
                         break;
                     }
                 }
-                SessionChatSendStep::BeginCodexCommandOutput { command } => {
+                SessionChatSendStep::BeginLocalCommandOutput {
+                    agent,
+                    command,
+                    durable_id,
+                } => {
                     if let Some(screen) = capture_session_terminal_text(&zmx_name).await {
-                        crate::session_chat_app_command::begin_codex_command_output(
+                        crate::session_chat_app_command::begin_local_command_output(
                             &project_id,
                             &session_id,
+                            agent.as_deref(),
                             &command,
+                            durable_id,
                             screen,
                         );
                     }
                 }
-                SessionChatSendStep::FinishCodexCommandOutput => {
+                SessionChatSendStep::FinishLocalCommandOutput => {
                     tokio::time::sleep(Duration::from_millis(250)).await;
                     if let Some(screen) = capture_session_terminal_text(&zmx_name).await {
-                        crate::session_chat_app_command::refresh_codex_command_output(
+                        crate::session_chat_app_command::refresh_local_command_output(
                             &project_id,
                             &session_id,
                             &screen,


### PR DESCRIPTION
## Summary

A slash command typed in the chat composer reached the terminal and nowhere else. Claude records a transcript envelope for only a handful of its commands (`/rename` writes none), Codex records nothing, and the client's marker bubble vanished on reload. This builds on #121 so every slash command sent from chat shows up in chat the same way `!` local commands do.

- **Archived and replayed:** gxserver archives each line-leading slash command sent from chat (`<state>/gxserver/session-commands/<project>/<session>.jsonl`) and replays it into `readSessionChat` as the envelope the CLI would have written, anchored after the transcript row it followed. The existing noise classifier then renders #121's compact rows (`Slash command · /rename x` + `Local command output · Session renamed to: x`). Long output collapses behind the usual chevron, and `/model`, `/effort`, `/fast` and `/compact` keep their status pills. Those four aren't archived at all, since the transcript already owns their result.
- **Output from the screen:** the Codex-only screen diff is now agent-aware. It ignores Claude's right-aligned notice line above the composer, never lets a later capture replace a full panel with a shorter one, and strips panel drawing. When chat view's shrunken alternate-screen grid pushes the anchor off, it falls back to the command's own echo, or to the visible part marked `…`.
- **Live:** the post-send redetect now publishes these rows as soon as they change, and the old client bubble retires once they appear.
- **Turn summary:** a `Slash command` row starts its own turn, so Claude's "No response requested." no longer folds the previous reply into "Worked for".

## Verification

- Manual test in the running app by @banozz0: `/rename`, `/context`, `/status`, `/effort` show their rows live, collapse when long, and survive a session reload.
- `cargo test --lib` in `server/`: 781 passed.
- `bun run typecheck`, `desktop:typecheck`, `web:typecheck`: clean.
- `bun run test`: 1270 passed. The one failure, `tooling/release-gpui/product-inputs.test.mjs`, is ENOENT on `.dependencies/zmx/build.zig.zon`: the submodule is empty in the fresh PR worktree. It passes in a full checkout.
- New tests: 15 Rust tests for the archive, merge/anchoring, dedupe and screen diff (including captures shaped like live ones), and client tests for the escaped-envelope round trip, the live-to-archived handoff, marker retirement and the turn boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFxJ9j96TK2NkotqouGj1M


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Archive and replay slash commands sent from chat with captured output
> - Adds `session_chat_local_command` module for durable JSONL storage of slash commands sent from session chat, including command text, captured output, and timestamps
> - Generalizes the prior Codex-only screen-diff output capture path to work for any agent, renaming `begin`/`stop`/`refresh` entrypoints and passing agent identity and durable archive ids through live command rows
> - On session-chat reads, archived commands are merged into the returned transcript messages at their chronological positions so reloads show both the command and its output
> - Shared client types gain an optional `localCommand` flag on `SessionChatAppCommand`; the command-envelope parser now decodes escaped markup attributes on replayed envelopes
> - Risk: `refresh_rows` in [session_chat_app_command.rs](https://github.com/maddada/Ghostex/pull/122/files#diff-5dbfa2d938e9ff60cc77fa845010b4e727ccf803e2e651921e0ddc4c30c381a1) changes output-extraction semantics — non-Codex agents keep an existing result when a later screen diff is not a prefix extension, while Codex retains last-result-wins; verify agent-specific extractors in [session_chat_local_command.rs](https://github.com/maddada/Ghostex/pull/122/files#diff-39d2363f3fd2aa2b7fe724a63f908d17dfad408f0c4e7b74db002b89403590fb) handle edge cases like repaint-only screens and tall results
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8318272. 16 files reviewed, 15 issues evaluated, 7 issues filtered, 7 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/core-ui/chat/session-chat-command-envelope.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 35](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/packages/core-ui/chat/session-chat-command-envelope.ts#L35): The escaped-mode decision checks for `data-ghostex-escaped="html"` anywhere in the envelope rather than on either marker tag. An ordinary (unescaped) transcript envelope whose command arguments contain that literal plus text such as `&lt;name&gt;` is decoded as if it had been escaped, changing the command arguments to `<name>` and breaking the displayed/deduplicated command. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>packages/core-ui/chat/session-chat-local-command-transcript.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 33](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/packages/core-ui/chat/session-chat-local-command-transcript.ts#L33): `sessionChatLocalCommandTexts` collapses every whitespace run in a live command by splitting on `/\s+/` and joining arguments with one space. For example, a sent `/rename My  title` is rendered live as `/rename My title`, whereas the archived envelope preserves the interior double space. The displayed command therefore changes when the archive takes over despite the function's same-row contract. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>packages/core-ui/chat/session-chat-pending.ts — 1 comment posted, 5 evaluated, 3 filtered</summary>
>
> - [line 568](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/packages/core-ui/chat/session-chat-pending.ts#L568): Moving the archive check before the `localCommand` rendering drops a newly captured output whenever the command envelope was already loaded. A live `sessionChatState` only updates `appCommands` (it does not replace `boundaried` transcript rows), so after the archive first supplies the command-only row, the later app command containing its screen output is discarded by `recorded.has(...)`; the output stays absent until a separate full read refreshes the archive. <b>[ Cross-file consolidated ]</b>
> - [line 577](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/packages/core-ui/chat/session-chat-pending.ts#L577): `sessionChatLocalCommandTexts` tokenizes `entry.command` with `split(/\s+/)` and rejoins arguments with single spaces, while the archived command stores its argument text verbatim. Commands containing meaningful/repeated whitespace (for example `/rename "two  spaces"`) therefore render one value live and a different value after archive handoff, despite these rows being intended as the same command. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 670](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/packages/core-ui/chat/session-chat-pending.ts#L670): Archive detection trusts a substring in arbitrary message text rather than validating that the message is a synthetic replay. A user can paste a leading `<command-name data-ghostex-escaped="html">/help</command-name>` payload in an ordinary prompt, then send `/help`; this loop adds `/help` to `covered` and removes the real command marker even though no archived command is present. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>packages/core-ui/chat/use-session-chat.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1393](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/packages/core-ui/chat/use-session-chat.ts#L1393): `retireSessionChatMarkersCoveredByLocalCommands` deduplicates only by normalized command text, without pairing a marker to an app-command/archive occurrence. After an earlier `/context` (or any identical slash command) is already in `boundaried`, sending `/context` again creates a new marker but this call filters it out immediately because the old archived envelope matches. The same happens while an older `localCommand` acknowledgement remains in the server's 300-second TTL. Thus the second send has no optimistic chat indication until a later read happens to deliver its own archived row/output, defeating the live feedback path for repeated commands. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>server/src/session_chat_options.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 2155](https://github.com/maddada/Ghostex/blob/8318272913d16371e381e1b27763148d0c51f913/server/src/session_chat_options.rs#L2155): `refresh_local_command_output` receives Claude's side-pane-stripped `capture.text`, but `BeginLocalCommandOutput` stored the unstripped terminal capture as its baseline. When a Claude diff side pane is visible while a slash command is sent, the baseline anchor includes the right-hand pane while this later screen does not; `newly_printed_lines` cannot find it and retains no output. Thus that command's archived row never receives its visible result after reload. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slash commands sent in session chat are now archived and replayed in conversation history.
  * Command output can be captured and displayed for supported agents, including Codex and Claude.
  * Archived commands and their output appear across paginated chat history.
* **Bug Fixes**
  * Prevented duplicate command entries when live and archived messages overlap.
  * Improved handling of escaped command markup and terminal output.
  * Command history and turn summaries now classify slash commands correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->