### PR TITLE
fix(release): include bundled skills in Linux packages

### DIFF
--- a/tooling/release-gpui/linux-stage.sh
+++ b/tooling/release-gpui/linux-stage.sh
@@ -100,6 +100,11 @@ mkdir -p \
 	"$PACKAGE_ROOT/usr/share/applications" \
 	"$PACKAGE_ROOT/usr/share/icons/hicolor/256x256/apps"
 cp -a "$APP_DIR/." "$PACKAGE_ROOT/opt/ghostex/"
+mkdir -p "$PACKAGE_ROOT/opt/ghostex/gxserver/bin/skills"
+for skill_dir in "$REPO_ROOT"/skills/ghostex-*; do
+	[[ -d "$skill_dir" ]] || continue
+	cp -a "$skill_dir" "$PACKAGE_ROOT/opt/ghostex/gxserver/bin/skills/"
+done
 cp "$REPO_ROOT/apps/desktop/resources/AppIcon.appiconset/icon_256x256.png" \
 	"$PACKAGE_ROOT/usr/share/icons/hicolor/256x256/apps/ghostex.png"
 cat >"$PACKAGE_ROOT/usr/bin/ghostex" <<'EOF'

--- a/tooling/release-gpui/product-inputs.mjs
+++ b/tooling/release-gpui/product-inputs.mjs
@@ -230,6 +230,7 @@ function linuxDesktopProduct(format) {
     kind: 'product',
     pathspecs: [
       ...DESKTOP_APP_PATHSPECS,
+      { pathspec: 'skills/**' },
       { pathspec: 'tooling/release-gpui/linux-stage.sh' },
       { pathspec: `tooling/release-gpui/linux-${format}.sh` },
       { pathspec: '.github/workflows/release-gpui-linux.yml' },


### PR DESCRIPTION
Fixes #124

### What changed

- include `skills/**` in the Linux release input fingerprint
- stage all bundled `ghostex-*` skills inside the installed Linux package next to the native CLI
- keep the existing CLI source-resolution logic able to use the packaged skills offline

### Validation

- `bash -n tooling/release-gpui/linux-stage.sh`
- `node --check tooling/release-gpui/product-inputs.mjs`
- `git diff --check`

Note: the focused `tooling/release-gpui/product-inputs.test.mjs` run is currently blocked by the checkout missing `.dependencies/zmx/build.zig.zon`; the failure is unrelated to this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include bundled Ghostex skills in Linux packages
> Linux package staging now copies `skills/ghostex-*` directories into the staged `gxserver` skills location. The `linuxDesktopProduct` input selector also adds `skills/**` so skill files are included as product inputs.
>
> - [linux-stage.sh](https://github.com/maddada/Ghostex/pull/127/files#diff-1b7f626b0da249aac4a957b8905253772ab86651ebd5ad2e57814c63b6088850) creates the packaged skills directory and recursively copies each matching `skills/ghostex-*` directory.
> - [product-inputs.mjs](https://github.com/maddada/Ghostex/pull/127/files#diff-506a03b4380d19e5bb4ba54b97e4498aa4ee972892d7a9af2a17dc12fa84f14f) adds `skills/**` to the Linux desktop product input paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72f484c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux desktop packages now include the available `ghostex` skills.
  * Changes to packaged skills are reflected in Linux package fingerprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->