### PR TITLE
fix(remote): read Unix hostname without PATH

### DIFF
--- a/server/src/remote_access/identity.rs
+++ b/server/src/remote_access/identity.rs
@@ -47,14 +47,31 @@ pub fn read_remote_access_identity() -> Result<RemoteAccessIdentity> {
 }
 
 /// macOS keeps the user-facing name in `ComputerName` (what Sharing shows),
-/// which can differ from the kernel hostname; every other OS shows `hostname`.
+/// which can differ from the kernel hostname. Unix reads the kernel value
+/// directly so a minimal gxserver PATH does not make remote pairing fail.
 fn read_computer_name() -> Result<String> {
     if cfg!(target_os = "macos") {
         if let Some(name) = read_first_line("scutil", &["--get", "ComputerName"]) {
             return Ok(name);
         }
     }
+    #[cfg(unix)]
+    if let Some(name) = read_unix_hostname() {
+        return Ok(name);
+    }
     read_first_line("hostname", &[]).with_context(|| "read this computer's name")
+}
+
+#[cfg(unix)]
+fn read_unix_hostname() -> Option<String> {
+    let mut buffer = [0_u8; 256];
+    let status = unsafe { libc::gethostname(buffer.as_mut_ptr().cast(), buffer.len()) };
+    if status != 0 {
+        return None;
+    }
+    let length = buffer.iter().position(|byte| *byte == 0)?;
+    let hostname = std::str::from_utf8(&buffer[..length]).ok()?.trim();
+    (!hostname.is_empty()).then(|| hostname.to_string())
 }
 
 fn read_login_username() -> Result<String> {


### PR DESCRIPTION
## Problem

On Linux, `/api/remoteAccessStatus` failed with HTTP 500 when gxserver ran with a minimal `PATH` that did not contain the `hostname` executable. The Remote Setup UI then remained stuck on “Checking SSH access…” and no Tailscale pairing QR code was generated.

## Fix

Read the Unix kernel hostname directly with `libc::gethostname()` before falling back to the `hostname` command. This removes the runtime dependency on `hostname` for Linux and other Unix builds.

## Verification

- `cd server && cargo fmt --check`
- `cd server && cargo check --release --bin gxserver`
- Reproduced on Manjaro with the installed gxserver binary: `/api/remoteAccessStatus` succeeds and the Tailscale QR code is generated.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve Unix hostname via libc instead of requiring `hostname` on PATH
> Adds a Unix-only helper in [identity.rs](https://github.com/maddada/Ghostex/pull/128/files#diff-3b11288ec76833ef6d2d4e4dde7a68461ef3dab1b2b9bc6c527087361d6ece69) that calls the libc hostname API, validates the result as UTF-8, trims whitespace, and rejects empty strings. The `read_computer_name` resolver now tries this direct lookup before falling back to invoking the `hostname` command, so computer-name resolution no longer depends on the executable being on PATH.
> - Behavioral Change: on Unix, the kernel hostname is now returned when available; command-based lookup is only used as a fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66cbb3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved computer-name detection on Unix systems by using the system hostname when available.
  * Added validation to ensure detected hostnames are safely bounded, properly encoded, and non-empty.
  * Preserved macOS behavior by continuing to prioritize the user-facing computer name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->